### PR TITLE
Add utils.getForm to get closest form for getScope using.

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -100,11 +100,31 @@ export const isEqual = (lhs: any, rhs: any): boolean => {
  */
 export const getScope = (el: HTMLInputElement) => {
   let scope = getDataAttribute(el, 'scope');
-  if (isNullOrUndefined(scope) && el.form) {
-    scope = getDataAttribute(el.form, 'scope');
+  if (isNullOrUndefined(scope)) {
+    let form = getForm(el);
+
+    if(form) {
+      scope = getDataAttribute(form, 'scope');
+    }
   }
 
   return !isNullOrUndefined(scope) ? scope : null;
+};
+
+/**
+ * Get the closest form element.
+ */
+export const getForm = (el: HTMLInputElement) => {
+  if (isNullOrUndefined(el))
+      return null;
+
+  if (el.tagName === "FORM")
+      return el;
+
+  if (!isNullOrUndefined(el.form))
+      return el.form
+
+  return !isNullOrUndefined(el.parentNode) ? getForm(el.parentNode) : null;
 };
 
 /**

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -43,6 +43,48 @@ test('gets the element scope from the element or from the owning form', () => {
   expect(utils.getScope(el)).toBe('form-scope');
 });
 
+test('gets the element scope from div tag', () => {
+  document.body.innerHTML =
+      `<div>
+          <div id="el" type="text" name="field" data-vv-scope="scope1">
+          </div>
+      </div>`;
+  let el = document.querySelector('#el');
+  expect(utils.getScope(el)).toBe('scope1');
+
+  document.body.innerHTML =
+      `<form data-vv-scope="form-scope">
+        <div id="el" type="text" name="field">
+        </div>
+      </form>`;
+  el = document.querySelector('#el');
+  expect(utils.getScope(el)).toBe('form-scope');
+});
+
+test('gets the element closest form', () => {
+  document.body.innerHTML =
+      `<div>
+          <input id="el" type="text" name="field" data-vv-scope="scope1">
+      </div>`;
+  let el = document.querySelector('#el');
+  expect(utils.getForm(el)).toBe(null);
+
+  document.body.innerHTML =
+      `<form id='test'>
+          <input id="el" type="text" name="field">
+      </form>`;
+  el = document.querySelector('#el');
+  expect(utils.getForm(el).id).toBe('test');
+
+  document.body.innerHTML =
+      `<form id='test'>
+          <div id="el">
+          </div>
+      </form>`;
+  el = document.querySelector('#el');
+  expect(utils.getForm(el).id).toBe('test');
+});
+
 test('checks if a value is an object', () => {
   expect(utils.isObject(null)).toBe(false);
   expect(utils.isObject([])).toBe(false);


### PR DESCRIPTION
 - get the closest form element.
Modified utils.getScope
 - using getForm to get the closest form.
Add unit test
 - gets the element scope from div tag
 - gets the element closest form