### PR TITLE
In setInteractionMode function, implementation parameter should be optional parameter

### DIFF
--- a/src/modes.ts
+++ b/src/modes.ts
@@ -46,7 +46,7 @@ export const modes: { [k: string]: InteractionModeFactory } = {
   lazy
 };
 
-export const setInteractionMode = (mode: string, implementation: InteractionModeFactory) => {
+export const setInteractionMode = (mode: string, implementation?: InteractionModeFactory) => {
   setConfig({ mode });
   if (!implementation) {
     return;


### PR DESCRIPTION
🔎 __Overview__

(SetInteractiveMode)
This PR fixes the bug by adds `?` to make implementation parameter of setInteractiveMode to be optional parameter

🤓 __Code snippets/examples (if applicable)__

```js
export const setInteractionMode = (mode: string, implementation?: InteractionModeFactory) => {
```

✔ __Issues affected__

list of issues formatted like this:

> closes #2351 
