### PR TITLE
Propagate ValidationObserver's errors added via setErrors

### DIFF
--- a/docs/guide/validation-observer.md
+++ b/docs/guide/validation-observer.md
@@ -152,7 +152,7 @@ export default {
 
 While you can add errors manually to `ValidationProvider` with the `setErrors` method, it can be annoying to do so for multiple fields at once.
 
-The `ValidationObserver` exposes a `setErrors` method that can set errors for its children providers.
+The `ValidationObserver` exposes a `setErrors` method that can set errors for its children providers and observers.
 
 ```vue
 <template>

--- a/src/components/Observer.ts
+++ b/src/components/Observer.ts
@@ -248,6 +248,10 @@ export const ValidationObserver = (Vue as withObserverNode).extend({
 
         provider.setErrors(errors[key] || []);
       });
+
+      this.observers.forEach((observer: any) => {
+        observer.setErrors(errors);
+      });
     }
   }
 });

--- a/tests/providers/observer.js
+++ b/tests/providers/observer.js
@@ -490,3 +490,51 @@ test('Sets errors for all providers', async () => {
   expect(wrapper.find('#error1').text()).toBe('wrong');
   expect(wrapper.find('#error2').text()).toBe('whoops');
 });
+
+test('Sets errors for nested observer providers', async () => {
+  const wrapper = mount(
+    {
+      data: () => ({
+        field1: '',
+        field2: ''
+      }),
+      template: `
+    <div>
+      <ValidationObserver ref="observer">
+        <ValidationObserver>
+          <ValidationProvider
+            vid="field1"
+            v-slot="{ errors }"
+          >
+            <input type="text" v-model="field1">
+            <span id="error1">{{ errors[0] }}</span>
+          </ValidationProvider>
+
+          <ValidationProvider
+            name="field2"
+            v-slot="{ errors }"
+          >
+            <input type="text" v-model="field2">
+            <span id="error2">{{ errors[0] }}</span>
+          </ValidationProvider>
+        </ValidationObserver>
+      </ValidationObserver>
+    </div>
+    `
+    },
+    { localVue: Vue }
+  );
+
+  await flushPromises();
+  expect(wrapper.find('#error1').text()).toBe('');
+  expect(wrapper.find('#error2').text()).toBe('');
+
+  wrapper.vm.$refs.observer.setErrors({
+    field1: ['wrong'],
+    field2: ['whoops']
+  });
+
+  await flushPromises();
+  expect(wrapper.find('#error1').text()).toBe('wrong');
+  expect(wrapper.find('#error2').text()).toBe('whoops');
+});


### PR DESCRIPTION
This PR enables error propagation, so calling setErrors on parent (form-level) observer will be enough and errors will be rendered even on providers which are children of nested observers.

Example of issue here: https://codesandbox.io/s/veevalidate-30-manually-setting-errors-iknf0

This will be quite useful for those who have such structure:
```slim
ValidationObserver(ref="form" tag="form")
  Tab
    ValidationObserver
      ValidationProvider
        input
  Tab
    ValidationObserver
      ValidationProvider
        input
```
Current implementation requires you not only to call setErrors on parent observer, but also on each nested ValidationObserver, so snippet like this has to be added every time:
```js
this.$refs.form.observers.forEach((observer) => {
  observer.setErrors(response.data);
});
```
Note that this snippet is for one-level nesting. I'm not sure if anyone would need to have ValidationObserver > ValidationObserver > ValidationObserver, but then the code will be even more complicated.

If you think that it's better to keep setErrors simple, maybe another method should be added for this feature, I can make another PR.