### PR TITLE
feat: export dictionary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export { extend } from './extend';
 export { install } from './install';
 export { configure } from './config';
 export { setInteractionMode } from './modes';
-export { localize } from './localize';
+export { localize, getDictionary } from './localize';
 export { ValidationProvider, ValidationObserver, withValidation } from './components';
 
 const version = '__VERSION__';

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -131,4 +131,8 @@ function localize(locale: string | RootI18nDictionary, dictionary?: PartialI18nD
   updateRules();
 }
 
-export { localize };
+function getDictionary(): Dictionary {
+  return DICTIONARY;
+}
+
+export { localize, getDictionary };


### PR DESCRIPTION
Ex (Feat):
This PR adds an export of the localisation dictionary.
If you can access the dictionary you can translate server side errors to the client locale. And keep the messages in one place.
You arre also able to use the getName function to display the correct label for the input field

🤓 __Code snippets/examples 

```js
import { getDictionary } from 'vee-validate'

const dict = getDictionary()
this.$refs.provider.setErrors([
  dict.format(dict.locale, this.name, 'a_server_side_rule', {
    _value_: this.value,
    _rule_: 'a_server_side_rule'
  }),
])

//.........//

const dict = getDictionary()
attrs.label = dict.getName(dict.locale, this.name)
```

If you require a test I will add it with pleasure