### PR TITLE
Errorbag first() refactor for readability

### DIFF
--- a/src/errorBag.js
+++ b/src/errorBag.js
@@ -120,14 +120,12 @@ export default class ErrorBag
         }
 
         for (let i = 0; i < this.errors.length; i++) {
-            if (this.errors[i].field === field) {
-                if (scope) {
-                    if (this.errors[i].scope === scope) {
-                        return this.errors[i].msg;
-                    }
-                } else {
-                    return this.errors[i].msg;
-                }
+            if (this.errors[i].field !== field) {
+                continue;
+            }
+
+            if (! scope || (scope && this.errors[i].scope === scope)) {
+                return this.errors[i].msg;
             }
         }
 


### PR DESCRIPTION
Just making it a little easier to understand. If we always set `scope` when adding it to the error bag, we can get rid of the `scope &&` part of my if. Tests still pass.

```
    add(field, msg, rule, scope) {
        this.errors.push({ field, msg, rule, scope });
    }
```

Thoughts?