### PR TITLE
Adding rules to Validator object

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -28,6 +28,7 @@ export default class Validator
     // so it may register it under an inaccurate scope.
     this.$deferred = [];
     this.$ready = false;
+    this.rules = Rules;
 
     // if momentjs is present, install the validators.
     if (typeof moment === 'function') {


### PR DESCRIPTION
Hey guys!
I've just add a reference to Rules setup as a method of Validator object.
So, rules will be available from now on in extend function:

    Validator.extend('registrationEmail', {
      getMessage: (field) => { return '' }
      , validate: (value) => {
        return this.validator.**rules**.email(value)
      }
    });  