### PR TITLE
feat: added localeChanged helper to force providers to re-validate

### DIFF
--- a/src/index.full.ts
+++ b/src/index.full.ts
@@ -20,3 +20,4 @@ export { setInteractionMode } from './modes';
 export { validate } from './validate';
 export { ValidationProvider, ValidationObserver, withValidation } from './components';
 export { normalizeRules } from './utils/rules';
+export { localeChanged } from './localeChanged';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { extend } from './extend';
 export { configure } from './config';
 export { setInteractionMode } from './modes';
 export { localize } from './localize';
+export { localeChanged } from './localeChanged';
 export { ValidationProvider, ValidationObserver, withValidation } from './components';
 export { normalizeRules } from './utils/rules';
 

--- a/src/localeChanged.ts
+++ b/src/localeChanged.ts
@@ -1,0 +1,9 @@
+import Vue from 'vue';
+
+const EVENT_BUS = new Vue();
+
+export function localeChanged() {
+  EVENT_BUS.$emit('change:locale');
+}
+
+export { EVENT_BUS };

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -2,6 +2,7 @@ import { isCallable, merge, interpolate } from './utils';
 import { ValidationMessageTemplate } from './types';
 import { extend, RuleContainer } from './extend';
 import { getConfig } from './config';
+import { localeChanged } from './localeChanged';
 
 interface PartialI18nDictionary {
   name?: string;
@@ -95,6 +96,7 @@ function localize(locale: string | RootI18nDictionary, dictionary?: PartialI18nD
     }
 
     updateRules();
+    localeChanged();
     return;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface ValidationResult {
   valid: boolean;
   errors: string[];
   failedRules: Record<string, string>;
+  regenerateMap?: Record<string, () => string>;
 }
 
 export type VueValidationContext = Vue & {

--- a/tests/localize.spec.js
+++ b/tests/localize.spec.js
@@ -168,3 +168,32 @@ test('can define custom field names', async () => {
 
   expect(error.text()).toContain('The Name field is required');
 });
+
+test('regenerates error messages when locale changes', async () => {
+  const wrapper = mount(
+    {
+      data: () => ({
+        value: ''
+      }),
+      template: `
+        <div>
+          <ValidationProvider :immediate="true" rules="required" v-slot="{ errors }">
+            <input v-model="value" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </ValidationProvider>
+        </div>
+      `
+    },
+    { localVue: Vue, sync: false }
+  );
+
+  const error = wrapper.find('#error');
+
+  // flush the pending validation.
+  await flushPromises();
+  expect(error.text()).toContain('The {field} field is required');
+  localize('ar');
+
+  await flushPromises();
+  expect(error.text()).toContain('هذا الحقل مطلوب');
+});


### PR DESCRIPTION
🔎 __Overview__

Since `v3` has shipped with changes to the locale system being more tool agnostic, the developers have been missing the feature to re-render validation messages after locale changes. This PR introduces a `localeChanged` function which should help them trigger updates throughout their application.

Proposed API:

```js
import { localeChanged } from 'vee-validate';

// call it whenever you need the messages to re-render.
localeChanged();

// VueI18n example

this.$i18n,locale = 'ar';
localeChanged();
```

Furthermore, the `localize` function already handles that for you if you use the shipped minimal i18n feature:

```js
import { localize } from 'vee-validate';

// messages will re-render automatically.
localize('ar');
```

✔ __Issues affected__

closes #2074
