### PR TITLE
add typo fix on rules markdown

### DIFF
--- a/docs/api/rules.md
+++ b/docs/api/rules.md
@@ -1,7 +1,7 @@
 # Validation Rules
 
 :::tip Bundle size
-VeeValidate default bundle do no include any of these rules, you can import them indivdually:
+VeeValidate default bundle do not include any of these rules, you can import them individually:
 
 ```js
 import { extend } from 'vee-validate';

--- a/docs/api/rules.md
+++ b/docs/api/rules.md
@@ -1,7 +1,7 @@
 # Validation Rules
 
 :::tip Bundle size
-VeeValidate default bundle do not include any of these rules, you can import them individually:
+VeeValidate default bundle does not include any of these rules, you can import them individually:
 
 ```js
 import { extend } from 'vee-validate';


### PR DESCRIPTION
🔎 __Overview__

Noticed there were a couple of typos at the top of the `rules.md` file.

This PR adds the corrections.

🤓 __Code snippets/examples (if applicable)__

Before:
`VeeValidate default bundle do no include any of these rules, you can import them indivdually:`

After:
`VeeValidate default bundle does not include any of these rules, you can import them individually:`

✔ __Issues affected__

N/A
