### PR TITLE
Stricter check for field dependency, add listener test file.

### DIFF
--- a/__tests__/listeners.js
+++ b/__tests__/listeners.js
@@ -1,0 +1,20 @@
+import ListenerGenerator from './../src/listeners';
+import helpers from './helpers';
+
+const lg = new ListenerGenerator({ name: 'el'}, '', '', {});
+
+it('has field dependent rule', () => {
+
+    expect(lg._hasFieldDependency('confirmed:field|required')).toBe('field');
+    expect(lg._hasFieldDependency('required|before:field')).toBe('field');
+    expect(lg._hasFieldDependency('after:field')).toBe('field');
+
+    // If no field was mentioned, we don't have to search for one
+    expect(lg._hasFieldDependency('required|after')).toBe(false);
+    expect(lg._hasFieldDependency('required|confirmed')).toBe(false);
+    expect(lg._hasFieldDependency('required|before')).toBe(false);
+
+    // custom user declared rules
+    expect(lg._hasFieldDependency('required|before_time:10')).toBe(false);
+    expect(lg._hasFieldDependency('required|only_after:10')).toBe(false);
+});

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -17,7 +17,7 @@ export default class ListenerGenerator
      * Determines if the validation rule requires additional listeners on target fields.
      */
     _hasFieldDependency(rules) {
-        const results = rules.split('|').filter(r => !! r.match(/confirmed|after|before/));
+        const results = rules.split('|').filter(r => !! r.match(/\b(confirmed|after|before):/));
         if (! results.length) {
             return false;
         }


### PR DESCRIPTION
Custom rules that had `confirmed`, `after` or `before` in the name were being checked if it had a param. Started a test file for `listener.js`.

One thing I noticed is that [listeners.js:107](https://github.com/logaretm/vee-validate/blob/next/src/listeners.js#L107) checks for a named <input> element. Shouldn't this support `<select>` elements as well or are they handled elsewhere?  
