### PR TITLE
refactor(tests): use jest fake timers

### DIFF
--- a/tests/providers/observer.js
+++ b/tests/providers/observer.js
@@ -9,13 +9,12 @@ Vue.component('ValidationObserver', ValidationObserver);
 
 async function flush() {
   await flushPromises();
-
-  return new Promise(resolve => {
-    setTimeout(resolve, 50);
-  });
+  jest.runAllTimers();
 }
 
 const DEFAULT_REQUIRED_MESSAGE = 'The {field} field is required';
+
+beforeEach(() => jest.useFakeTimers());
 
 test('renders the slot', () => {
   const wrapper = mount(
@@ -311,6 +310,7 @@ test('exposes nested observers state', async () => {
   const input = wrapper.find('input');
   input.setValue('1');
   await flush();
+  await flush();
 
   expect(wrapper.find('p').text()).toContain('The {field} field may only contain alphabetic characters');
 });
@@ -339,8 +339,10 @@ test('validates and resets nested observers', async () => {
   expect(wrapper.find('p').text()).not.toContain(DEFAULT_REQUIRED_MESSAGE);
   await wrapper.vm.$refs.obs.validate();
   await flush();
+  await flush();
   expect(wrapper.find('p').text()).toContain(DEFAULT_REQUIRED_MESSAGE);
   await wrapper.vm.$refs.obs.reset();
+  await flush();
   await flush();
   expect(wrapper.find('p').text()).not.toContain(DEFAULT_REQUIRED_MESSAGE);
 });


### PR DESCRIPTION
🔎 __Overview__

Refactor the observer tests to use `jest.useFakeTimers()` instead of really waiting 50ms.