### PR TITLE
Fixed a simple typo

### DIFF
--- a/docs/guide/a11y.md
+++ b/docs/guide/a11y.md
@@ -16,9 +16,9 @@ The `ValidationProvider` slot props expose an `ariaInput` object which you can b
 
 ```vue{3,7}
 <template>
-  <ValidationProvider rules="required" v-slot="{ aria }">
+  <ValidationProvider rules="required" v-slot="{ ariaInput }">
     <input type="text" v-model="value" v-bind="aria" />
-    <pre>{{ aria }}</pre>
+    <pre>{{ ariaInput }}</pre>
   </ValidationProvider>
 </template>
 


### PR DESCRIPTION
The documentation said that `ValidationProvider` exposed `aria` in it's scope. Changed that to `ariaInput`.
