### PR TITLE
add strict mode & override to allow rule-less keys to pass

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -6,6 +6,7 @@ import warn from './utils/warn';
 
 const EVENT_NAME = 'veeValidate';
 let DEFAULT_LOCALE = 'en';
+let STRICT_MODE = true;
 
 /* eslint-disable no-underscore-dangle */
 
@@ -13,6 +14,7 @@ export default class Validator
 {
     constructor(validations, $vm) {
         this.locale = DEFAULT_LOCALE;
+        this.strictMode = STRICT_MODE;
         this.$fields = this._normalize(validations);
         this.errorBag = new ErrorBag();
         this.$vm = $vm;
@@ -31,6 +33,16 @@ export default class Validator
         }
 
         DEFAULT_LOCALE = language;
+    }
+
+    /**
+     * Sets default strict mode value for all validators.
+     *
+     * @param {Boolean} strictMode Whether to run in strict mode.
+     */
+    static setStrictMode(strictMode = true) {
+
+        STRICT_MODE = strictMode;
     }
 
     /**
@@ -233,6 +245,9 @@ export default class Validator
      */
     validate(name, value) {
         if (! this.$fields[name]) {
+        	/* istanbul ignore if */
+        	if (!this.strictMode) { return true }
+
             warn('You are trying to validate a non-existant field. Use "attach()" first.');
 
             return false;

--- a/test/validator.js
+++ b/test/validator.js
@@ -144,6 +144,12 @@ test('it can set the default locale for newly created validators', t => {
     Validator.updateDictionary({ ar: { alpha: '' } }); // reset the dictionary for other tests.
 });
 
+test('it can override the default strict mode for newly created validators', t => {
+    Validator.setStrictMode(false);
+    const loc = new Validator({ name: 'alpha' });
+    t.true(loc.validate('location', '1234'));
+});
+
 test('it throws an exception when extending with an invalid validator', t => {
     // Static Extend.
     // No getMessage nor a validate method.


### PR DESCRIPTION
Option for #2 introducing a strict mode which is on by default.  Disabling it allows object keys with no validation rule to pass.