### PR TITLE
Fixed issue with regex example as it allows non numeric characters

### DIFF
--- a/docs/rules.html
+++ b/docs/rules.html
@@ -310,7 +310,7 @@ The field under validation must have a string that is a valid ipv4 value.
 <li><code>flags:</code> list of regular expression flags (optional)</li>
 </ul>
 <p><label class="label">Regex: ^([0-9]+)$</label>
-<input v-validate="'regex:^([0-9]+)'" data-vv-as="field" :class="{'input': true, 'is-danger': errors.has('regex_field') }" name="regex_field" type="text" placeholder="Numbers only">
+<input v-validate="{ rules: { regex: /^([0-9]+)$/} }" data-vv-as="field" :class="{'input': true, 'is-danger': errors.has('regex_field') }" name="regex_field" type="text" placeholder="Numbers only">
 <span v-show="errors.has('regex_field')" class="help is-danger">{{ errors.first('regex_field') }}</span></p>
 <blockquote>
 <p>You should not use the pipe '|' or commas ',' within your regular expression when using the string rules format as it will cause a conflict with how validators parsing work. You should use the object format of the rules instead, for example: <code>v-validate=&quot;{ rules: { regex: /.(js|ts)$/} }&quot;</code></p>


### PR DESCRIPTION
In documentation, i was looking for validations using Regular Expressions. Fortunately there is an example, which shows that input will only take numbers. It was working fine if i type a letter in the beginning, but then noticed something, If you type a number, then type a letter it accepts it, and validation error is gone. There was an issue with Regex. Its fixed in forked repo. 
Thanks 👍 