### PR TITLE
[feat] allow strings to be returned in rule validation functions

### DIFF
--- a/docs/guide/advanced-validation.md
+++ b/docs/guide/advanced-validation.md
@@ -21,35 +21,20 @@ Consider this dummy `profanity` rule where we have 2 states for the error messag
 ```js
 import { extend } from 'vee-validate';
 
-extend('profanity', {
-  validate: value => {
-    if (value === 'heck') {
-      return { valid: false, data: { reason: 'NICE_H_TRY' } };
-    }
-
-    if (value === 'frick') {
-      return { valid: false, data: { reason: 'NICE_F_TRY' } };
-    }
-
-    return true;
-  },
-  message: (field, values) => {
-    if (values.reason === 'NICE_H_TRY') {
-      return 'You cannot say any of the H words.';
-    }
-
-    if (values.reason === 'NICE_F_TRY') {
-      return 'You cannot say any of the F words.';
-    }
-
-    return 'You cannot say that.';
+extend('profanity', value => {
+  if (value === 'heck') {
+    return 'You cannot say any of the H words.';
   }
+
+  if (value === 'frick') {
+    return 'You cannot say any of the F words.';
+  }
+
+  return true;
 });
 ```
 
-The `data` property returned in the `validate` function result is an object that contains additional information that we want to pass to our message generator function. The contents of the `data` prop will be merged with the `values` passed to the message function, allowing you to craft specific error messages for specific reasons.
-
-You can find this example [live right here](https://codesandbox.io/embed/veevalidate-30-dynamic-messages-3k649).
+Here we take advantage of being able to return messages directly in our `validate` function, with this we are able to return multiple messages or **reasons** for failing a rule. You can find this example [live right here](https://codesandbox.io/embed/veevalidate-30-dynamic-messages-3k649).
 
 ## Cross-Field validation
 

--- a/docs/guide/basic-validation.md
+++ b/docs/guide/basic-validation.md
@@ -49,19 +49,39 @@ Rule functions can also accept params to configure their behavior.
 ```js
 import { extend } from 'vee-validate';
 
-extend('required', {
+extend('maxVal', {
   params: ['max'], // list of parameter names
   validate(value, { max }) {
-    return Number(value) > max;
+    return Number(value) <= max;
   }
 });
 ```
 
 declared parameters will be passed in an object in the second parameter to the `validate` function.
 
-## Customizing the error message
+## Error messages
 
-To provide a custom error message for that rule, we will pass an object instead of a function. This object will contain a `validate` method, as well as a `message` prop.
+### Returning messages directly <Badge text="3.0.6+" type="tip"/>
+
+You can return a string in your `validate` function and it will be used as the error message.
+
+```js
+import { extend } from 'vee-validate';
+
+extend('required', value => {
+  if (!!value) {
+    return true;
+  }
+
+  return 'This field is required';
+});
+```
+
+This is very handy for complex rules that may have multiple reasons to fail validation, it is also very concise and allows you to dynamically return messages as needed. [Check this advanced example](./advanced-validation.md#dynamic-messages) that takes advantage of this.
+
+### via extend Options
+
+Alternatively, you can provide a custom error message for that rule, we will pass an object instead of a function. This object will contain a `validate` method, as well as a `message` prop.
 
 ```js
 import { extend } from 'vee-validate';

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export interface ValidationRuleResult {
 export type ValidationRuleFunction = (
   value: any,
   params: any[] | Record<string, any>
-) => boolean | ValidationRuleResult | Promise<boolean | ValidationRuleResult>;
+) => boolean | string | ValidationRuleResult | Promise<boolean | string | ValidationRuleResult>;
 
 export interface RuleParamConfig {
   name: string;

--- a/tests/extend.spec.js
+++ b/tests/extend.spec.js
@@ -1,4 +1,4 @@
-import { extend } from '@/index.full';
+import { extend, validate } from '@/index.full';
 
 test('passing a non-function as the validate method will throw', () => {
   expect(() => {
@@ -6,4 +6,24 @@ test('passing a non-function as the validate method will throw', () => {
       validate: ''
     });
   }).toThrow();
+});
+
+test('Can return error messages directly in the validate fn', async () => {
+  extend('test-direct', value => {
+    if (value === '1') {
+      return 'Cannot be 1';
+    }
+
+    if (value === '2') {
+      return '{_field_} Cannot be 2';
+    }
+
+    return true;
+  });
+
+  let result = await validate('1', 'test-direct');
+  expect(result.errors[0]).toBe('Cannot be 1');
+
+  result = await validate('2', 'test-direct', { name: 'test' });
+  expect(result.errors[0]).toBe('test Cannot be 2');
 });


### PR DESCRIPTION
🔎 __Overview__

Explain the premise for adding this PR and why is it important.

This PR allows returning templated strings from the validation functions directly, leading to easier and more dynamic messages.

✔ __Issues affected__

closes #2327
