### PR TITLE
docs: added Installing All Rules with typescript

### DIFF
--- a/docs/guide/rules.md
+++ b/docs/guide/rules.md
@@ -42,7 +42,14 @@ import * as rules from 'vee-validate/dist/rules';
 Object.keys(rules).forEach(rule => {
   extend(rule, rules[rule]);
 });
-```
+
+// with typescript
+for (let [rule, validation] of Object.entries(rules)) {
+  extend(rule, {
+    ...validation
+  });
+}
+``` 
 
 One downside of the previous snippet is that you lose the ability to define error messages as you no longer know which rule is in the iteration. Luckily vee-validate includes messages for all of those rules in 40+ locales that you can import, and they map nicely to rule names, let's define messages in our previous sample:
 


### PR DESCRIPTION
🔎 __Overview__

This PR adds docs.
It fixes TS(7053) error.

`Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'typeof import(".../node_modules/vee-validate/dist/rules")'. No index signature with a parameter of type 'string' was found on type 'typeof import(".../node_modules/vee-validate/dist/rules")'.ts(7053)`

🤓 __Code snippets/examples (if applicable)__

**[AS-IS]**
![ts7053](https://user-images.githubusercontent.com/11773683/69628916-46a7ef00-108f-11ea-8ea6-9d7f2fbdeb35.png)

**[TO-BE]**
``` ts
import { extend } from "vee-validate";
import * as rules from "vee-validate/dist/rules";

for (let [rule, validation] of Object.entries(rules)) {
  extend(rule, {
    ...validation
  });
}
```