### PR TITLE
Fix v2 docs link to fieldBag

### DIFF
--- a/docs/api/validator.md
+++ b/docs/api/validator.md
@@ -9,7 +9,7 @@ The validator offers an API to add new fields and trigger validations.
 |Name  | Type  | Description  |
 |---------|---------|---------|
 | errors | [`ErrorBag`](/api/errorbag.md)| Instance of the ErrorBag class to manage errors. |
-| fields     | [`FieldBag`](https://github.com/logaretm/vee-validate/blob/master/src/core/fieldBag.js)| Instance of the FieldBag class to manage fields. |
+| fields     | [`FieldBag`](https://github.com/logaretm/vee-validate/blob/v2/src/core/fieldBag.js)| Instance of the FieldBag class to manage fields. |
 | locale | `string` | The Currently activated locale. |
 
 ### Methods


### PR DESCRIPTION
Minor fix for the V2 documentation.

(Sigh... eventually I'll get to switch to V3!)

🔎 __Overview__

This PR corrects the link to v2's FieldBag.js in the V2 docs.

See [this page](http://vee-validate.logaretm.com/v2/api/validator.html#api) and click on `FieldBag` to observe the broken link.