### PR TITLE
Feature/cross field syntax

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,6 +1,13 @@
 import { RuleContainer } from './extend';
 import { isObject, isNullOrUndefined, normalizeRules, isEmptyArray, interpolate, isLocator } from './utils';
-import { ValidationResult, ValidationRuleSchema, ValidationMessageTemplate, RuleParamConfig } from './types';
+import {
+  ValidationResult,
+  ValidationRuleSchema,
+  ValidationMessageTemplate,
+  RuleParamConfig,
+  ValidationMessageGenerator,
+  RuleParamSchema
+} from './types';
 import { getConfig } from './config';
 
 interface FieldContext {
@@ -210,39 +217,26 @@ function _generateFieldError(
   params: Record<string, any>,
   data?: Record<string, any>
 ) {
+  const message = field.customMessages[ruleName] || ruleSchema.message;
+  const ruleTargets = _getRuleTargets(field, ruleSchema, ruleName);
+  const { userTargets, userMessage } = _getUserTargets(field, ruleSchema, ruleName, message);
   const values = {
     ...(params || {}),
     ...(data || {}),
     _field_: field.name,
     _value_: value,
     _rule_: ruleName,
-    ..._getTargetNames(field, ruleSchema, ruleName)
+    ...ruleTargets,
+    ...userTargets
   };
 
-  if (
-    Object.prototype.hasOwnProperty.call(field.customMessages, ruleName) &&
-    typeof field.customMessages[ruleName] === 'string'
-  ) {
-    return {
-      msg: _normalizeMessage(field.customMessages[ruleName], field.name, values),
-      rule: ruleName
-    };
-  }
-
-  if (ruleSchema.message) {
-    return {
-      msg: _normalizeMessage(ruleSchema.message, field.name, values),
-      rule: ruleName
-    };
-  }
-
   return {
-    msg: _normalizeMessage(getConfig().defaultMessage, field.name, values),
+    msg: _normalizeMessage(userMessage || getConfig().defaultMessage, field.name, values),
     rule: ruleName
   };
 }
 
-function _getTargetNames(
+function _getRuleTargets(
   field: FieldContext,
   ruleSchema: ValidationRuleSchema,
   ruleName: string
@@ -286,6 +280,48 @@ function _getTargetNames(
   }
 
   return names;
+}
+
+function _getUserTargets(
+  field: FieldContext,
+  ruleSchema: ValidationRuleSchema,
+  ruleName: string,
+  userMessage: string | ValidationMessageGenerator | undefined
+) {
+  const userTargets: any = {};
+  const values: Record<string, any> = field.rules[ruleName];
+  const params: RuleParamSchema[] = ruleSchema.params || [];
+
+  if (values) {
+    // check to see if any are targets
+    Object.keys(values).forEach((key: string, index: number) => {
+      // variables
+      const value: any = values[key];
+
+      // user targets start with @
+      if (typeof value === 'string' && value.startsWith('@')) {
+        // get associated parameter
+        const param: any = params[index];
+        if (param) {
+          // grab the name of the target
+          const key = value.substr(1);
+          const placeholder = `_${key}Target_`;
+          userTargets[placeholder] = field.names[key] || key;
+
+          // update template if it's a string
+          if (typeof userMessage === 'string') {
+            const rx = new RegExp(`{${param.name}}`, 'g');
+            userMessage = userMessage.replace(rx, `{${placeholder}}`);
+          }
+        }
+      }
+    });
+  }
+
+  return {
+    userTargets,
+    userMessage
+  };
 }
 
 function _normalizeMessage(template: ValidationMessageTemplate, field: string, values: Record<string, any>) {

--- a/tests/targets.spec.js
+++ b/tests/targets.spec.js
@@ -1,0 +1,104 @@
+import { validate } from '@/validate';
+import { extend } from '@/extend';
+import { between, confirmed } from '@/rules';
+
+describe('target field placeholder', () => {
+  extend('confirmed', {
+    ...confirmed,
+    message: '{_field_} must match {_target_}'
+  });
+
+  const names = { foo: 'Foo', bar: 'Bar', baz: 'Baz' };
+
+  test('uses target field name, if supplied in options', async () => {
+    const values = { foo: 10, bar: 20 };
+    const rules = 'confirmed:foo';
+    const options = {
+      name: names.bar,
+      values,
+      names
+    };
+    const result = await validate(values.bar, rules, options);
+    expect(result.errors[0]).toEqual('Bar must match Foo');
+  });
+
+  test('uses target field key, if target field name not supplied in options', async () => {
+    const values = { foo: 10, bar: 20 };
+    const rules = 'confirmed:foo';
+    const options = {
+      name: names.bar,
+      values
+    };
+    const result = await validate(values.bar, rules, options);
+    expect(result.errors[0]).toEqual('Bar must match foo');
+  });
+
+  test('works for multiple targets', async () => {
+    extend('sum_of', {
+      message: '{_field_} must be the sum of {_aTarget_} and {_bTarget_}',
+      // eslint-disable-next-line prettier/prettier
+      params: [
+        { name: 'a', isTarget: true },
+        { name: 'b', isTarget: true }
+      ],
+      validate: (value, { a, b }) => value === parseInt(a, 10) + parseInt(b, 10)
+    });
+
+    const values = { foo: 10, bar: 10, baz: 10 };
+    const names = { foo: 'Foo', bar: 'Bar', baz: 'Baz' };
+    const rules = 'sum_of:bar,baz';
+    const options = {
+      name: names.foo,
+      values,
+      names
+    };
+
+    const result = await validate(values.foo, rules, options);
+    expect(result.errors[0]).toEqual('Foo must be the sum of Bar and Baz');
+  });
+});
+
+describe('cross-field syntax', () => {
+  extend('between', {
+    ...between,
+    message: '{_field_} must be between {min} and {max}'
+  });
+
+  const values = { value: 20, maxValue: 15 };
+  const names = { value: 'Value', maxValue: 'Max Value' };
+  const rules = 'between:0,@maxValue';
+  const options = {
+    name: names.value,
+    values
+  };
+
+  describe('should validate and generate the correct message', () => {
+    test('without options.names', async () => {
+      const result = await validate(values.value, rules, options);
+      expect(result.errors[0]).toEqual('Value must be between 0 and maxValue');
+    });
+
+    test('with options.names', async () => {
+      const result = await validate(values.value, rules, { ...options, names });
+      expect(result.errors[0]).toEqual('Value must be between 0 and Max Value');
+    });
+
+    test('with options.customMessages string', async () => {
+      const customMessages = {
+        between: 'The Value field must be more than {min} but less than {max}'
+      };
+      const result = await validate(values.value, rules, { ...options, customMessages, names });
+      expect(result.errors[0]).toEqual('The Value field must be more than 0 but less than Max Value');
+    });
+
+    test('with options.customMessages function', async () => {
+      const customMessages = {
+        between(field, { min, _maxValueTarget_ }) {
+          return `Must be more than ${min} and less than ${_maxValueTarget_}`;
+        }
+      };
+      const result = await validate(values.value, rules, { ...options, customMessages, names });
+      expect(result.errors[0]).toEqual('Must be more than 0 and less than Max Value');
+    });
+  });
+});

--- a/tests/validate.spec.js
+++ b/tests/validate.spec.js
@@ -1,6 +1,6 @@
 import { validate } from '@/validate';
 import { extend } from '@/extend';
-import { confirmed, numeric } from '@/rules';
+import { numeric } from '@/rules';
 
 test('returns custom error messages passed in ValidationOptions', async () => {
   extend('truthy', {
@@ -20,62 +20,6 @@ test('returns custom error messages passed in ValidationOptions', async () => {
   const result = await validate(value, rules, options);
 
   expect(result.errors[0]).toEqual(customMessage);
-});
-
-describe('target field placeholder', () => {
-  extend('confirmed', {
-    ...confirmed,
-    message: '{_field_} must match {_target_}'
-  });
-
-  const names = { foo: 'Foo', bar: 'Bar', baz: 'Baz' };
-
-  test('uses target field name, if supplied in options', async () => {
-    const values = { foo: 10, bar: 20 };
-    const rules = 'confirmed:foo';
-    const options = {
-      name: names.bar,
-      values,
-      names
-    };
-    const result = await validate(values.bar, rules, options);
-    expect(result.errors[0]).toEqual('Bar must match Foo');
-  });
-
-  test('uses target field key, if target field name not supplied in options', async () => {
-    const values = { foo: 10, bar: 20 };
-    const rules = 'confirmed:foo';
-    const options = {
-      name: names.bar,
-      values
-    };
-    const result = await validate(values.bar, rules, options);
-    expect(result.errors[0]).toEqual('Bar must match foo');
-  });
-
-  test('works for multiple targets', async () => {
-    extend('sum_of', {
-      message: '{_field_} must be the sum of {_aTarget_} and {_bTarget_}',
-      // eslint-disable-next-line prettier/prettier
-      params: [
-        { name: 'a', isTarget: true },
-        { name: 'b', isTarget: true }
-      ],
-      validate: (value, { a, b }) => value === parseInt(a, 10) + parseInt(b, 10)
-    });
-
-    const values = { foo: 10, bar: 10, baz: 10 };
-    const names = { foo: 'Foo', bar: 'Bar', baz: 'Baz' };
-    const rules = 'sum_of:bar,baz';
-    const options = {
-      name: names.foo,
-      values,
-      names
-    };
-
-    const result = await validate(values.foo, rules, options);
-    expect(result.errors[0]).toEqual('Foo must be the sum of Bar and Baz');
-  });
 });
 
 test('allows empty rules for the string format', async () => {


### PR DESCRIPTION
### 🔎 Overview

This PR adds a new `@target` syntax to allow fields to be targeted without needing to rewrite rule definitions.

- any rule can now **target** another field by referencing it via `@fieldName`.
- target field **values** will resolved and used in validation
- any **error messages** will be populated with the `@field` names if included in options, i.e. "Max Value" or the name of the field if not i.e. "maxValue"

This potentially removes the need for `isTarget` in rule definitions.

I haven't added any documentation for this update, as I don't know the docs as well as you at this point, so probably better you add it where you think it's best.

### 🤓 Code snippets/examples

```js
const values = { value: 20, maxValue: 15 };
const names = { value: 'Value', maxValue: 'Max Value' };
const rules = 'between:0,@maxValue';
const options = {
  name: names.value,
  values,
  names,
};

// Value must be between 0 and Max Value
const result = validate(values.value, rules, options);
```

### ✔ Issues affected

> closes #2367
