### PR TITLE
Update babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,13 @@
 {
-  "presets": ["es2015"]
+  "presets": [
+    [
+      "es2015",
+      {
+        "modules": false
+      }
+    ]
+  ],
+  "plugins": [
+    "external-helpers"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
   },
   "peerDependencies": {
     "vue": "2.x"
+  },
+  "dependencies": {
+    "babel-plugin-external-helpers": "^6.22.0"
   }
 }


### PR DESCRIPTION
Using `modules = true` will prevent babelify from working as supposed. The output in `dist` is an example because there is still bunch of arrow functions (...) in the bundle. 
According to `rollup-babelify` documentation this should roughly be enough to get babel working again.