### PR TITLE
Feat/rule negation

### DIFF
--- a/src/components/Provider.ts
+++ b/src/components/Provider.ts
@@ -129,7 +129,7 @@ export const ValidationProvider = (Vue as withProviderPrivates).extend({
       return Object.keys(this.normalizedRules)
         .filter(RuleContainer.isTargetRule)
         .reduce((acc: string[], rule: string) => {
-          const deps = RuleContainer.getTargetParamNames(rule, this.normalizedRules[rule]).map(
+          const deps = RuleContainer.getTargetParamNames(rule, this.normalizedRules[rule].params).map(
             (dep: any) => dep.__locatorRef
           );
           acc.push(...deps);

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,5 +98,7 @@ export type VNodeWithVeeContext = VNode & {
 };
 
 export interface NormalizedRule {
+  name: string;
   params: Record<string, any>;
+  isNegated: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,3 +96,7 @@ export type VNodeWithVeeContext = VNode & {
     $_veeObserver?: VeeObserver;
   };
 };
+
+export interface NormalizedRule {
+  params: Record<string, any>;
+}

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -38,7 +38,9 @@ export function normalizeRules(rules: any): Record<string, NormalizedRule> {
       }
 
       if (rules[curr] !== false) {
-        prev[curr] = { params: buildParams(curr, params) };
+        const isNegated = curr[0] === '!';
+        const name = isNegated ? curr.slice(1) : curr;
+        prev[name] = { name, params: buildParams(curr, params), isNegated };
       }
 
       return prev;
@@ -57,7 +59,13 @@ export function normalizeRules(rules: any): Record<string, NormalizedRule> {
       return prev;
     }
 
-    prev[parsedRule.name] = { params: buildParams(parsedRule.name, parsedRule.params) };
+    const isNegated = parsedRule.name[0] === '!';
+    const name = isNegated ? parsedRule.name.slice(1) : parsedRule.name;
+    prev[name] = {
+      name,
+      params: buildParams(parsedRule.name, parsedRule.params),
+      isNegated
+    };
 
     return prev;
   }, acc);

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -1,11 +1,11 @@
-import { Locator, RuleParamConfig } from '../types';
+import { Locator, RuleParamConfig, NormalizedRule } from '../types';
 import { RuleContainer } from '../extend';
 import { includes, isObject, warn } from './index';
 
 /**
  * Normalizes the given rules expression.
  */
-export function normalizeRules(rules: any) {
+export function normalizeRules(rules: any): Record<string, NormalizedRule> {
   // if falsy value return an empty object.
   const acc: { [x: string]: any } = {};
   Object.defineProperty(acc, '_$$isNormalized', {
@@ -38,7 +38,7 @@ export function normalizeRules(rules: any) {
       }
 
       if (rules[curr] !== false) {
-        prev[curr] = buildParams(curr, params);
+        prev[curr] = { params: buildParams(curr, params) };
       }
 
       return prev;
@@ -57,7 +57,7 @@ export function normalizeRules(rules: any) {
       return prev;
     }
 
-    prev[parsedRule.name] = buildParams(parsedRule.name, parsedRule.params);
+    prev[parsedRule.name] = { params: buildParams(parsedRule.name, parsedRule.params) };
 
     return prev;
   }, acc);

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -6,14 +6,15 @@ import {
   ValidationMessageGenerator,
   ValidationMessageTemplate,
   ValidationResult,
-  ValidationRuleSchema
+  ValidationRuleSchema,
+  NormalizedRule
 } from './types';
 import { getConfig } from './config';
 import { normalizeRules } from './utils/rules';
 
 interface FieldContext {
   name: string;
-  rules: Record<string, any>;
+  rules: Record<string, NormalizedRule>;
   bails: boolean;
   skipIfEmpty: boolean;
   forceRequired: boolean;
@@ -91,7 +92,7 @@ async function _validate(field: FieldContext, value: any, { isInitial = false } 
     const rule = rules[i];
     const result = await _test(field, value, {
       name: rule,
-      params: field.rules[rule]
+      params: field.rules[rule].params
     });
 
     if (!result.valid && result.error) {
@@ -253,7 +254,7 @@ function _getRuleTargets(
   }
 
   const names: Record<string, string> = {};
-  let ruleConfig = field.rules[ruleName];
+  let ruleConfig = field.rules[ruleName].params;
   if (!Array.isArray(ruleConfig) && isObject(ruleConfig)) {
     ruleConfig = params.map((param: any) => {
       return ruleConfig[param.name];
@@ -290,7 +291,7 @@ function _getUserTargets(
   userMessage: string | ValidationMessageGenerator | undefined
 ) {
   const userTargets: any = {};
-  const rules: Record<string, any> = field.rules[ruleName];
+  const rules: Record<string, any> = field.rules[ruleName].params;
   const params: RuleParamSchema[] = ruleSchema.params || [];
 
   // early return if no rules

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -194,6 +194,10 @@ async function _test(field: FieldContext, value: any, rule: NormalizedRule) {
     result = { valid: result, data: {} };
   }
 
+  if (rule.isNegated) {
+    result.valid = !result.valid;
+  }
+
   return {
     valid: result.valid,
     required: result.required,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -90,10 +90,7 @@ async function _validate(field: FieldContext, value: any, { isInitial = false } 
     }
 
     const rule = rules[i];
-    const result = await _test(field, value, {
-      name: rule,
-      params: field.rules[rule].params
-    });
+    const result = await _test(field, value, field.rules[rule]);
 
     if (!result.valid && result.error) {
       errors.push(result.error);
@@ -122,10 +119,7 @@ async function _shouldSkip(field: FieldContext, value: any) {
 
   for (let i = 0; i < length; i++) {
     const rule = requireRules[i];
-    const result = await _test(field, value, {
-      name: rule,
-      params: field.rules[rule]
-    });
+    const result = await _test(field, value, field.rules[rule]);
 
     if (!isObject(result)) {
       throw new Error('Require rules has to return an object (see docs)');
@@ -172,7 +166,7 @@ async function _shouldSkip(field: FieldContext, value: any) {
 /**
  * Tests a single input value against a rule.
  */
-async function _test(field: FieldContext, value: any, rule: { name: string; params: Record<string, any> }) {
+async function _test(field: FieldContext, value: any, rule: NormalizedRule) {
   const ruleSchema = RuleContainer.getRuleDefinition(rule.name);
   if (!ruleSchema || !ruleSchema.validate) {
     throw new Error(`No such validator '${rule.name}' exists.`);

--- a/tests/validate.spec.js
+++ b/tests/validate.spec.js
@@ -1,6 +1,6 @@
 import { validate } from '@/validate';
 import { extend } from '@/extend';
-import { numeric } from '@/rules';
+import { numeric, oneOf } from '@/rules';
 
 test('returns custom error messages passed in ValidationOptions', async () => {
   extend('truthy', {
@@ -29,4 +29,15 @@ test('allows empty rules for the string format', async () => {
 
   result = await validate(100, '||||numeric');
   expect(result.valid).toBe(true);
+});
+
+describe('rules can be negated', () => {
+  extend('oneOf', oneOf);
+  test('test basic negation', async () => {
+    let result = await validate('4', '!oneOf:1,2,3');
+    expect(result.valid).toBe(true);
+
+    result = await validate('1', '!oneOf:1,2,3');
+    expect(result.valid).toBe(false);
+  });
 });


### PR DESCRIPTION
🔎 __Overview__

This PR implements a mechanism of **rule negation**, which like the name suggests: allows you to flip the result of a validation rule.

The syntax looks like this:

```js
// implementing `is_not` by inverting `is`:
await validate(5, '!is:5');

// implementing `noneOf` by inverting `oneOf`:
await validate('1', '!oneOf:1,2,3');
```

The object syntax will look like this:

```js
await validate('1', {
  '!oneOf': [1,2,3]
});
```

There are some complications when it comes to error messages, as usually the error message for the negated rule is not quite the same for the base one, so I have two roads i could take to address this:

- Allow nested messages per rule.
- Separate keys for the negated rules.

Here is what a basic dictionary would look like in either case:

```js
// Nested Keys
const lang = {
  oneOf: {
    base: 'base message',
    negated: 'negated message'
  }
};

// Separate keys

const lang = {
  oneOf: 'base message',
  '!oneOf': 'negated message'
};
```

The first approach opens a door for having different modes for rules, but is complex and probably not needed as there won't be much use of modes down the line. I'm currently in favor of the second one as it is simpler and more straight forward.

Lastly, it would be useful for rules to be aware when they are being negated, which could allow you to tune in certain behaviors in negation to make the rule more useful. So we would probably introduce a new parameter for validation rule functions called `context` which will hold some metadata like full information about the field and if the rule is negated.

```js
function validateSomething (value, params, context) {
   const isNegated = context.isNegated;

   // ...
}
```

---

- [x] Implementing basic Negation
- [ ] Rules can be aware of negation.
- [ ] Handling Negated Message.
- [ ] Tests.
- [ ] Docs.

---


✔ __Issues affected__

closes #2285 
