### PR TITLE
Auto-detect field when 'confirmed' rule has no target.

### DIFF
--- a/__tests__/validator.js
+++ b/__tests__/validator.js
@@ -446,6 +446,18 @@ it('can translate target field for field dependent validations', () => {
     expect(v.errorBag.first('email')).toBe('The Email Address does not match the Email Confirmation.');
 });
 
+
+it('auto detect confirmation field when none given', () => {
+    const v = new Validator({
+        password: 'confirmed'
+    });
+
+    helpers.querySelector({ name: 'password_confirmation', value: 'secret' });
+    expect(v.validate('password', 'secret')).toBe(true);
+
+    expect(v.validate('password', 'fail')).toBe(false);
+});
+
 describe('validators can provide reasoning for failing', () => {
     it('without promises', () => {
         const v = new Validator();

--- a/src/rules/confirmed.js
+++ b/src/rules/confirmed.js
@@ -1,5 +1,7 @@
-export default (value, [confirmedField]) => {
-    const field = document.querySelector(`input[name='${confirmedField}']`);
+export default (value, [confirmedField], validatingField) => {
+    const field = confirmedField
+    ? document.querySelector(`input[name='${confirmedField}']`)
+    : document.querySelector(`input[name='${validatingField}_confirmation']`);
 
     return !! (field && String(value) === field.value);
 };

--- a/src/validator.js
+++ b/src/validator.js
@@ -484,7 +484,7 @@ export default class Validator
      */
     _test(name, value, rule, scope) {
         const validator = Rules[rule.name];
-        let result = validator(value, rule.params);
+        let result = validator(value, rule.params, name);
 
         // If it is a promise.
         if (typeof result.then === 'function') {


### PR DESCRIPTION
Laravel looks for a "{fieldname}_confirmation" field when using the confirmed rule, so I made this work the same when no field is explicitly set.