### PR TITLE
Choose validation events to opt into, rather than use disable/skip logic

### DIFF
--- a/src/listeners.js
+++ b/src/listeners.js
@@ -153,10 +153,11 @@ export default class ListenerGenerator
                 break;
         }
 
-        // users are able to skip validation on certain events
-        // pipe separated list of handler names to skip
-        const skipValidateOn = this.el.dataset.skip ? this.el.dataset.skip.split('|') : [];
-        listener.names = listener.names.filter(listenerName => skipValidateOn.indexOf(listenerName) === -1);
+        // users are able to specify which events they want to validate on
+        // pipe separated list of handler names to use
+        if (this.el.dataset.validateOn) {
+            listener.names = this.el.dataset.validateOn.split('|');
+        } 
 
         return listener;
     }


### PR DESCRIPTION
As discussed, rather than have "skip" to opt out of certain validations, allow users to choose which events to opt into.

Usage:
<input name="email" v-model="email" data-validate-on="blur">

As opposed to:
<input name="email" v-model="email" data-skip="input">

Advantages:
- Don't need to know the default events, and then opt out of them, just tell the library which events you're interested in
- Allowed opt-in to validation on custom events that may be emitted from other places?  Low use case, but could be handy at times

