### PR TITLE
Fix documentation errors

### DIFF
--- a/gh-pages/api.html
+++ b/gh-pages/api.html
@@ -65,7 +65,7 @@
 
                         validator.detach('email'); // you can also detach fields.
                     </code-block>
-                    After that you can validate values with <code class="inline">validate(field, value)</code> which should returna boolean if all validations pass. like this:
+                    After that you can validate values with <code class="inline">validate(field, value)</code> which should return a boolean if all validations pass. Like this:
                     <code-block class="language-javascript">
                         validator.validate('email', 'foo@bar.com'); // true
                         validator.validate('email', 'foo@bar'); // false
@@ -74,7 +74,7 @@
                         <b>Note:</b> Most validators return a Boolean, however some validators (very few) return a <code>Promise</code> The validator is aware of this and will only return a Promise if at least one validation yields a promise. the promise is resolved to boolean which you can later chain to check your fields.
                     </div>
                     <br>
-                    You Can validate multiple values at the same time using <code class="inline">validateAll(obj)</code>:
+                    You can validate multiple values at the same time using <code class="inline">validateAll(obj)</code>:
                     <code-block class="language-javascript">
                         validator.validateAll({
                             email: 'foo@bar.com',

--- a/gh-pages/examples.html
+++ b/gh-pages/examples.html
@@ -31,7 +31,7 @@
                     The basic approach relies on listening to the <code class="inline">input</code> or the <code class="inline">change</code> events depending on the file type.
                     However most of the time, your values are bound to your Vue instance and some code may change their inputs programatically, the basic approach won't detect this change.
                     <br><br>
-                    <b class="important">The Solution:</b> The <code class="inline">v-validate</code> directive can take a binding expression, the expression is the data name you wish to validte. for example:
+                    <b class="important">The Solution:</b> The <code class="inline">v-validate</code> directive can take a binding expression, the expression is the data name you wish to validate. for example:
                     <code-block class="language-html">
                         &lt;input v-validate=&quot;email&quot; data-rules=&quot;required|email&quot; type=&quot;text&quot; name=&quot;email&quot;&gt;
                     </code-block>

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -8,19 +8,19 @@
     </head>
     <body>
         <div id="app">
-            <app heading="Vee-Validate" subtitle="Simple VueJS Form Validation">
+            <app heading="Vee-Validate" subtitle="Simple Vue.JS Form Validation">
                 <h2 id="about" class="content-subhead"><a href="#about">What is vee-validate?</a></h2>
                 <p>
                     This is a lightweight plugin for <a href="https://vuejs.org/" class="link">VueJS</a> that allows you to validate input fields, and display errors.
                     <br><br>
-                    You don't have to do anything fancy in your app, most of the work goes into the html,
+                    You don't have to do anything fancy in your app, most of the work goes into the html.
                     You only need to specify for each input what kind of validators should be used when the value changes. You will then get informed of the errors for each field.
                     <br><br>
                     Although most of the validations occur automatically, you can use the validator however you see fit. The validator object has no dependencies and is a standalone object.
                     <br><br>
                     Currently there are over 20 validation rules available in the plugin.
                     This plugin is inspired by <a href="https://laravel.com/" class="link">PHP Framework Laravel's validation syntax</a>.
-                    <br><br>It also supports Vue 2.0, All examples here are built using Vue 2.0 with the plugin.
+                    <br><br>It also supports Vue 2.0. All examples here are built using Vue 2.0 with the plugin.
                 </p>
                 <h2 id="installation" class="content-subhead"><a href="#installation">Installation</a></h2>
                 <p>
@@ -61,7 +61,7 @@
                 <p>
                     All you need is to add the <code class="inline">v-validate</code> directive to the input you wish to validate.
                     <br><br>
-                    Then Add a <code class="inline">data-rules</code> attribute which contains a list of validation rules separated by a pipe '<code class="inline">|</code>'.
+                    Then add a <code class="inline">data-rules</code> attribute which contains a list of validation rules separated by a pipe '<code class="inline">|</code>'.
                     For the following example the validation rules are straight forward, use <code class="inline">required</code> to indicate that the field is required.
                     And <code class="inline">email</code> to indicate that the field must be an email.
                     To combine both rules we assign the value <code class="inline">required|email</code> to the <code class="inline">data-rules</code> data-set attribute.
@@ -75,7 +75,7 @@
                 </div>
                 <h2 id="render-errors" class="content-subhead"><a href="#render-errors">Rendering Errors</a></h2>
                 <p>
-                    Naturally, you would want to display the errors to your users, The plugin augments your Vue instance with a private validator object and a public errors data object.
+                    Naturally, you would want to display the errors to your users. The plugin augments your Vue instance with a private validator object and a public errors data object.
                     You are responsible for how the errors should be rendered.
                     <br><br>The errors object exposes a simple methods to help you render errors:
                     <ul>
@@ -100,7 +100,7 @@
                 <h2 id="configuration" class="content-subhead"><a href="#configuration">Configuration</a></h2>
                 <p>
                     You may need to configure some options to tweak some of the plugin internals, this is not required, but could cause conflicts. For example: if you are using a property called <code class="inline">errors</code> on your vue instance this may cause conflicts.
-                     here is how you would set up the options along with the default values:
+                     Here is how you would set up the options along with the default values:
                 </p>
                 <code-block class="language-javascript">
                     import Vue from 'vue';

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -8,10 +8,10 @@
     </head>
     <body>
         <div id="app">
-            <app heading="Vee-Validate" subtitle="Simple Vue.JS Form Validation">
+            <app heading="Vee-Validate" subtitle="Simple Vue.js Form Validation">
                 <h2 id="about" class="content-subhead"><a href="#about">What is vee-validate?</a></h2>
                 <p>
-                    This is a lightweight plugin for <a href="https://vuejs.org/" class="link">VueJS</a> that allows you to validate input fields, and display errors.
+                    This is a lightweight plugin for <a href="https://vuejs.org/" class="link">Vue.js</a> that allows you to validate input fields, and display errors.
                     <br><br>
                     You don't have to do anything fancy in your app, most of the work goes into the html.
                     You only need to specify for each input what kind of validators should be used when the value changes. You will then get informed of the errors for each field.

--- a/gh-pages/localization.html
+++ b/gh-pages/localization.html
@@ -15,7 +15,7 @@
                 <p>
                     This plugin only comes with English messages to keep things small, but it was built with flexible message generation in mind.
                     <br>
-                    The <a href="https://github.com/logaretm/vee-validate/blob/master/src/messages/en.js" class="link" target="github">English messages file</a> is an example on how you would structure those messages.
+                    The <a href="https://github.com/logaretm/vee-validate/blob/master/dist/locale/en.js" class="link" target="github">English messages file</a> is an example on how you would structure those messages.
                     Then you may want to update the validator dictionary, which should happen once in your app startup. still you may update them whenever you want in any point of your app, review the <a href="rules.html#custom-messages" class="link">custom messages</a> here.
                 </p>
                 <h2 id="attributes-data-as" class="content-subhead"><a href="#attributes-data-as">Attributes (data-as)</a></h2>


### PR DESCRIPTION
Summary of changes are as follows:

- Fix various grammatical and typographical errors in documentation.
- Update documentation to use 'Vue.js' spelling of the library. This matches the official documentation.
- Fix a dead link in documentation for the english messages file.