### PR TITLE
Fix constructor signature mismatch. Add fieldBag to interface. (TypeScript definitions)

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -19,10 +19,11 @@ export class ErrorBag {
 export class Validator {
 
     errorBag: ErrorBag
+    fieldBag: any
     strictMode: boolean
     readonly dictionary: any
 
-    constructor(validations: any, $vm: any, options: any);
+    constructor(validations: any, options: any);
     addScope(scope: string): void;
     append(name: string, checks: string|Object, options: any): void;
     attach(name: string, checks: string|Object, options: any): void;


### PR DESCRIPTION
Minor improvements to TypeScript definitions. Fixes constructor signature not matching the code. Adds the `fieldBag` to the interface.