### PR TITLE
Correction in the translation of "confirmed" rule for fr

### DIFF
--- a/locale/fr.json
+++ b/locale/fr.json
@@ -6,7 +6,7 @@
     "alpha_dash": "Le champ {_field_} ne peut contenir que des caractères alpha-numériques, tirets ou soulignés",
     "alpha_spaces": "Le champ {_field_} ne peut contenir que des lettres ou des espaces",
     "between": "Le champ {_field_} doit être compris entre {min} et {max}",
-    "confirmed": "Le champ {_field_} ne correspond pas à {target}",
+    "confirmed": "Le champ {_field_} ne correspond pas",
     "digits": "Le champ {_field_} doit être un nombre entier de {length} chiffres",
     "dimensions": "Le champ {_field_} doit avoir une taille de {width} pixels par {height} pixels",
     "email": "Le champ {_field_} doit être une adresse e-mail valide",


### PR DESCRIPTION
🔎 __Overview__

(Locale):
This PR changes the fr messages for confirmed because the confirmation message showed up the hidden password.
![image](https://user-images.githubusercontent.com/13848893/66471815-4e361900-ea8c-11e9-894e-55ff92951f97.png)
