### PR TITLE
feat: nest nested observer errors instead of nesting

### DIFF
--- a/src/components/Observer.ts
+++ b/src/components/Observer.ts
@@ -99,13 +99,21 @@ export const ValidationObserver = (Vue as withObserverNode).extend({
 
     this.$watch(() => {
       const vms = [...values(this.refs), ...this.observers];
-      const errors: ObserverErrors = {};
+      let errors: ObserverErrors = {};
       const flags: ValidationFlags = createObserverFlags();
 
       const length = vms.length;
       for (let i = 0; i < length; i++) {
         const vm = vms[i];
-        errors[vm.id] = vm.errors;
+
+        // validation provider error
+        if (Array.isArray(vm.errors)) {
+          errors[vm.id] = vm.errors;
+          continue;
+        }
+
+        // Nested observer
+        errors = { ...errors, ...vm.errors };
       }
 
       FLAGS_STRATEGIES.forEach(([flag, method]) => {

--- a/tests/providers/observer.js
+++ b/tests/providers/observer.js
@@ -345,7 +345,7 @@ test('validates and resets nested observers', async () => {
   expect(wrapper.find('p').text()).not.toContain(DEFAULT_REQUIRED_MESSAGE);
 });
 
-test('handles unmouting nested observers', async () => {
+test('merges nested observers state', async () => {
   const wrapper = mount(
     {
       data: () => ({
@@ -367,12 +367,12 @@ test('handles unmouting nested observers', async () => {
   );
 
   await flush();
-  expect(wrapper.find('p').text()).toContain(`NESTED_OBS`); // observer is mounted.
+  expect(wrapper.find('p').text()).toContain(`name`); // nested observer is mounted.
   wrapper.setData({
     isMounted: false
   });
   await flush();
-  expect(wrapper.find('p').text()).not.toContain(`NESTED_OBS`); // observer is mounted.
+  expect(wrapper.find('p').text()).not.toContain(`name`); // nested observer is unmounted.
 });
 
 test('Sets errors for all providers', async () => {


### PR DESCRIPTION
This PR introduces a different strategy to handle nested observers which have been very confusing. The observers' errors were also nested, but this PR merges errors that make the structure predictable. Which allows us to tackle #1923 and #2484 

closes #2528