### PR TITLE
Fix undefined type dictionary [ts]

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -21,7 +21,7 @@ export class Validator {
     errorBag: ErrorBag
     fieldBag: any
     strictMode: boolean
-    dictionary: any
+    readonly dictionary: any
 
     constructor(validations: any, $vm: any, options: any);
     addScope(scope: string): void;

--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -21,7 +21,7 @@ export class Validator {
     errorBag: ErrorBag
     fieldBag: any
     strictMode: boolean
-    dictionary: Dictionary
+    dictionary: any
 
     constructor(validations: any, $vm: any, options: any);
     addScope(scope: string): void;


### PR DESCRIPTION
This commit fixes the following error:

> ERROR in /path/to/project/node_modules/vee-validate/types/vee-validate.d.ts
(25,17): error TS2304: Cannot find name 'Dictionary'.

A strong type (`Dictionary`) can only be used after it's defined. Since we haven't written definitions for `Dictionary` yet, I've changed the type to `any`.

(Type definitions only exist for `Validator` and `ErrorBag` at the moment.)