### PR TITLE
Applying a scope when providing an object to validateAll().

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -806,9 +806,10 @@ export default class Validator
   /**
    * Validates each value against the corresponding field validations.
    * @param  {object} values The values to be validated.
+   * @param  {String} scope The scope to be applied on validation.
    * @return {Promise} Returns a promise with the validation result.
    */
-  validateAll(values) {
+  validateAll(values, scope = '__global__') {
     let normalizedValues;
     if (! values || typeof values === 'string') {
       this.errorBag.clear(values);
@@ -817,7 +818,8 @@ export default class Validator
       normalizedValues = {};
       Object.keys(values).forEach(key => {
         normalizedValues[key] = {
-          value: values[key]
+          value: values[key],
+          scope
         };
       });
     }

--- a/test/validator.js
+++ b/test/validator.js
@@ -446,6 +446,30 @@ test('can validate specific scopes', async t => {
     }
 });
 
+test('can validate specific scopes on an object', async t => {
+    const v = new Validator({
+        'field': 'required'
+    });
+
+    v.attach('field', 'required', { scope: 'myscope' })
+    v.attach('anotherfield', 'required', { scope: 'myscope' })
+
+    // only '__global__' scope got validated.
+    try {
+        await v.validateAll({ field: null });
+    } catch (error) {
+        t.is(v.errorBag.count(), 1);
+    }
+
+    // this time only 'myscope' got validated.
+    v.errorBag.clear();
+    try {
+        await v.validateAll({ field: null, anotherfield: null }, 'myscope');
+    } catch (error) {
+        t.is(v.errorBag.count(), 2);
+    }
+})
+
 test('can find errors by field and rule', async t => {
     const v = new Validator({ name: 'alpha' });
     try {


### PR DESCRIPTION
Applying a scope when providing an object to validateAll() is not currently possible (when using the Validator object programmatically).

This PR is an attempt at removing this limitation.