### PR TITLE
Change package version based on the doc

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -16,17 +16,17 @@ You can install this plugin via [npm](#npm) or via a [CDN](#cdn).
 ### npm
 
 ```bash
-npm install vee-validate --save
+npm install vee-validate@"<3.0.0" --save
 ```
 
 ### CDN
 
 ```html
   <!-- jsdelivr cdn -->
-  <script src="https://cdn.jsdelivr.net/npm/vee-validate@latest/dist/vee-validate.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vee-validate@<3.0.0/dist/vee-validate.js"></script>
 
   <!-- unpkg -->
-  <script src="https://unpkg.com/vee-validate@latest"></script>
+  <script src="https://unpkg.com/vee-validate@<3.0.0"></script>
 ```
 
 ## Usage


### PR DESCRIPTION
🔎 __Overview__

`npm install vee-validate` gets the latest package which is `3.*` and this doc is for vee-validate 2.
