### PR TITLE
Feat/resolve name

### DIFF
--- a/docs/guide/basics.md
+++ b/docs/guide/basics.md
@@ -340,6 +340,32 @@ To display the field name, you set the `name` prop on the validation provider:
 </ValidationProvider>
 ```
 
+Additionally, the field name can be automatically picked up from `name` or `id` attributes on HTML5 nodes if not specified already in the `ValidationProvider`'s `name` prop.
+
+Here since a `name` prop is not provided, vee-validate uses the `name` attribute on the input tag as a field name.
+
+```vue{5}
+<ValidationProvider
+  rules="positive"
+  v-slot="{ errors }"
+>
+  <input v-model="value" name="age" type="text">
+  <span>{{ errors[0] }}</span>
+</ValidationProvider>
+```
+
+Here since a `name` prop is not provided nor a `name` attribute on the input, vee-validate uses the `id` attribute on the input tag as a field name.
+
+```vue{5}
+<ValidationProvider
+  rules="positive"
+  v-slot="{ errors }"
+>
+  <input v-model="value" id="age" type="text">
+  <span>{{ errors[0] }}</span>
+</ValidationProvider>
+```
+
 ### Arguments Placeholders
 
 You can't really have the `min` rule message to be "this field is invalid", this is not only confusing to the user, they will have no knowledge on how to fix them.

--- a/docs/guide/basics.md
+++ b/docs/guide/basics.md
@@ -342,7 +342,7 @@ To display the field name, you set the `name` prop on the validation provider:
 
 Additionally, the field name can be automatically picked up from `name` or `id` attributes on HTML5 nodes if not specified already in the `ValidationProvider`'s `name` prop.
 
-Here since a `name` prop is not provided, vee-validate uses the `name` attribute on the input tag as a field name.
+Here since a `name` prop is not set, vee-validate uses the `name` attribute on the input tag as a field name.
 
 ```vue{5}
 <ValidationProvider
@@ -354,7 +354,7 @@ Here since a `name` prop is not provided, vee-validate uses the `name` attribute
 </ValidationProvider>
 ```
 
-Here since a `name` prop is not provided nor a `name` attribute on the input, vee-validate uses the `id` attribute on the input tag as a field name.
+Here since a `name` prop is not set nor a `name` attribute on the input, vee-validate uses the `id` attribute on the input tag as a field name.
 
 ```vue{5}
 <ValidationProvider

--- a/src/utils/vnode.ts
+++ b/src/utils/vnode.ts
@@ -197,6 +197,10 @@ export function getInputEventName(vnode: VNode, model?: VNodeDirective): string 
   return 'change';
 }
 
+export function isHTMLNode(node: VNode) {
+  return includes(['input', 'select', 'textarea'], node.tag);
+}
+
 // TODO: Type this one properly.
 export function normalizeSlots(slots: any, ctx: Vue): VNode[] {
   const acc: VNode[] = [];

--- a/tests/providers/provider.js
+++ b/tests/providers/provider.js
@@ -1119,6 +1119,46 @@ describe('HTML5 Rule inference', () => {
   });
 });
 
+test('field name can be resolved from name attribute', async () => {
+  const wrapper = mount(
+    {
+      data: () => ({ val: '123' }),
+      template: `
+        <ValidationProvider v-slot="{ errors }" rules="required">
+          <input v-model="val" name="firstName" type="text">
+          <span id="error">{{ errors[0] }}</span>
+        </ValidationProvider>
+      `
+    },
+    { localVue: Vue, sync: false }
+  );
+  await flushPromises();
+  wrapper.find('input').setValue('');
+  await flushPromises();
+
+  expect(wrapper.find('#error').text()).toBe(DEFAULT_REQUIRED_MESSAGE.replace('{field}', 'firstName'));
+});
+
+test('field name can be resolved from id attribute', async () => {
+  const wrapper = mount(
+    {
+      data: () => ({ val: '123' }),
+      template: `
+        <ValidationProvider v-slot="{ errors }" rules="required">
+          <input v-model="val" id="firstName" type="text">
+          <span id="error">{{ errors[0] }}</span>
+        </ValidationProvider>
+      `
+    },
+    { localVue: Vue, sync: false }
+  );
+  await flushPromises();
+  wrapper.find('input').setValue('');
+  await flushPromises();
+
+  expect(wrapper.find('#error').text()).toBe(DEFAULT_REQUIRED_MESSAGE.replace('{field}', 'firstName'));
+});
+
 test('array param collecting in the last parameter', async () => {
   extend('isOneOf', {
     validate(value, { val, isOneOf }) {


### PR DESCRIPTION
🔎 __Overview__

This PR adds automatic name resolution based on the `name` or `id` attributes if present on an HTML5 input, this potentially reduces code in some forms and is not breaking since no name was resolved before.

🤓 __Code snippets/examples (if applicable)__

Since a `name` prop is not provided, vee-validate uses the `name` attribute on the input tag as a field name.

```vue{5}
<ValidationProvider
  rules="positive"
  v-slot="{ errors }"
>
  <input v-model="value" name="age" type="text">
  <span>{{ errors[0] }}</span>
</ValidationProvider>
```

And here, since a `name` prop is not provided nor a `name` attribute on the input, vee-validate uses the `id` attribute on the input tag as a field name.

```vue{5}
<ValidationProvider
  rules="positive"
  v-slot="{ errors }"
>
  <input v-model="value" id="age" type="text">
  <span>{{ errors[0] }}</span>
</ValidationProvider>
```

✔ __Issues affected__

closes #2482 
