### PR TITLE
fix: allow empty rules expressions

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -183,6 +183,10 @@ export const normalizeRules = (rules: any) => {
 
   return rules.split('|').reduce((prev, rule) => {
     const parsedRule = parseRule(rule);
+    if (!parsedRule.name) {
+      return prev;
+    }
+
     prev[parsedRule.name] = parsedRule.params;
 
     return prev;

--- a/tests/validate.spec.js
+++ b/tests/validate.spec.js
@@ -1,6 +1,6 @@
 import { validate } from '@/validate';
 import { extend } from '@/extend';
-import { confirmed } from '@/rules';
+import { confirmed, numeric } from '@/rules';
 
 test('returns custom error messages passed in ValidationOptions', async () => {
   extend('truthy', {
@@ -76,4 +76,13 @@ describe('target field placeholder', () => {
     const result = await validate(values.foo, rules, options);
     expect(result.errors[0]).toEqual('Foo must be the sum of Bar and Baz');
   });
+});
+
+test('allows empty rules for the string format', async () => {
+  extend('numeric', numeric);
+  let result = await validate(100, '|numeric');
+  expect(result.valid).toBe(true);
+
+  result = await validate(100, '||||numeric');
+  expect(result.valid).toBe(true);
 });


### PR DESCRIPTION
🔎 __Overview__

This PR allows having empty pipes in string rules and aims to close #2386
```
||||required
```

✔ __Issues affected__

closes #2386 
