### PR TITLE
#2314 Fix required is explicit false

### DIFF
--- a/src/utils/vnode.ts
+++ b/src/utils/vnode.ts
@@ -226,7 +226,7 @@ export function resolveRules(vnode: VNode) {
   }
 
   const rules: Record<string, any> = {};
-  if ('required' in attrs) {
+  if ('required' in attrs && attrs.required !== false) {
     rules.required = attrs.type === 'checkbox' ? [true] : true;
   }
 

--- a/tests/providers/provider.js
+++ b/tests/providers/provider.js
@@ -894,6 +894,26 @@ describe('HTML5 Rule inference', () => {
     expect(wrapper.find('#error').text()).toContain('email');
   });
 
+  test('Required explicit false', async () => {
+    const wrapper = mount(
+      {
+        data: () => ({ val: '1' }),
+        template: `
+        <ValidationProvider v-slot="{ errors }">
+          <input type="text" :required="false" v-model="val">
+          <p id="error">{{ errors[0] }}</p>
+        </ValidationProvider>`
+      },
+      { localVue: Vue, sync: false }
+    );
+
+    await flushPromises();
+    expect(wrapper.find('#error').text()).toBe('');
+    wrapper.find('input').setValue('');
+    await flushPromises();
+    expect(wrapper.find('#error').text()).toBe('');
+  });
+
   test('regex and minlength and maxlength rules', async () => {
     const wrapper = mount(
       {


### PR DESCRIPTION
🔎 __Overview__

This PR makes dynamic required on input dom elements possible to be disabled

```js
{
  data: () => ({ val: '1' }),
  template: `
    <ValidationProvider v-slot="{ errors }">
      <input type="text" :required="false" v-model="val">
        <p id="error">{{ errors[0] }}</p>
       </ValidationProvider>
    `
}
```

✔ __Issues affected__
> closes #2314 
