### PR TITLE
Add inclusivity parameter to date_between rule

### DIFF
--- a/src/plugins/date/date_between.js
+++ b/src/plugins/date/date_between.js
@@ -19,4 +19,4 @@ export default (moment) => (value, params) => {
   }
 
   return dateVal.isBetween(minDate, maxDate, 'days', inclusivity);
-}
+};

--- a/src/plugins/date/date_between.js
+++ b/src/plugins/date/date_between.js
@@ -1,4 +1,15 @@
-export default (moment) => (value, [min, max, format]) => {
+export default (moment) => (value, params) => {
+  let min;
+  let max;
+  let format;
+  let inclusivity = '()';
+
+  if (params.length > 3) {
+    [min, max, inclusivity, format] = params;
+  } else {
+    [min, max, format] = params;
+  }
+
   const minDate = moment(min, format, true);
   const maxDate = moment(max, format, true);
   const dateVal = moment(value, format, true);
@@ -7,5 +18,5 @@ export default (moment) => (value, [min, max, format]) => {
     return false;
   }
 
-  return dateVal.isBetween(minDate, maxDate);
-};
+  return dateVal.isBetween(minDate, maxDate, 'days', inclusivity);
+}

--- a/test/rules/date_between.js
+++ b/test/rules/date_between.js
@@ -4,7 +4,7 @@ import date_between from './../../src/plugins/date/date_between'; // eslint-disa
 
 const validate = date_between(moment);
 
-test('checks if a date is between two other dates', t => {
+test('checks if a date is between two other dates - exclusive', t => {
     const format = 'DD/MM/YYYY';
 
     t.true(validate('16/09/2016', ['01/09/2016', '20/09/2016', format]));
@@ -18,4 +18,26 @@ test('fails the valiadation if any date is in incorrect format', t => {
     t.false(validate('09/16/2016', ['01/09/2016', '20/09/2016', format])); // invalid value.
     t.false(validate('16/09/2016', ['199/10/2016', '20/09/2016', format])); // invalid low bound.
     t.false(validate('16/09/2016', ['01/09/2016', '1/15/2016', format])); // invalid upper bound.
+});
+
+test('checks if a date is between two other dates - left inclusive', t => {
+    const format = 'DD/MM/YYYY';
+    
+    t.true(validate('01/09/2016', ['01/09/2016', '20/09/2016', '[)', format]));
+    t.false(validate('20/09/2016', ['01/09/2016', '20/09/2016', '[)', format]));    
+});
+
+test('checks if a date is between two other dates - right inclusive', t => {
+    const format = 'DD/MM/YYYY';
+    
+    t.false(validate('01/09/2016', ['01/09/2016', '20/09/2016', '(]', format]));
+    t.true(validate('20/09/2016', ['01/09/2016', '20/09/2016', '(]', format]));    
+});
+
+
+test('checks if a date is between two other dates - all inclusive', t => {
+    const format = 'DD/MM/YYYY';
+    
+    t.true(validate('01/09/2016', ['01/09/2016', '20/09/2016', '[]', format]));
+    t.true(validate('20/09/2016', ['01/09/2016', '20/09/2016', '[]', format]));    
 });


### PR DESCRIPTION
Expose the inclusivity parameter from the momentjs date_between function
to allow the date_between rule to be right, left or all inclusive

Reference issue #418