### PR TITLE
Fix link to component injections

### DIFF
--- a/docs/api/mixin.md
+++ b/docs/api/mixin.md
@@ -7,5 +7,5 @@ VeeValidate injects a mixin that augments your Vue instances with the following 
 - `fields` An object containing state flags for the validated fields.
 
 ::: tip
-  You can choose to not automatically inject those properties in your instances by setting the `inject` [config option](/configuration.md) to false, but you will need to manage providing the `$validator` instance yourself so that the directive can work, refer to the [component injections](/advanced.md#component-injections) section.
+  You can choose to not automatically inject those properties in your instances by setting the `inject` [config option](/configuration.md) to false, but you will need to manage providing the `$validator` instance yourself so that the directive can work, refer to the [component injections](/concepts.md#component-injections) section.
 :::


### PR DESCRIPTION
It is now located under `concepts` instead of `advanced`