### PR TITLE
Always modify errorBag in-place. Fixes #558

### DIFF
--- a/src/errorBag.js
+++ b/src/errorBag.js
@@ -52,7 +52,14 @@ export default class ErrorBag {
       scope = '__global__';
     }
 
-    this.errors = this.errors.filter(e => e.scope !== scope);
+    const removeCondition = e => e.scope === scope;
+
+    for (let i = 0; i < this.errors.length; ++i) {
+      if (removeCondition(this.errors[i])) {
+        this.errors.splice(i, 1);
+        i--;
+      }
+    }
   }
 
     /**
@@ -166,12 +173,16 @@ export default class ErrorBag {
      * @param {String} scope The Scope name, optional.
      */
   remove(field, scope) {
-    const filter = scope ? (e => e.field !== field || e.scope !== scope) :
-                           (e => e.field !== field || e.scope !== '__global__');
+    const removeCondition = scope ? (e => e.field === field && e.scope === scope) :
+                                    (e => e.field === field && e.scope === '__global__');
 
-    this.errors = this.errors.filter(filter);
+    for (let i = 0; i < this.errors.length; ++i) {
+      if (removeCondition(this.errors[i])) {
+        this.errors.splice(i, 1);
+        i--;
+      }
+    }
   }
-
 
     /**
      * Get the field attributes if there's a rule selector.

--- a/src/errorBag.js
+++ b/src/errorBag.js
@@ -57,7 +57,7 @@ export default class ErrorBag {
     for (let i = 0; i < this.errors.length; ++i) {
       if (removeCondition(this.errors[i])) {
         this.errors.splice(i, 1);
-        i--;
+        --i;
       }
     }
   }
@@ -123,7 +123,7 @@ export default class ErrorBag {
       return this.firstByRule(selector.name, selector.rule, scope);
     }
 
-    for (let i = 0; i < this.errors.length; i++) {
+    for (let i = 0; i < this.errors.length; ++i) {
       if (this.errors[i].field === field && (this.errors[i].scope === scope)) {
         return this.errors[i].msg;
       }
@@ -179,7 +179,7 @@ export default class ErrorBag {
     for (let i = 0; i < this.errors.length; ++i) {
       if (removeCondition(this.errors[i])) {
         this.errors.splice(i, 1);
-        i--;
+        --i;
       }
     }
   }


### PR DESCRIPTION
I believe this fixes my issue #558. The problem seems to be related to this remark in the Vue documentation:

> Mutation methods, as the name suggests, mutate the original array they are called on. In comparison, there are also non-mutating methods, e.g. filter(), concat() and slice(), which do not mutate the original array but always return a new array. When working with non-mutating methods, you can just replace the old array with the new one.
> 
> You might think this will cause Vue to throw away the existing DOM and re-render the entire list - luckily, that is not the case. **Vue implements some smart heuristics** to maximize DOM element reuse, so replacing an array with another array containing overlapping objects is a very efficient operation.

(emphasis mine)

It seems that these "smart heuristics" fail in the case of VeeValidate's errorBag, and calling ```remove``` or ```clear```, which both replace the errors array, causes Vue to re-render the whole DOM of the component, which causes the issues in #558.

I changed ```remove``` and ```clear``` to modify the errors array in-place. This seems to fix my issues and all tests still pass when running ```npm run test```.