### PR TITLE
fix(docs): validation observer for advanced validation

### DIFF
--- a/docs/guide/advanced-validation.md
+++ b/docs/guide/advanced-validation.md
@@ -81,8 +81,8 @@ Here is a working snippet of the last example:
 
 <ValidationObserver>
   <StyledProvider
-    name="Password"
-    rules="required|password:confirmation"
+    name="password"
+    :rules="{required:true, password: { confirm }}"
     v-slot="{ errors }"
   >
    <input v-model="pass" type="password">
@@ -306,10 +306,8 @@ export default {
   },
   mounted () {
     this.extendRule('password', {
-      validate: (value, { other }) => value === other,
-      params: [
-        { name: 'other', isTarget: true }
-      ],
+      validate: (value,  {confirm}) => value === confirm,
+      params: ['confirm'],
       message: 'The password confirmation does not match.',
     });
 


### PR DESCRIPTION
🔎 __Overview__

This PR is about a potential fix for the related issue #2358. There was a bug when visiting the [advanced validation](https://logaretm.github.io/vee-validate/guide/advanced-validation.html#dynamic-messages) page for the cross-field validation part. If we start from the accessibility page and then scroll to the bottom by clicking the next section (do this until you reach the page related to the problem), the validation system will not work anymore and the 'password' and 'confirmation' fields will never correspond.

__My solution__

I have changed the rules for the _StyledProvider_ related to the **password** field. First, I pass an object instead of a string, and then, in the **password** field, I directly put the value of the **confirmation** field (v-model = _confirm_). 

With this little modification, I also needed to change the extended rule _'password'_ in the **mounted** hook to make the sample works again. 

✔ __Issues affected__

> closes #2358 
