### PR TITLE
Add type defintions for fieldBag and fieldFlags (TypeScript definitions)

### DIFF
--- a/types/vee-validate.d.ts
+++ b/types/vee-validate.d.ts
@@ -15,13 +15,25 @@ export class ErrorBag {
     remove(field: string, scope?: string): void;
 }
 
+export class FieldBag {
+    [field: string]: FieldFlags;
+}
+
+export class FieldFlags {
+    untouched: boolean;
+    touched: boolean;
+    dirty: boolean;
+    pristine: boolean;
+    valid: boolean;
+    invalid: boolean;
+}
 
 export class Validator {
 
-    errorBag: ErrorBag
-    fieldBag: any
-    strictMode: boolean
-    readonly dictionary: any
+    errorBag: ErrorBag;
+    fieldBag: FieldBag;
+    strictMode: boolean;
+    readonly dictionary: any;
 
     constructor(validations: any, options: any);
     addScope(scope: string): void;


### PR DESCRIPTION
Improvements to TypeScript definitions. Fixes fieldBag types which enables field state checks in typescript.

e.g.:
$validator.fieldBag['field'].valid; // check one field
_.every(this.$validator.fieldBag, (field: FieldFlags) => field.valid); // check all fields with lodash function
