### PR TITLE
fix(types): use right types for rules

### DIFF
--- a/src/rules/alpha.ts
+++ b/src/rules/alpha.ts
@@ -1,7 +1,7 @@
 import { alpha } from './alpha_helper';
 import { RuleParamSchema } from '../types';
 
-const validate = (value: any, { locale = '' } = {}): boolean => {
+const validate = (value: string | string[], { locale = '' }: Record<string, any> = {}): boolean => {
   if (Array.isArray(value)) {
     return value.every(val => validate(val, { locale }));
   }

--- a/src/rules/alpha_dash.ts
+++ b/src/rules/alpha_dash.ts
@@ -1,7 +1,7 @@
 import { alphaDash } from './alpha_helper';
 import { RuleParamSchema } from '../types';
 
-const validate = (value: any, { locale = '' }: any = {}): boolean => {
+const validate = (value: string | string[], { locale = '' }: Record<string, any> = {}): boolean => {
   if (Array.isArray(value)) {
     return value.every(val => validate(val, { locale }));
   }

--- a/src/rules/alpha_num.ts
+++ b/src/rules/alpha_num.ts
@@ -1,7 +1,7 @@
 import { alphanumeric } from './alpha_helper';
 import { RuleParamSchema } from '../types';
 
-const validate = (value: any, { locale = '' }: any = {}): boolean => {
+const validate = (value: string | string[], { locale = '' }: Record<string, any> = {}): boolean => {
   if (Array.isArray(value)) {
     return value.every(val => validate(val, { locale }));
   }

--- a/src/rules/alpha_spaces.ts
+++ b/src/rules/alpha_spaces.ts
@@ -1,7 +1,7 @@
 import { alphaSpaces } from './alpha_helper';
 import { RuleParamSchema } from '../types';
 
-const validate = (value: any, { locale = '' } = {}): boolean => {
+const validate = (value: string | string[], { locale = '' }: Record<string, any> = {}): boolean => {
   if (Array.isArray(value)) {
     return value.every(val => validate(val, { locale }));
   }

--- a/src/rules/between.ts
+++ b/src/rules/between.ts
@@ -1,6 +1,6 @@
-import { ValidationRuleFunction, RuleParamSchema } from '../types';
+import { RuleParamSchema, StringOrNumber } from '../types';
 
-const validate: ValidationRuleFunction = (value, { min, max }: any = {}) => {
+const validate = (value: StringOrNumber | StringOrNumber[], { min, max }: Record<string, any> = {}): boolean => {
   if (Array.isArray(value)) {
     return value.every(val => !!validate(val, { min, max }));
   }

--- a/src/rules/confirmed.ts
+++ b/src/rules/confirmed.ts
@@ -1,6 +1,6 @@
-import { ValidationRuleFunction, RuleParamSchema } from '../types';
+import { RuleParamSchema } from '../types';
 
-const validate: ValidationRuleFunction = (value, { target }: any) => String(value) === String(target);
+const validate = (value: string, { target }: Record<string, any>) => String(value) === String(target);
 
 const params: RuleParamSchema[] = [
   {

--- a/src/rules/digits.ts
+++ b/src/rules/digits.ts
@@ -1,6 +1,6 @@
-import { RuleParamSchema } from '../types';
+import { RuleParamSchema, StringOrNumber } from '../types';
 
-const validate = (value: any, { length }: any): boolean => {
+const validate = (value: StringOrNumber | StringOrNumber[], { length }: Record<string, any>): boolean => {
   if (Array.isArray(value)) {
     return value.every(val => validate(val, { length }));
   }

--- a/src/rules/dimensions.ts
+++ b/src/rules/dimensions.ts
@@ -12,7 +12,7 @@ const validateImage = (file: File, width: number, height: number): Promise<boole
   });
 };
 
-const validate = (files: File | File[], { width, height }: any) => {
+const validate = (files: File | File[], { width, height }: Record<string, any>) => {
   const list = [];
   files = Array.isArray(files) ? files : [files];
   for (let i = 0; i < files.length; i++) {

--- a/src/rules/email.ts
+++ b/src/rules/email.ts
@@ -1,6 +1,6 @@
 import { RuleParamSchema } from '../types';
 
-const validate = (value: string | string[], { multiple }: any = {}) => {
+const validate = (value: string | string[], { multiple }: Record<string, any> = {}) => {
   // eslint-disable-next-line
   const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
   if (multiple && !Array.isArray(value)) {

--- a/src/rules/excluded.ts
+++ b/src/rules/excluded.ts
@@ -1,6 +1,7 @@
 import { validate as includes } from './oneOf';
+import { ValidationRuleFunction } from '../types';
 
-const validate = (value: any, args: any[]) => {
+const validate: ValidationRuleFunction = (value, args) => {
   return !includes(value, args);
 };
 

--- a/src/rules/ext.ts
+++ b/src/rules/ext.ts
@@ -1,4 +1,4 @@
-const validate = (files: File | File[], extensions: string[]) => {
+const validate = (files: File | File[], extensions: string[] | Record<string, any>) => {
   const regex = new RegExp(`.(${extensions.join('|')})$`, 'i');
   if (Array.isArray(files)) {
     return files.every(file => regex.test(file.name));

--- a/src/rules/integer.ts
+++ b/src/rules/integer.ts
@@ -1,4 +1,6 @@
-const validate = (value: any) => {
+import { StringOrNumber } from '../types';
+
+const validate = (value: StringOrNumber | StringOrNumber[]) => {
   if (Array.isArray(value)) {
     return value.every(val => /^-?[0-9]+$/.test(String(val)));
   }

--- a/src/rules/is.ts
+++ b/src/rules/is.ts
@@ -1,6 +1,6 @@
 import { RuleParamSchema } from '../types';
 
-const validate = (value: any, { other }: any) => {
+const validate = (value: any, { other }: Record<string, any>) => {
   return value === other;
 };
 

--- a/src/rules/is_not.ts
+++ b/src/rules/is_not.ts
@@ -1,6 +1,6 @@
 import { RuleParamSchema } from '../types';
 
-const validate = (value: any, { other }: any) => {
+const validate = (value: any, { other }: Record<string, any>) => {
   return value !== other;
 };
 

--- a/src/rules/length.ts
+++ b/src/rules/length.ts
@@ -1,7 +1,7 @@
 import { isNullOrUndefined, toArray } from '../utils';
 import { RuleParamSchema } from '../types';
 
-const validate = (value: any, { length }: any) => {
+const validate = (value: string | number | string[], { length }: Record<string, any>) => {
   if (isNullOrUndefined(value)) {
     return false;
   }

--- a/src/rules/max.ts
+++ b/src/rules/max.ts
@@ -1,7 +1,7 @@
 import { isNullOrUndefined } from '../utils';
-import { RuleParamSchema } from '../types';
+import { RuleParamSchema, StringOrNumber } from '../types';
 
-const validate = (value: any, { length }: any): boolean => {
+const validate = (value: StringOrNumber | StringOrNumber[], { length }: Record<string, any>): boolean => {
   if (isNullOrUndefined(value)) {
     return length >= 0;
   }

--- a/src/rules/max_value.ts
+++ b/src/rules/max_value.ts
@@ -1,7 +1,7 @@
 import { isNullOrUndefined } from '../utils';
-import { RuleParamSchema } from '../types';
+import { RuleParamSchema, ValidationRuleFunction, StringOrNumber } from '../types';
 
-const validate = (value: any, { max }: any): boolean => {
+const validate: ValidationRuleFunction = (value: StringOrNumber | StringOrNumber[], { max }: Record<string, any>) => {
   if (isNullOrUndefined(value) || value === '') {
     return false;
   }

--- a/src/rules/mimes.ts
+++ b/src/rules/mimes.ts
@@ -1,4 +1,4 @@
-const validate = (files: File | File[], mimes: any) => {
+const validate = (files: File | File[], mimes: string[] | Record<string, any>) => {
   const regex = new RegExp(`${mimes.join('|').replace('*', '.+')}$`, 'i');
   if (Array.isArray(files)) {
     return files.every(file => regex.test(file.type));

--- a/src/rules/min.ts
+++ b/src/rules/min.ts
@@ -1,7 +1,7 @@
 import { isNullOrUndefined } from '../utils';
-import { RuleParamSchema } from '../types';
+import { RuleParamSchema, StringOrNumber } from '../types';
 
-const validate = (value: any, { length }: any): boolean => {
+const validate = (value: StringOrNumber | StringOrNumber[], { length }: Record<string, any>): boolean => {
   if (isNullOrUndefined(value)) {
     return false;
   }

--- a/src/rules/min_value.ts
+++ b/src/rules/min_value.ts
@@ -1,7 +1,7 @@
 import { isNullOrUndefined } from '../utils';
-import { RuleParamSchema } from '../types';
+import { RuleParamSchema, StringOrNumber } from '../types';
 
-const validate = (value: any, { min }: any): boolean => {
+const validate = (value: StringOrNumber | StringOrNumber[], { min }: Record<string, any>): boolean => {
   if (isNullOrUndefined(value) || value === '') {
     return false;
   }

--- a/src/rules/numeric.ts
+++ b/src/rules/numeric.ts
@@ -1,8 +1,10 @@
+import { StringOrNumber } from '../types';
+
 const ar = /^[٠١٢٣٤٥٦٧٨٩]+$/;
 const en = /^[0-9]+$/;
 
-const validate = (value: any) => {
-  const testValue = (val: any) => {
+const validate = (value: StringOrNumber | StringOrNumber[]) => {
+  const testValue = (val: StringOrNumber) => {
     const strValue = String(val);
 
     return en.test(strValue) || ar.test(strValue);

--- a/src/rules/oneOf.ts
+++ b/src/rules/oneOf.ts
@@ -1,11 +1,12 @@
 import { toArray } from '../utils';
+import { ValidationRuleFunction } from '../types';
 
-const validate = (value: any, options: any[]): boolean => {
+const validate: ValidationRuleFunction = (value, options) => {
   if (Array.isArray(value)) {
     return value.every(val => validate(val, options));
   }
 
-  return toArray(options).some(item => {
+  return toArray(options as any[]).some(item => {
     // eslint-disable-next-line
     return item == value;
   });

--- a/src/rules/regex.ts
+++ b/src/rules/regex.ts
@@ -1,6 +1,6 @@
-import { RuleParamSchema } from '../types';
+import { RuleParamSchema, StringOrNumber } from '../types';
 
-const validate = (value: any, { regex }: any): boolean => {
+const validate = (value: StringOrNumber | StringOrNumber[], { regex }: Record<string, any>): boolean => {
   if (Array.isArray(value)) {
     return value.every(val => validate(val, { regex: regex }));
   }

--- a/src/rules/required.ts
+++ b/src/rules/required.ts
@@ -1,7 +1,7 @@
 import { isEmptyArray, isNullOrUndefined } from '../utils';
 import { RuleParamSchema } from '../types';
 
-const validate = (value: any, { allowFalse }: any = { allowFalse: true }) => {
+const validate = (value: any, { allowFalse }: Record<string, any> = { allowFalse: true }) => {
   const result = {
     valid: false,
     required: true

--- a/src/rules/required_if.ts
+++ b/src/rules/required_if.ts
@@ -1,8 +1,8 @@
 import { isEmptyArray } from '../utils';
 import { RuleParamSchema } from '../types';
 
-const validate = (value: any, { target, values }: any) => {
-  let required = values.includes(String(target).trim());
+const validate = (value: any, { target, values }: Record<string, any>) => {
+  const required = values.includes(String(target).trim());
 
   if (!required) {
     return {

--- a/src/rules/size.ts
+++ b/src/rules/size.ts
@@ -1,6 +1,6 @@
 import { RuleParamSchema } from '../types';
 
-const validate = (files: File | File[], { size }: any) => {
+const validate = (files: File | File[], { size }: Record<string, any>) => {
   if (isNaN(size)) {
     return false;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,8 @@ export interface ValidationRuleSchema {
 
 export type ValidationRule = ValidationRuleFunction | ValidationRuleSchema;
 
+export type StringOrNumber = string | number;
+
 // Extracts explicit keys of an interface without index signature
 // https://stackoverflow.com/questions/51465182/typescript-remove-index-signature-using-mapped-types
 export type KnownKeys<T> = {


### PR DESCRIPTION
🔎 __Overview__

This PR fixes the bug of types on rules. Some rule could not be use in typescript like `ext` or `alpha`.

_Note : for the rule with type of `value` to any or rule with type `ValidationRuleFunction` it's just because i don't know what is the type excepted._

🤓 __Code snippets/examples (if applicable)__

```ts
import { extend } from 'vee-validate'
import { ext } from 'vee-validate/dist/rules'

extend('ext', ext)
```
This code is now work correctly.

✔ __Issues affected__

list of issues formatted like this:

> closes #2289
