### PR TITLE
Add a 'valid' event when validation state changes

### DIFF
--- a/src/components/Provider.ts
+++ b/src/components/Provider.ts
@@ -120,7 +120,10 @@ export const ValidationProvider = (Vue as withProviderPrivates).extend({
       handler(val: any, oldVal: any) {
         this._needsValidation = !isEqual(val, oldVal);
       }
-    }
+    },
+    'flags.valid'(valid) {
+      this.$emit('valid', valid);
+    },
   },
   data,
   computed: {


### PR DESCRIPTION
🔎 __Overview__

It's sometimes useful to do some action when the validation state of a provider changes

For example: Two inputs are invalid, with a complex relationship behind it, changing one input will mark it as valid, however the second one, while now valid, will not revalidate because the value did not change, forcing the revalidation of this other provider from the `valid` event would solve the problem

Emitting an event every time the valid flag changes would take care of this use case