### PR TITLE
Use field name in template for default error message

### DIFF
--- a/src/localize.ts
+++ b/src/localize.ts
@@ -1,6 +1,6 @@
 import { isCallable, merge, interpolate } from './utils';
 import { ValidationMessageTemplate } from './types';
-import { getConfig, setConfig } from './config';
+import { setConfig } from './config';
 import { localeChanged } from './localeChanged';
 
 interface PartialI18nDictionary {
@@ -33,7 +33,7 @@ class Dictionary {
     // find if specific message for that field was specified.
     message = this.container[locale]?.fields?.[field]?.[rule] || this.container[locale]?.messages?.[rule];
     if (!message) {
-      message = '{field} is not valid';
+      message = '{_field_} is not valid';
     }
 
     field = this.container[locale]?.names?.[field] ?? field;

--- a/tests/localize.spec.js
+++ b/tests/localize.spec.js
@@ -139,6 +139,34 @@ test('falls back to the default message if rule without message exists', async (
   expect(error.text()).toContain('{field} is not valid');
 });
 
+test('uses field name in the default message if rule without message exists', async () => {
+  extend('ruleWithoutMessage', () => false);
+
+  const wrapper = mount(
+    {
+      data: () => ({
+        value: '1'
+      }),
+      template: `
+        <div>
+          <ValidationProvider :immediate="true" rules="required|ruleWithoutMessage" v-slot="{ errors }">
+            <input name="MyFancyInputName" v-model="value" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </ValidationProvider>
+        </div>
+      `
+    },
+    { localVue: Vue, sync: false }
+  );
+
+  const error = wrapper.find('#error');
+
+  // flush the pending validation.
+  await flushPromises();
+
+  expect(error.text()).toContain('MyFancyInputName is not valid');
+});
+
 test('can define custom field names', async () => {
   localize('en', {
     names: {


### PR DESCRIPTION
🔎 __Overview__

This PR fixes the template of default error message. Uses `{_field_}` instead of "invalid" param `{field}` name 

✔ __Issues affected__

list of issues formatted like this:

> closes #2641 
