### PR TITLE
fix(rules): Verifying for BigInt

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,5 +22,8 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-use-before-define": "off"
+  },
+  "globals": {
+    "BigInt": true
   }
 }

--- a/src/rules/max_value.ts
+++ b/src/rules/max_value.ts
@@ -1,9 +1,13 @@
-import { isNullOrUndefined } from '../utils';
+import { isBigInt, isNullOrUndefined } from '../utils';
 import { RuleParamSchema, ValidationRuleFunction, StringOrNumber } from '../types';
 
 const validate: ValidationRuleFunction = (value: StringOrNumber | StringOrNumber[], { max }: Record<string, any>) => {
   if (isNullOrUndefined(value) || value === '') {
     return false;
+  }
+
+  if (isBigInt(value) || isBigInt(max)) {
+    return BigInt(value) <= BigInt(max);
   }
 
   if (Array.isArray(value)) {

--- a/src/rules/max_value.ts
+++ b/src/rules/max_value.ts
@@ -21,6 +21,10 @@ const params: RuleParamSchema[] = [
   {
     name: 'max',
     cast(value) {
+      if (isBigInt(value)) {
+        return BigInt(value);
+      }
+
       return Number(value);
     }
   }

--- a/src/rules/min_value.ts
+++ b/src/rules/min_value.ts
@@ -21,6 +21,10 @@ const params: RuleParamSchema[] = [
   {
     name: 'min',
     cast(value) {
+      if (isBigInt(value)) {
+        return BigInt(value);
+      }
+
       return Number(value);
     }
   }

--- a/src/rules/min_value.ts
+++ b/src/rules/min_value.ts
@@ -1,9 +1,13 @@
-import { isNullOrUndefined } from '../utils';
+import { isBigInt, isNullOrUndefined } from '../utils';
 import { RuleParamSchema, StringOrNumber } from '../types';
 
 const validate = (value: StringOrNumber | StringOrNumber[], { min }: Record<string, any>): boolean => {
   if (isNullOrUndefined(value) || value === '') {
     return false;
+  }
+
+  if (isBigInt(value) || isBigInt(min)) {
+    return BigInt(value) >= BigInt(min);
   }
 
   if (Array.isArray(value)) {

--- a/src/utils/assertions.ts
+++ b/src/utils/assertions.ts
@@ -6,6 +6,18 @@ export function isNaN(value: unknown): boolean {
   return value !== value;
 }
 
+export function isBigInt(value: unknown): boolean {
+  if (typeof value === 'bigint') {
+    return true;
+  }
+
+  if (isEmptyArray(value as any[]) || isObject(value) || isNaN(Number(value))) {
+    return false;
+  }
+
+  return Number(value).toString() !== `${value}`;
+}
+
 export function isNullOrUndefined(value: unknown): value is undefined | null {
   return value === null || value === undefined;
 }

--- a/tests/rules/max_value.js
+++ b/tests/rules/max_value.js
@@ -4,8 +4,10 @@ const valid = [0, '1', 10];
 
 const invalid = ['', 10.01, 11, [], undefined, null, {}, 'abc'];
 
+const bigInts = ['9223372036854775806', '922337203685477584513', 92233798596859775896n];
+
 test('validates number maximum value', () => {
-  expect.assertions(11);
+  expect.assertions(14);
   const max = 10;
 
   // valid.
@@ -13,10 +15,15 @@ test('validates number maximum value', () => {
 
   // invalid
   invalid.forEach(value => expect(validate(value, { max })).toBe(false));
+
+  // invalid big integers
+  bigInts.forEach(value => expect(validate(value, { max: BigInt(Number.MAX_SAFE_INTEGER + 1) })).toBe(false));
 });
 
 test('handles array of values', () => {
   expect(validate(valid, { max: 10 })).toBe(true);
 
   expect(validate(invalid, { max: 10 })).toBe(false);
+
+  expect(validate(bigInts, { max: 10 })).toBe(false);
 });

--- a/tests/rules/min_value.js
+++ b/tests/rules/min_value.js
@@ -4,8 +4,10 @@ const valid = [-1, 0, '5'];
 
 const invalid = ['', [], undefined, null, {}, 'abc', -2, '-3'];
 
+const bigInts = ['-9223372036854775806', '-922337203685477584513', -92233798596859775896n];
+
 test('validates number minimum value', () => {
-  expect.assertions(11);
+  expect.assertions(14);
   const min = -1;
 
   // valid
@@ -13,10 +15,15 @@ test('validates number minimum value', () => {
 
   // invalid
   invalid.forEach(value => expect(validate(value, { min })).toBe(false));
+
+  // invalid big integers
+  bigInts.forEach(value => expect(validate(value, { min: BigInt(Number.MIN_SAFE_INTEGER - 1) })).toBe(false));
 });
 
 test('handles array of values', () => {
   expect(validate(valid, { min: -1 })).toBe(true);
 
   expect(validate(invalid, { min: -1 })).toBe(false);
+
+  expect(validate(bigInts, { min: -1 })).toBe(false);
 });


### PR DESCRIPTION
🔎 __Overview__

Fix to safelly use long values for both `max_value` and `min_value` rules.

✔ __Issues affected__

> #2621
