### PR TITLE
Fix confirmed rule not working on data-vv-name'd elements

### DIFF
--- a/src/rules/confirmed.js
+++ b/src/rules/confirmed.js
@@ -1,7 +1,13 @@
 export default (value, [confirmedField], validatingField) => {
-  const field = confirmedField
+  let field = confirmedField
     ? document.querySelector(`input[name='${confirmedField}']`)
     : document.querySelector(`input[name='${validatingField}_confirmation']`);
+
+  if (! field) {
+    field = confirmedField
+      ? document.querySelector(`input[data-vv-name='${confirmedField}']`)
+      : document.querySelector(`input[data-vv-name='${validatingField}_confirmation']`);
+  }
 
   return !! (field && String(value) === field.value);
 };


### PR DESCRIPTION
Currently, the `confirmed` rule only works on inputs with the `name` attribute. This fix allows components with `data-vv-name` to work the same way.