### PR TITLE
Require rule should fail for empty objects

### DIFF
--- a/__tests__/rules/required.js
+++ b/__tests__/rules/required.js
@@ -11,6 +11,7 @@ const valid = [
 const invalid = [
     '',
     ' ',
+    {},
     [],
     undefined,
     null

--- a/src/rules/required.js
+++ b/src/rules/required.js
@@ -1,5 +1,7 @@
+import { isObject } from '../utils/helpers';
+
 export default (value) => {
-    if (Array.isArray(value)) {
+    if (Array.isArray(value) || isObject(value)) {
         return !! value.length;
     }
 


### PR DESCRIPTION
I have a `<select>` in my code that is using vue to bind values to it:

```
<select>
<option :value="{}" disabled>Select ...</option>
<option :value="{id: 1}">First</option>
</select>
```

The required rule was passing for an empty object. This fixes that.