### PR TITLE
feat: add target field placeholder

### DIFF
--- a/docs/guide/displaying-errors.md
+++ b/docs/guide/displaying-errors.md
@@ -202,6 +202,7 @@ You can use any names for your placeholders, except for:
 - `{_field_}` which is the field name.
 - `{_value_}` which is the field value.
 - `{_rule_}` which is the rule name.
+- `{_target_}` which is any related target field name.
 
 Which are provided internally.
 :::
@@ -216,7 +217,7 @@ interface ValidationMessageGenerator {
 }
 ```
 
-The `field` is the field name, the `values` argument is an object containing the placeholder values used in string interpolation. Meaning it will contain `_value_`, `_field_` and `_rule_` values as well as any other params previously declared.
+The `field` is the field name, the `values` argument is an object containing the placeholder values used in string interpolation. Meaning it will contain `_value_`, `_field_`, `_rule_` and `_target_` values as well as any other params previously declared.
 
 You can use this feature to create dynamic messages for your rules which is helpful for [providing multiple reasons for failing a rule](./advanced-validation.md#dynamic-messages), or [localization](./localization.md).
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -215,7 +215,8 @@ function _generateFieldError(
     ...(data || {}),
     _field_: field.name,
     _value_: value,
-    _rule_: ruleName
+    _rule_: ruleName,
+    _target_: _getTargetName(field, ruleSchema, ruleName)
   };
 
   if (
@@ -239,6 +240,19 @@ function _generateFieldError(
     msg: _normalizeMessage(getConfig().defaultMessage, field.name, values),
     rule: ruleName
   };
+}
+
+function _getTargetName(field: FieldContext, ruleSchema: ValidationRuleSchema, ruleName: string): string {
+  if (ruleSchema.params) {
+    for (let index = 0; index < ruleSchema.params.length; index++) {
+      const param: RuleParamConfig = ruleSchema.params[index] as RuleParamConfig;
+      if (param.isTarget) {
+        const targetName = field.rules[ruleName][index];
+        return field.names[targetName] || targetName;
+      }
+    }
+  }
+  return '';
 }
 
 function _normalizeMessage(template: ValidationMessageTemplate, field: string, values: Record<string, any>) {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -216,7 +216,7 @@ function _generateFieldError(
     _field_: field.name,
     _value_: value,
     _rule_: ruleName,
-    _target_: _getTargetName(field, ruleSchema, ruleName)
+    ..._getTargetName(field, ruleSchema, ruleName)
   };
 
   if (
@@ -242,17 +242,29 @@ function _generateFieldError(
   };
 }
 
-function _getTargetName(field: FieldContext, ruleSchema: ValidationRuleSchema, ruleName: string): string {
+function _getTargetName(
+  field: FieldContext,
+  ruleSchema: ValidationRuleSchema,
+  ruleName: string
+): Record<string, string> {
   if (ruleSchema.params) {
+    const hasMultiple = ruleSchema.params.filter(param => (param as RuleParamConfig).isTarget).length > 1;
+    const names: Record<string, string> = {};
     for (let index = 0; index < ruleSchema.params.length; index++) {
       const param: RuleParamConfig = ruleSchema.params[index] as RuleParamConfig;
       if (param.isTarget) {
-        const targetName = field.rules[ruleName][index];
-        return field.names[targetName] || targetName;
+        const key = field.rules[ruleName][index];
+        const name = field.names[key] || key;
+        if (hasMultiple) {
+          names[`_${param.name}Target_`] = name;
+        } else {
+          names._target_ = name;
+        }
       }
     }
+    return names;
   }
-  return '';
+  return {};
 }
 
 function _normalizeMessage(template: ValidationMessageTemplate, field: string, values: Record<string, any>) {

--- a/tests/validate.spec.js
+++ b/tests/validate.spec.js
@@ -1,5 +1,6 @@
 import { validate } from '@/validate';
 import { extend } from '@/extend';
+import { confirmed } from '@/rules';
 
 test('returns custom error messages passed in ValidationOptions', async () => {
   extend('truthy', {
@@ -19,4 +20,36 @@ test('returns custom error messages passed in ValidationOptions', async () => {
   const result = await validate(value, rules, options);
 
   expect(result.errors[0]).toEqual(customMessage);
+});
+
+describe('target field placeholder', () => {
+  extend('confirmed', {
+    ...confirmed,
+    message: '{_field_} must match {_target_}'
+  });
+
+  const names = { foo: 'Foo', bar: 'Bar', baz: 'Baz' };
+
+  test('uses target field name, if supplied in options', async () => {
+    const values = { foo: 10, bar: 20 };
+    const rules = 'confirmed:foo';
+    const options = {
+      name: names.bar,
+      values,
+      names
+    };
+    const result = await validate(values.bar, rules, options);
+    expect(result.errors[0]).toEqual('Bar must match Foo');
+  });
+
+  test('uses target field key, if target field name not supplied in options', async () => {
+    const values = { foo: 10, bar: 20 };
+    const rules = 'confirmed:foo';
+    const options = {
+      name: names.bar,
+      values
+    };
+    const result = await validate(values.bar, rules, options);
+    expect(result.errors[0]).toEqual('Bar must match foo');
+  });
 });

--- a/tests/validate.spec.js
+++ b/tests/validate.spec.js
@@ -52,4 +52,28 @@ describe('target field placeholder', () => {
     const result = await validate(values.bar, rules, options);
     expect(result.errors[0]).toEqual('Bar must match foo');
   });
+
+  test('works for multiple targets', async () => {
+    extend('sum_of', {
+      message: '{_field_} must be the sum of {_aTarget_} and {_bTarget_}',
+      // eslint-disable-next-line prettier/prettier
+      params: [
+        { name: 'a', isTarget: true },
+        { name: 'b', isTarget: true }
+      ],
+      validate: (value, { a, b }) => value === parseInt(a, 10) + parseInt(b, 10)
+    });
+
+    const values = { foo: 10, bar: 10, baz: 10 };
+    const names = { foo: 'Foo', bar: 'Bar', baz: 'Baz' };
+    const rules = 'sum_of:bar,baz';
+    const options = {
+      name: names.foo,
+      values,
+      names
+    };
+
+    const result = await validate(values.foo, rules, options);
+    expect(result.errors[0]).toEqual('Foo must be the sum of Bar and Baz');
+  });
 });


### PR DESCRIPTION
🔎 __Overview__

This PR adds functionality to show any related target field names using `{_target_}` or for multiple targets `{_fooTarget_}`, `{_barTarget_}`, ... 

```js
  test('fills target field placeholder', async () => {
    const names = { foo: 'Foo', bar: 'Bar', baz: 'Baz' };
    const values = { foo: 10, bar: 20 };
    const rules = 'confirmed:foo';
    const options = {
      name: names.bar,
      values,
      names
    };
    const result = await validate(values.bar, rules, options);
    expect(result.errors[0]).toEqual('Bar must match Foo');
  });
```

See tests in:

- https://github.com/davestewart/vee-validate/blob/feature/add-target-placeholder/tests/validate.spec.js#L25-L55

✔ __Issues affected__

closes #2290
