### PR TITLE
fix: ensure that building arrays does not happen to objects with leng…

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -295,7 +295,7 @@ function _buildParams(
 
   let definedRules: RuleParamConfig[];
   // collect the params schema.
-  if (!defined || defined.length < provided.length) {
+  if (!defined || (defined.length < provided.length && Array.isArray(provided))) {
     let lastDefinedParam: RuleParamConfig;
     // collect any additional parameters in the last item.
     definedRules = provided.map((_: any, idx: number) => {


### PR DESCRIPTION
🔎 __Overview__

As reported in #2398, rules with `length` param will get treated as arrays by mistake. This PR adds an additional check to prevent trying to call `map`.

✔ __Issues affected__

closes #2398
