### PR TITLE
feat: provider and observer state reducers

### DIFF
--- a/src/components/Observer.ts
+++ b/src/components/Observer.ts
@@ -62,7 +62,7 @@ export const ValidationObserver = (Vue as withObserverNode).extend({
       from: '$_veeObserver',
       default() {
         if (!this.$vnode.context.$_veeObserver) {
-          return null;
+          this.$vnode.context.$_veeObserver = this;
         }
 
         return this.$vnode.context.$_veeObserver;
@@ -137,23 +137,27 @@ export const ValidationObserver = (Vue as withObserverNode).extend({
   },
   created() {
     this.id = this.vid;
-    if (this.$_veeObserver) {
+    if (this.$_veeObserver && this.$_veeObserver !== this) {
       this.$_veeObserver.subscribe(this, 'observer');
     }
   },
   activated() {
-    if (this.$_veeObserver) {
+    if (this.$_veeObserver && this.$_veeObserver !== this) {
       this.$_veeObserver.subscribe(this, 'observer');
     }
   },
   deactivated() {
-    if (this.$_veeObserver) {
+    if (this.$_veeObserver && this.$_veeObserver !== this) {
       this.$_veeObserver.unsubscribe(this.id, 'observer');
     }
   },
   beforeDestroy() {
-    if (this.$_veeObserver) {
+    if (this.$_veeObserver && this.$_veeObserver !== this) {
       this.$_veeObserver.unsubscribe(this.id, 'observer');
+    }
+
+    if (this.$_veeObserver === this) {
+      delete this.$vnode.context.$_veeObserver;
     }
   },
   render(h: CreateElement): VNode {

--- a/src/components/Observer.ts
+++ b/src/components/Observer.ts
@@ -62,7 +62,7 @@ export const ValidationObserver = (Vue as withObserverNode).extend({
       from: '$_veeObserver',
       default() {
         if (!this.$vnode.context.$_veeObserver) {
-          this.$vnode.context.$_veeObserver = this;
+          return null;
         }
 
         return this.$vnode.context.$_veeObserver;
@@ -137,22 +137,26 @@ export const ValidationObserver = (Vue as withObserverNode).extend({
   },
   created() {
     this.id = this.vid;
-    if (this.$_veeObserver && this.$_veeObserver !== this) {
+    if (this.$_veeObserver) {
       this.$_veeObserver.subscribe(this, 'observer');
+    }
+
+    if (!this.$vnode.context.__vee_observer) {
+      this.$vnode.context.__vee_observer = this;
     }
   },
   activated() {
-    if (this.$_veeObserver && this.$_veeObserver !== this) {
+    if (this.$_veeObserver) {
       this.$_veeObserver.subscribe(this, 'observer');
     }
   },
   deactivated() {
-    if (this.$_veeObserver && this.$_veeObserver !== this) {
+    if (this.$_veeObserver) {
       this.$_veeObserver.unsubscribe(this.id, 'observer');
     }
   },
   beforeDestroy() {
-    if (this.$_veeObserver && this.$_veeObserver !== this) {
+    if (this.$_veeObserver) {
       this.$_veeObserver.unsubscribe(this.id, 'observer');
     }
 

--- a/src/components/Observer.ts
+++ b/src/components/Observer.ts
@@ -256,6 +256,18 @@ export const ValidationObserver = (Vue as withObserverNode).extend({
       this.observers.forEach((observer: any) => {
         observer.setErrors(errors);
       });
+    },
+    resolveField(id: string) {
+      let field = this.refs[id];
+      if (!field) {
+        this.observers.some(obs => {
+          field = obs.resolveField(id);
+
+          return field;
+        });
+      }
+
+      return field;
     }
   }
 });

--- a/src/components/Provider.ts
+++ b/src/components/Provider.ts
@@ -238,8 +238,7 @@ export const ValidationProvider = (Vue as withProviderPrivates).extend({
         customMessages: this.customMessages
       });
 
-      this.setFlags({ pending: false });
-      this.setFlags({ valid: result.valid, invalid: !result.valid });
+      this.setFlags({ pending: false, valid: result.valid, invalid: !result.valid });
 
       return result;
     },
@@ -321,6 +320,9 @@ function createObserver(): VeeObserver {
     },
     unsubscribe(id: string) {
       delete this.refs[id];
+    },
+    resolveField(id: string) {
+      return this.refs[id];
     }
   };
 }

--- a/src/index.full.ts
+++ b/src/index.full.ts
@@ -20,3 +20,4 @@ export { setInteractionMode } from './modes';
 export { validate } from './validate';
 export { install } from './install';
 export { ValidationProvider, ValidationObserver, withValidation } from './components';
+export * from './reducers';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { configure } from './config';
 export { setInteractionMode } from './modes';
 export { localize } from './localize';
 export { ValidationProvider, ValidationObserver, withValidation } from './components';
+export * from './reducers';
 
 const version = '__VERSION__';
 

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -1,0 +1,81 @@
+import Vue from 'vue';
+import { createFlags } from './utils';
+import { createValidationCtx } from './components/common';
+
+function normalizeToRecord<T extends string>(strOrArray: T | T[] | Record<string, T>) {
+  if (typeof strOrArray === 'string') {
+    return { [strOrArray]: strOrArray };
+  }
+
+  if (Array.isArray(strOrArray)) {
+    return strOrArray.reduce((acc: Record<string, T>, f) => {
+      acc[f] = f;
+
+      return acc;
+    }, {});
+  }
+
+  return strOrArray;
+}
+
+export function mapFieldState(fields: string | string[] | Record<string, string>) {
+  const map = normalizeToRecord(fields);
+  const reactiveHack = Vue.observable({
+    isMounted: false
+  });
+
+  return Object.keys(map).reduce((computed: Record<string, Function>, field) => {
+    const mappedName = map[field];
+    computed[mappedName] = function(this: any) {
+      if (!reactiveHack.isMounted) {
+        this.$on('hook:mounted', () => {
+          reactiveHack.isMounted = true;
+        });
+      }
+
+      const provider = this.$_veeObserver && this.$_veeObserver.resolveField(field);
+
+      // observer wasn't created yet or not found.
+      if (!provider) {
+        return {
+          ...createFlags(),
+          errors: [],
+          classes: {},
+          failedRules: {}
+        };
+      }
+
+      return createValidationCtx(provider);
+    };
+
+    return computed;
+  }, {});
+}
+
+export function mapFormState(name: string) {
+  const reactiveHack = Vue.observable({
+    isMounted: false
+  });
+
+  return {
+    [name](this: any) {
+      if (!reactiveHack.isMounted) {
+        this.$on('hook:mounted', () => {
+          reactiveHack.isMounted = true;
+        });
+      }
+
+      const observer = this.__vee_observer;
+
+      // observer wasn't created yet or not found.
+      if (!observer) {
+        return {
+          ...createFlags(),
+          errors: {}
+        };
+      }
+
+      return observer.ctx;
+    }
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,5 +90,6 @@ export interface InactiveRefCache {
 export type VNodeWithVeeContext = VNode & {
   context: Vue & {
     $_veeObserver?: VeeObserver;
+    __vee_observer?: VeeObserver;
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface ValidationFlags {
 
 export interface VeeObserver {
   refs: Record<string, ProviderInstance>;
+  resolveField(id: string): any;
   subscribe(provider: any, type?: 'provider' | 'observer'): void;
   unsubscribe(id: string, type?: 'provider' | 'observer'): void;
 }


### PR DESCRIPTION
🔎 __Overview__

This PR adds a couple of reducer functions that help with using the provider's and observer components state in their JavaScript.

The problem was some users needed access to the provider/observer state in their scripts to craft a customized validation experience for their apps. Using `$refs` was inconvenient and sometimes doesn't play well with reactivity meaning they can't be watched or used in computed values, making them only useful in methods.

This PR adds `mapFieldState` and `mapFormState` helpers to add a reactive shortcut to the validation state. You will find them very similar to Vuex's approach.

#### mapFieldState()

This function creates mappings between providers' state and local computed props.

```vue
<template>
    <ValidationProvider name="field" v-slot="ctx" rules="required">
      <input v-model="text">
    </ValidationProvider>
</template>

<script>
import { mapFieldState } from 'vee-validate';

export default {
  // ...
  computed: {
    ...mapFieldState({
      field: 'state'
    })
  },
// ...
};
</script>
```

The `mapFieldState` accepts an object that maps provider's by `vid` or `name` to a local computed state, in that example, we mapped the `field` provider to `state` computed prop.

This new mapper could mean that the `v-slot` will be no longer required for providers.

#### mapFormState()

This function maps an Observer's state to a local computed prop:

```vue
<template>
  <div>
    <ValidationObserver>
      <ValidationProvider name="field" v-slot="ctx" rules="required">
        <input v-model="val1">
      </ValidationProvider>

      <ValidationProvider name="field2" v-slot="ctx" rules="required">
        <input v-model="val2">
      </ValidationProvider>
    </ValidationObserver>

    <pre>{{ form }}</pre>
  </div>
</template>

<script>
import {  mapFormState } from 'vee-validate';

export default {
  data: () => ({
    text: '',
    text2: ''
  }),
  computed: {
    ...mapFormState('form')
  }
};
```

The `mapFieldState` accepts an object that maps observers by `vid`  to a local computed state, or if a single observer exists, maps that observer to a local computed state. In that example, we mapped the only observer to `form` computed prop.

✔ __Issues affected__

list of issues formatted like this:

closes #2350, closes #2283, closes #2248 
