### PR TITLE
fix: remove uneeded check when provider re-renders closes #2388

### DIFF
--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -70,10 +70,6 @@ export function createValidationCtx(ctx: ProviderInstance): ValidationContext {
 }
 
 export function onRenderUpdate(vm: ProviderInstance, value: any | undefined) {
-  if (value === undefined) {
-    return;
-  }
-
   if (!vm.initialized) {
     vm.initialValue = value;
   }


### PR DESCRIPTION
🔎 __Overview__

Fixes a bug introduced by #2355 where a value of `undefined` would be skipped.

✔ __Issues affected__

closes #2388