### PR TITLE
Add rule selector for error bag.

### DIFF
--- a/__tests__/errorBag.js
+++ b/__tests__/errorBag.js
@@ -59,10 +59,22 @@ it('clears the errors within a scope', () => {
     expect(errors.count()).toBe(1);
 });
 
+it('checks for field selector existence', () => {
+    const errors = new ErrorBag();
+
+    expect(errors.selector('name:rule').name).toBe('name');
+    expect(errors.selector('name:rule').rule).toBe('rule');
+
+    expect(errors.selector('name')).toBe(null);
+});
+
 it('checks for field error existence', () => {
     const errors = new ErrorBag();
     errors.add('name', 'The name is invalid', 'rule1',);
     expect(errors.has('name')).toBe(true);
+    expect(errors.has('name:rule1')).toBe(true);
+
+    expect(errors.has('name:rule2')).toBe(false);
     expect(errors.has('email')).toBe(false);
 });
 
@@ -89,7 +101,11 @@ it('fetches the first error message for a specific field', () => {
     errors.add('email', 'The email is invalid', 'rule1');
     errors.add('email', 'The email is shorter than 3 chars.', 'rule1');
 
+    errors.add('email', 'This is the third rule', 'rule2');
+    errors.add('email', 'This is the forth rule', 'rule2');
+
     expect(errors.first('email')).toBe('The email is invalid');
+    expect(errors.first('email:rule2')).toBe('This is the third rule');
 
     errors.clear();
     errors.add('email', 'The email is shorter than 3 chars.', 'rule1');

--- a/src/errorBag.js
+++ b/src/errorBag.js
@@ -41,7 +41,7 @@ export default class ErrorBag
     }
 
     /**
-     * Checks if there is any errrors in the internal array.
+     * Checks if there are any errors in the internal array.
      * @param {String} scope The Scope name, optional.
      * @return {boolean} result True if there was at least one error, false otherwise.
      */
@@ -55,6 +55,7 @@ export default class ErrorBag
 
     /**
      * Removes all items from the internal array.
+     *
      * @param {String} scope The Scope name, optional.
      */
     clear(scope) {
@@ -112,6 +113,12 @@ export default class ErrorBag
      * @return {string|null} message The error message.
      */
     first(field, scope) {
+        const selector = this.selector(field);
+
+        if (selector) {
+            return this.firstOf(selector.name, selector.rule, scope);
+        }
+
         for (let i = 0; i < this.errors.length; i++) {
             if (this.errors[i].field === field) {
                 if (scope) {
@@ -134,19 +141,7 @@ export default class ErrorBag
      * @return {Boolean} result True if at least one error is found, false otherwise.
      */
     has(field, scope) {
-        for (let i = 0; i < this.errors.length; i++) {
-            if (this.errors[i].field === field) {
-                if (scope) {
-                    if (this.errors[i].scope === scope) {
-                        return true;
-                    }
-                } else {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return !! this.first(field, scope);
     }
 
     /**
@@ -162,7 +157,7 @@ export default class ErrorBag
     }
 
     /**
-     * Removes all error messages assoicated with a specific field.
+     * Removes all error messages associated with a specific field.
      *
      * @param  {string} field The field which messages are to be removed.
      * @param {String} scope The Scope name, optional.
@@ -175,5 +170,22 @@ export default class ErrorBag
         }
 
         this.errors = this.errors.filter(e => e.field !== field);
+    }
+
+
+    /**
+     * Get the field attributes if there's a rule selector.
+     *
+     * @param  {string} field The specified field.
+     * @return {Object|null}
+     */
+    selector(field) {
+        if (field.indexOf(':') > -1) {
+            const [name, rule] = field.split(':');
+
+            return { name, rule };
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
I added support for `first()` and `has()` only at this point.  Do we need support for any other methods?

It would be easy: `errors.all(':required')` or with a scope, `errors.all('scope:required')`.

I also refactored the `has()` method to use the `first()` method since it was an exact repeat except for the boolean return type. I felt dirty writing the same exact code in two places while implementing this feature. 

Let me know if you want me to change anything.