### PR TITLE
feat: pass custom messages to `ValidationProvider` or `validate()`

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -20,17 +20,19 @@ interface ValidationOptions {
   bails?: boolean;
   skipOptional:? boolean;
   isInitial?: boolean;
+  customMessages?: { [k: string]: string };
 }
 ```
 
-| Property     | Type                      | Description                                                                                                                                    |
-| ------------ | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| name         | `string | null`           | The name of the field to be validate (will be used for error messages).                                                                        |
-| values       | `{ [k: string]: any }`    | The values of other fields (used in cross-field validation).                                                                                   |
-| names        | `{ [k: string]: string }` | The names of other fields (used in cross-field rules messages).                                                                                |
-| bails        | `boolean`                 | If true, the validation will stop at the first failing rule, otherwise trigger all rules.                                                      |
-| skipOptional | `boolean`                 | If true, the validation will skip optional (non-required) fields if they have empty values (empty string, empty array, `null` or `undefined`). |
-| isInitial    | `boolean`                 | if true will skip all rules configured not to run at the first validation attempt.                                                             |
+| Property       | Type                      | Description                                                                                                                                    |
+| -------------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| name           | `string | null`           | The name of the field to be validate (will be used for error messages).                                                                        |
+| values         | `{ [k: string]: any }`    | The values of other fields (used in cross-field validation).                                                                                   |
+| names          | `{ [k: string]: string }` | The names of other fields (used in cross-field rules messages).                                                                                |
+| bails          | `boolean`                 | If true, the validation will stop at the first failing rule, otherwise trigger all rules.                                                      |
+| skipOptional   | `boolean`                 | If true, the validation will skip optional (non-required) fields if they have empty values (empty string, empty array, `null` or `undefined`). |
+| isInitial      | `boolean`                 | If true will skip all rules configured not to run at the first validation attempt.                                                             |
+| customMessages | `{ [k: string]: string }` | Custom error messages, keyed by rule name. These will override any default messages, as well as any messages set in `extend()`.                |
 
 ### ValidationResult
 

--- a/docs/guide/validation-provider.md
+++ b/docs/guide/validation-provider.md
@@ -534,19 +534,20 @@ Below is the reference of the ValidationProvider public API.
 
 All the following props are optional.
 
-| Prop      | Type       | Default Value         | Description                                                                                                                                           |
-| --------- | ---------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| rules     | `string`   | `undefined`           | The validation rules.                                                                                                                                 |
-| vid       | `string`   | auto increment number | Identifier used for target/cross-field based rules.                                                                                                   |
-| immediate | `boolean`  | `false`               | If the field should be validated immediately after render (initially).                                                                                |
-| events    | `string[]` | `['input']`           | deprecated: check [interaction modes](../interaction.md)                                                                                              |
-| name      | `string`   | `undefined`           | A string that will be used to replace `{field}` in error messages and for [custom error messages](/guide/messages.md#field-specific-custom-messages). |
-| bails     | `boolean`  | `true`                | If true, the validation will stop on the first failing rule.                                                                                          |
-| skipIfEmpty     | `boolean`  | `true`                | If true, the validation will be skipped if the value is empty).                                                                                          |
-| debounce  | `number`   | `0`                   | Debounces the validation for the specified amount of milliseconds.                                                                                    |
-| tag       | `string`   | `span`                | The default tag to [render](#rendering).                                                                                                              |
-| persist   | `boolean`  | `false`               | If true, the provider will keep its errors across mounted/destroyed lifecycles                                                                        |
-| disabled | `boolean` | `false`       | If true, the provider will be ignored when `validate` is called by a parent observer. |
+| Prop           | Type                      | Default Value         | Description                                                                                                                                           |
+| -------------- | ------------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| rules          | `string`                  | `undefined`           | The validation rules.                                                                                                                                 |
+| vid            | `string`                  | auto increment number | Identifier used for target/cross-field based rules.                                                                                                   |
+| immediate      | `boolean`                 | `false`               | If the field should be validated immediately after render (initially).                                                                                |
+| events         | `string[]`                | `['input']`           | deprecated: check [interaction modes](../interaction.md)                                                                                              |
+| name           | `string`                  | `undefined`           | A string that will be used to replace `{field}` in error messages and for [custom error messages](/guide/messages.md#field-specific-custom-messages). |
+| bails          | `boolean`                 | `true`                | If true, the validation will stop on the first failing rule.                                                                                          |
+| skipIfEmpty    | `boolean`                 | `true`                | If true, the validation will be skipped if the value is empty).                                                                                       |
+| debounce       | `number`                  | `0`                   | Debounces the validation for the specified amount of milliseconds.                                                                                    |
+| tag            | `string`                  | `span`                | The default tag to [render](#rendering).                                                                                                              |
+| persist        | `boolean`                 | `false`               | If true, the provider will keep its errors across mounted/destroyed lifecycles                                                                        |
+| disabled       | `boolean`                 | `false`               | If true, the provider will be ignored when `validate` is called by a parent observer.                                                                 |
+| customMessages | `{ [k: string]: string }` | `{}`                  | Custom error messages, keyed by rule name. These will override any default messages, as well as any messages set in `extend()`.                       |
 
 ### Methods
 

--- a/src/components/Provider.ts
+++ b/src/components/Provider.ts
@@ -109,6 +109,10 @@ export const ValidationProvider = (Vue as withProviderPrivates).extend({
     disabled: {
       type: Boolean,
       default: false
+    },
+    customMessages: {
+      type: Object,
+      default: {}
     }
   },
   watch: {
@@ -227,7 +231,8 @@ export const ValidationProvider = (Vue as withProviderPrivates).extend({
         values: createValuesLookup(this),
         bails: this.bails,
         skipIfEmpty: this.skipIfEmpty,
-        isInitial: !this.initialized
+        isInitial: !this.initialized,
+        customMessages: this.customMessages
       });
 
       this.setFlags({ pending: false });

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -11,6 +11,7 @@ interface FieldContext {
   forceRequired: boolean;
   crossTable: Record<string, any>;
   names: Record<string, string>;
+  customMessages: Record<string, string>;
 }
 
 interface ValidationOptions {
@@ -20,6 +21,7 @@ interface ValidationOptions {
   bails?: boolean;
   skipIfEmpty?: boolean;
   isInitial?: boolean;
+  customMessages?: Record<string, string>;
 }
 
 /**
@@ -39,7 +41,8 @@ export async function validate(
     skipIfEmpty: isNullOrUndefined(skipIfEmpty) ? true : skipIfEmpty,
     forceRequired: false,
     crossTable: (options && options.values) || {},
-    names: (options && options.names) || {}
+    names: (options && options.names) || {},
+    customMessages: (options && options.customMessages) || {}
   };
 
   const result = await _validate(field, value, options);
@@ -200,6 +203,16 @@ function _generateFieldError(
     _value_: value,
     _rule_: ruleName
   };
+
+  if (
+    Object.prototype.hasOwnProperty.call(field.customMessages, ruleName) &&
+    typeof field.customMessages[ruleName] === 'string'
+  ) {
+    return {
+      msg: _normalizeMessage(field.customMessages[ruleName], field.name, values),
+      rule: ruleName
+    };
+  }
 
   if (ruleSchema.message) {
     return {

--- a/tests/providers/provider.js
+++ b/tests/providers/provider.js
@@ -1038,3 +1038,28 @@ test('should throw if required rule does not return an object', () => {
 
   expect(wrapper.vm.$refs.pro.validate()).rejects.toThrow();
 });
+
+test('returns custom error messages passed in the customMessages prop', async () => {
+  extend('truthy', {
+    validate: Boolean,
+    message: 'Original Message',
+  });
+
+  const customMessage = 'Custom Message';
+
+  const wrapper = mount(
+    {
+      data: () => ({ val: false }),
+      template: `
+        <ValidationProvider rules="truthy" :customMessages="{ truthy: '${customMessage}' }" v-slot="ctx" ref="pro">
+          <input v-model="val" type="text">
+        </ValidationProvider>
+      `
+    },
+    { localVue: Vue, sync: false }
+  );
+
+  const result = await wrapper.vm.$refs.pro.validate();
+
+  expect(result.errors[0]).toEqual(customMessage);
+});

--- a/tests/validate.spec.js
+++ b/tests/validate.spec.js
@@ -1,0 +1,22 @@
+import { validate } from '@/validate';
+import { extend } from '@/extend';
+
+test('returns custom error messages passed in ValidationOptions', async () => {
+  extend('truthy', {
+    validate: Boolean,
+    message: 'Original Message',
+  });
+
+  const customMessage = 'Custom Message';
+
+  const value = false;
+  const rules = 'truthy';
+  const options = {
+    customMessages: {
+      truthy: customMessage,
+    },
+  };
+  const result = await validate(value, rules, options);
+
+  expect(result.errors[0]).toEqual(customMessage);
+});


### PR DESCRIPTION
🔎 __Overview__

<!--
Explain the premise for adding this PR and why is it important.

Ex (Feat):
> This PR {adds/fixes/improves} the {feature/bug/something}.

Ex (Locale):
> This PR changes the {locale} messages style because {reason}
-->
This adds the ability to override any default error messages, or messages set with `extend()` for a specific `ValidationProvider` or `validate()` call.

🤓 __Code snippets/examples (if applicable)__

```js
extend('truthy', {
  validate: Boolean,
  message: 'Original Message',
});
```
```html
<validation-provider rules="truthy" :customMessages="{ truthy: 'Custom Message' }">
  <input v-model="data" />
</validation-provider>
```
```js
validate(false, 'truthy', { truthy: 'Custom Message' });
```

✔ __Issues affected__

None.
<!--
list of issues formatted like this:

> closes #{issue id}
-->