### PR TITLE
Fix example in "Messages as Functions"

### DIFF
--- a/docs/guide/basics.md
+++ b/docs/guide/basics.md
@@ -417,7 +417,7 @@ extend('minmax', {
   },
   params: ['min', 'max'],
   message: (fieldName, placeholders) => {
-    return `The ${fieldName} field must have at least ${min} characters and ${max} characters at most`
+    return `The ${fieldName} field must have at least ${placeholders.min} characters and ${placeholders.max} characters at most`
   }
 });
 ```


### PR DESCRIPTION
The example in "Messages as Functions" results in the message "ReferenceError: min is not defined".

🔎 __Overview__

Explain the premise for adding this PR and why is it important.

Ex (Feat):
> This PR {adds/fixes/improves} the {feature/bug/something}.

Ex (Locale):
> This PR changes the {locale} messages style because {reason}

🤓 __Code snippets/examples (if applicable)__

```js
// some code
```

✔ __Issues affected__

list of issues formatted like this:

> closes #{issue id}
