### PR TITLE
fix: 2378

### DIFF
--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -1,4 +1,4 @@
-import { VNodeDirective, VNode } from 'vue';
+import { VNode } from 'vue';
 import { isCallable, debounce, identity } from '../utils';
 import { modes, InteractionModeFactory } from '../modes';
 import { ValidationResult, ValidationFlags, KnownKeys, ProviderInstance } from '../types';
@@ -153,7 +153,7 @@ export function addListeners(vm: ProviderInstance, node: VNode) {
   const value = findValue(node);
   // cache the input eventName.
   vm._inputEventName = vm._inputEventName || getInputEventName(node, findModel(node));
-  onRenderUpdate(vm, value);
+  onRenderUpdate(vm, value && value.value);
 
   const { onInput, onBlur, onValidate } = createCommonHandlers(vm);
   addVNodeListener(node, vm._inputEventName, onInput);

--- a/src/components/withValidation.ts
+++ b/src/components/withValidation.ts
@@ -37,7 +37,7 @@ export function withValidation(component: ComponentLike, mapProps: ValidationCon
     const model = findModel(this.$vnode);
     this._inputEventName = this._inputEventName || getInputEventName(this.$vnode, model);
     const value = findValue(this.$vnode);
-    onRenderUpdate(this, value);
+    onRenderUpdate(this, value && value.value);
 
     const { onInput, onBlur, onValidate } = createCommonHandlers(this);
 

--- a/src/utils/vnode.ts
+++ b/src/utils/vnode.ts
@@ -44,21 +44,21 @@ export function findModel(vnode: VNode): VNodeDirective | undefined {
   return find(vnode.data.directives, d => d.name === 'model');
 }
 
-export function findValue(vnode: VNode): any | undefined {
+export function findValue(vnode: VNode): { value: any } | undefined {
   const model = findModel(vnode);
   if (model) {
-    return model.value;
+    return { value: model.value };
   }
 
   const config = findModelConfig(vnode);
   const prop = (config && config.prop) || 'value';
   if (vnode.componentOptions && vnode.componentOptions.propsData && prop in vnode.componentOptions.propsData) {
     const propsDataWithValue = vnode.componentOptions.propsData as any;
-    return propsDataWithValue[prop];
+    return { value: propsDataWithValue[prop] };
   }
 
   if (vnode.data && vnode.data.domProps && 'value' in vnode.data.domProps) {
-    return vnode.data.domProps.value;
+    return { value: vnode.data.domProps.value };
   }
 
   return undefined;

--- a/src/utils/vnode.ts
+++ b/src/utils/vnode.ts
@@ -50,9 +50,11 @@ export function findValue(vnode: VNode): any | undefined {
     return model.value;
   }
 
-  if (vnode.componentOptions && vnode.componentOptions.propsData && 'value' in vnode.componentOptions.propsData) {
+  const config = findModelConfig(vnode);
+  const prop = (config && config.prop) || 'value';
+  if (vnode.componentOptions && vnode.componentOptions.propsData && prop in vnode.componentOptions.propsData) {
     const propsDataWithValue = vnode.componentOptions.propsData as any;
-    return propsDataWithValue.value;
+    return propsDataWithValue[prop];
   }
 
   if (vnode.data && vnode.data.domProps && 'value' in vnode.data.domProps) {


### PR DESCRIPTION
🔎 __Overview__

This PR fixes an issue introduced by #2355 which caused values initialized to `undefined` to get confused between the "found nodes but with undefined values" vs "found nodes with no values".

This caused the stop condition for the recursive "extractVNodes" to not function properly when a structure of the parent with model with children with `value` attribute, like a group of checkboxes or a group of radio buttons.

list of issues formatted like this:

closes #2378
