### PR TITLE
feat: improve rule normalization

### DIFF
--- a/src/components/Provider.ts
+++ b/src/components/Provider.ts
@@ -128,7 +128,9 @@ export const ValidationProvider = (Vue as withProviderPrivates).extend({
       return Object.keys(this.normalizedRules)
         .filter(RuleContainer.isTargetRule)
         .reduce((acc: string[], rule: string) => {
-          const deps = RuleContainer.getTargetParamNames(rule, this.normalizedRules[rule]);
+          const deps = RuleContainer.getTargetParamNames(rule, this.normalizedRules[rule]).map(
+            (dep: any) => dep.__locatorKey
+          );
           acc.push(...deps);
           deps.forEach(depName => {
             watchCrossFieldDep(this, depName);

--- a/src/components/Provider.ts
+++ b/src/components/Provider.ts
@@ -129,7 +129,7 @@ export const ValidationProvider = (Vue as withProviderPrivates).extend({
         .filter(RuleContainer.isTargetRule)
         .reduce((acc: string[], rule: string) => {
           const deps = RuleContainer.getTargetParamNames(rule, this.normalizedRules[rule]).map(
-            (dep: any) => dep.__locatorKey
+            (dep: any) => dep.__locatorRef
           );
           acc.push(...deps);
           deps.forEach(depName => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export type VueValidationContext = Vue & {
   $_veeObserver?: VeeObserver;
 };
 
-export type Locator = { __isLocator?: boolean; __locatorRef?: string } & Function;
+export type Locator = { __locatorRef: string } & Function;
 
 export interface ValidationMessageGenerator {
   (field: string, params?: Record<string, any>): string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ export type VueValidationContext = Vue & {
   $_veeObserver?: VeeObserver;
 };
 
+export type Locator = { __isLocator?: boolean; __locatorRef?: string } & Function;
+
 export interface ValidationMessageGenerator {
   (field: string, params?: Record<string, any>): string;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { ValidationFlags, RuleParamConfig } from '../types';
+import { ValidationFlags, RuleParamConfig, Locator } from '../types';
 import { ValidationClassMap } from '../config';
 import { RuleContainer } from '../extend';
 
@@ -133,6 +133,20 @@ export const warn = (message: string) => {
   console.warn(`[vee-validate] ${message}`);
 };
 
+function createLocator(value: string): Locator {
+  const locator: Locator = (crossTable: Record<string, any>) => {
+    return crossTable[value];
+  };
+
+  locator.__locatorRef = value;
+
+  return locator;
+}
+
+export function isLocator(value: unknown): value is Locator {
+  return isCallable(value) && !!(value as any).__locatorRef;
+}
+
 function buildParams(ruleName: string, provided: any[] | Record<string, any>) {
   const ruleSchema = RuleContainer.getRuleDefinition(ruleName);
   if (!ruleSchema) {
@@ -188,17 +202,7 @@ function buildParams(ruleName: string, provided: any[] | Record<string, any>) {
 
     // if the param is a target, resolve the target value.
     if (options.isTarget) {
-      const __locatorKey = value;
-      const locator: { __isLocator?: boolean; __locatorKey?: string } & Function = (
-        crossTable: Record<string, any>
-      ) => {
-        return crossTable[__locatorKey];
-      };
-
-      locator.__isLocator = true;
-      locator.__locatorKey = __locatorKey;
-
-      value = locator;
+      value = createLocator(value);
     }
 
     // If there is a transformer defined.

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,5 +1,14 @@
 import { RuleContainer } from './extend';
-import { isObject, isNullOrUndefined, normalizeRules, isEmptyArray, interpolate, isCallable, find } from './utils';
+import {
+  isObject,
+  isNullOrUndefined,
+  normalizeRules,
+  isEmptyArray,
+  interpolate,
+  isCallable,
+  find,
+  isLocator
+} from './utils';
 import { ValidationResult, ValidationRuleSchema, ValidationMessageTemplate, RuleParamConfig } from './types';
 import { getConfig } from './config';
 
@@ -272,8 +281,8 @@ function _getTargetNames(
     }
 
     let key = ruleConfig[index];
-    if (isCallable(key) && key.__isLocator) {
-      key = key.__locatorKey;
+    if (isLocator(key)) {
+      key = key.__locatorRef;
     }
 
     const name = field.names[key] || key;
@@ -303,7 +312,7 @@ function fillTargetValues(params: Record<string, any>, crossTable: Record<string
 
   const values: typeof params = {};
   const normalize = (value: any) => {
-    if (isCallable(value) && value.__isLocator) {
+    if (isLocator(value)) {
       return value(crossTable);
     }
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -247,27 +247,33 @@ function _getTargetNames(
   ruleSchema: ValidationRuleSchema,
   ruleName: string
 ): Record<string, string> {
-  if (ruleSchema.params) {
-    const numTargets = ruleSchema.params.filter(param => (param as RuleParamConfig).isTarget).length;
-    if (numTargets > 0) {
-      const names: Record<string, string> = {};
-      for (let index = 0; index < ruleSchema.params.length; index++) {
-        const param: RuleParamConfig = ruleSchema.params[index] as RuleParamConfig;
-        if (param.isTarget) {
-          const key = field.rules[ruleName][index];
-          const name = field.names[key] || key;
-          if (numTargets === 1) {
-            names._target_ = name;
-            break;
-          } else {
-            names[`_${param.name}Target_`] = name;
-          }
-        }
-      }
-      return names;
-    }
+  if (!ruleSchema.params) {
+    return {};
   }
-  return {};
+
+  const numTargets = ruleSchema.params.filter(param => (param as RuleParamConfig).isTarget).length;
+  if (numTargets <= 0) {
+    return {};
+  }
+
+  const names: Record<string, string> = {};
+  for (let index = 0; index < ruleSchema.params.length; index++) {
+    const param: RuleParamConfig = ruleSchema.params[index] as RuleParamConfig;
+    if (!param.isTarget) {
+      continue;
+    }
+
+    const key = field.rules[ruleName][index];
+    const name = field.names[key] || key;
+    if (numTargets === 1) {
+      names._target_ = name;
+      break;
+    }
+
+    names[`_${param.name}Target_`] = name;
+  }
+
+  return names;
 }
 
 function _normalizeMessage(template: ValidationMessageTemplate, field: string, values: Record<string, any>) {


### PR DESCRIPTION
🔎 __Overview__

@davestewart you might want to watch out for this one.

I have re-worked how normalization occurs internally for rules, it is still done on two stages, but with a lot of changes:

**first-stage**: initial normalization for rules given to the `validate` function or the `provider` rules prop.

**second-stage**: Right before validation, the rules are normalized from the first stage to a consumable state.

#### before

Rules were normalized to key, array pairs in the first stage then converted to objects in the second stage, this was done due to target rules needing to take part in the normalization of values.

#### after

Rules are normalized to objects in the first stage, target rules params are wrapped into a `Locator` function which when called with a cross table, it would return the current target value.

The second stage is now much simpler as it only fills the target value rules.

This should have a slight performance gain.
