### PR TITLE
Fix flags not refreshed after a data change on custom components

### DIFF
--- a/src/classes.js
+++ b/src/classes.js
@@ -60,10 +60,10 @@ export default class ClassListener {
       this.field.flags.touched = true;
       this.field.flags.untouched = false;
 
-      if (this.component) return;
-
       // only needed once.
-      this.el.removeEventListener('focus', this.listeners.focus);
+      if (!this.component) {
+        this.el.removeEventListener('focus', this.listeners.focus);
+      }
       this.listeners.focus = null;
     };
 
@@ -83,10 +83,10 @@ export default class ClassListener {
       this.field.flags.dirty = true;
       this.field.flags.pristine = false;
 
-      if (this.component) return;
-
       // only needed once.
-      this.el.removeEventListener(event, this.listeners.input);
+      if (!this.component) {
+        this.el.removeEventListener(event, this.listeners.input);
+      }
       this.listeners.input = null;
     };
 


### PR DESCRIPTION
Close #580

[addInteractionListeners() method](https://github.com/logaretm/vee-validate/blob/830bc9ceb591463b135f14c15270caf374c5ddc2/src/classes.js#L100-L108) is responsible to add input and focus listeners on the element if there are not already registered.

But with current codebase, `this.listeners.input` [is not set to null](https://github.com/logaretm/vee-validate/blob/master/src/classes.js#L86-L90) after listener beeing invoked once for a component, so addInteractionListeners() nevers add the listener back on component.

This patch fix the issue by setting `this.listeners.input` to `null` for components too.