### PR TITLE
Missing template closing tag

### DIFF
--- a/docs/guide/validation-provider.md
+++ b/docs/guide/validation-provider.md
@@ -370,7 +370,7 @@ This is the `TextInput` Component:
     <input type="text" v-model="innerValue" :value="value" />
     <span v-show="error">{{ error }}</span>
   </div>
-<template>
+</template>
 
 <script>
   export default {


### PR DESCRIPTION
A `</template>` tag is missing in one of the examples which would cause issues when copy/pasting.