### PR TITLE
fix: handle `v-model.trim` and `v-model.number`

### DIFF
--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -43,5 +43,11 @@ export function normalizeEventValue(value: unknown): any {
     return valueAsNumber;
   }
 
+  if (input._vModifiers && input._vModifiers.trim) {
+    const trimmedValue = typeof input.value === 'string' ? input.value.trim() : input.value;
+
+    return trimmedValue;
+  }
+
   return input.value;
 }

--- a/tests/providers/provider.js
+++ b/tests/providers/provider.js
@@ -794,7 +794,7 @@ test('validates manually with a initial value using the validate event handler o
             <input type="text" :value="myValue" @input="validate">
             <p id="error">{{ errors[0] }}</p>
           </ValidationProvider>
-        </ValidationObserver> 
+        </ValidationObserver>
       `
     },
     { localVue: Vue, sync: false }
@@ -819,7 +819,7 @@ test('validates manually with a initial value using the validate event handler o
             <ModelComp :value="myValue" @input="validate" />
             <p id="error">{{ errors[0] }}</p>
           </ValidationProvider>
-        </ValidationObserver> 
+        </ValidationObserver>
       `
     },
     { localVue: Vue, sync: false }
@@ -1109,4 +1109,42 @@ test('returns custom error messages passed in the customMessages prop', async ()
   const result = await wrapper.vm.$refs.pro.validate();
 
   expect(result.errors[0]).toEqual(customMessage);
+});
+
+describe('Handle value mutating modifiers', () => {
+  test('handles .number modifier', () => {
+    const wrapper = mount(
+      {
+        data: () => ({ val: '' }),
+        template: `
+        <ValidationProvider rules="required" v-slot="ctx" ref="provider">
+          <input v-model.number="val" type="text">
+        </ValidationProvider>
+      `
+      },
+      { localVue: Vue, sync: false }
+    );
+
+    // should happen synchronously!
+    wrapper.find('input').setValue('11');
+    expect(wrapper.vm.$refs.provider.value).toBe(11);
+  });
+
+  test('handles .trim modifier', () => {
+    const wrapper = mount(
+      {
+        data: () => ({ val: '' }),
+        template: `
+        <ValidationProvider rules="required" v-slot="ctx" ref="provider">
+          <input v-model.trim="val" type="text">
+        </ValidationProvider>
+      `
+      },
+      { localVue: Vue, sync: false }
+    );
+
+    // should happen synchronously!
+    wrapper.find('input').setValue('  abc');
+    expect(wrapper.vm.$refs.provider.value).toBe('abc');
+  });
 });

--- a/tests/providers/provider.js
+++ b/tests/providers/provider.js
@@ -1128,6 +1128,10 @@ describe('Handle value mutating modifiers', () => {
     // should happen synchronously!
     wrapper.find('input').setValue('11');
     expect(wrapper.vm.$refs.provider.value).toBe(11);
+
+    // NaN values are left as is.
+    wrapper.find('input').setValue('x23');
+    expect(wrapper.vm.$refs.provider.value).toBe('x23');
   });
 
   test('handles .trim modifier', () => {


### PR DESCRIPTION
🔎 __Overview__

This PR handles both `v-model.trim` and `v-model.number` modifiers, The `ValidationProvider` component uses both `v-model` and `input` event to keep the value tracked, but when one of the two modifiers used, it will end up with 2 different values between re-renders, causing stuff like `eager` mode to break due to it thinking the value changed already in-between the renders.

This PR enhances the value normalization, by casting the value to number using `parseFloat` when the number modifier is used. And `String.trim` if the trim modifier is used.

✔ __Issues affected__

closes #2403
