### PR TITLE
Extended the ErrorBag with a method to return the first error type violated

### DIFF
--- a/__tests__/errorBag.js
+++ b/__tests__/errorBag.js
@@ -122,6 +122,17 @@ it('fetches the first error message for a specific field', () => {
     expect(errors.first('scope2.email:rule2')).toBe('mah');
 });
 
+it('fetches the first error rule for a specific field', () => {
+    const errors = new ErrorBag();
+    errors.add('email', 'The email is invalid', 'rule1');
+    errors.add('name', 'Your name is required', 'rule2');
+
+    expect(errors.firstRule('email')).toBe('rule1');
+    expect(errors.firstRule('name')).toBe('rule2');
+    expect(errors.firstRule('email', 'scope3')).toBeNull();
+    expect(errors.firstRule('password')).toBeNull();
+});
+
 it('fetches the first error message for a specific scoped field', () => {
     const errors = new ErrorBag();
     errors.add('email', 'The email is invalid', 'rule1', 'scope1');

--- a/src/errorBag.js
+++ b/src/errorBag.js
@@ -123,6 +123,18 @@ export default class ErrorBag
     }
 
     /**
+     * Returns the first error rule for the specified field
+     *
+     * @param {string} field The specified field.
+     * @return {string|null} First error rule on the specified field if one is found, otherwise null
+     */
+    firstRule(field, scope) {
+        const errors = this.collect(name, scope, false);
+
+        return (errors.length && errors[0].rule) || null;
+    }
+
+    /**
      * Checks if the internal array has at least one error for the specified field.
      *
      * @param  {string} field The specified field.

--- a/src/errorBag.js
+++ b/src/errorBag.js
@@ -129,7 +129,7 @@ export default class ErrorBag
      * @return {string|null} First error rule on the specified field if one is found, otherwise null
      */
     firstRule(field, scope) {
-        const errors = this.collect(name, scope, false);
+        const errors = this.collect(field, scope, false);
 
         return (errors.length && errors[0].rule) || null;
     }


### PR DESCRIPTION
When working with a CMS based approach you might want to render the
validation messages from fields within the CMS. Currently there is no
possibility to retrieve the first error that occured on a field. This
extention makes it possible.

Example markup:

```
<span v-show="errors.firstRule('email') === 'required'">FROM CMS: Email
is required</span>
<span v-show="errors.firstRule('email') === 'email'">FROM CMS: Email
invalid</span>
```