### PR TITLE
Prefer data-vv-name over name attribute

### DIFF
--- a/src/listeners.js
+++ b/src/listeners.js
@@ -34,7 +34,7 @@ export default class ListenerGenerator
       return getDataAttribute(this.el, 'name') || this.component.name;
     }
 
-    return this.el.name || getDataAttribute(this.el, 'name');
+    return getDataAttribute(this.el, 'name') || this.el.name;
   }
 
     /**


### PR DESCRIPTION
If the user explicitly sets a `data-vv-name` it should should have precidence over the `name` attribute.