### PR TITLE
Deep watch arguments

### DIFF
--- a/src/listeners.js
+++ b/src/listeners.js
@@ -333,7 +333,7 @@ export default class ListenerGenerator
         if (arg) {
             this.unwatch = this.vm.$watch(arg, (value) => {
                 this.vm.$validator.validate(this.fieldName, value, this.scope || getScope(this.el));
-            });
+            }, {deep: true});
 
             return;
         }

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -333,7 +333,7 @@ export default class ListenerGenerator
         if (arg) {
             this.unwatch = this.vm.$watch(arg, (value) => {
                 this.vm.$validator.validate(this.fieldName, value, this.scope || getScope(this.el));
-            }, {deep: true});
+            }, { deep: true });
 
             return;
         }


### PR DESCRIPTION
Some rules might be interested in receiving a object as a argument. Deep option is needed so the callback gets triggered when a object property updates. 