### PR TITLE
Update rules.md

### DIFF
--- a/docs/guide/rules.md
+++ b/docs/guide/rules.md
@@ -18,6 +18,12 @@ extend('required', {
   ...required,
   message: 'This field is required'
 });
+
+// include the field name in the message
+extend('required', {
+  ...required,
+  message: 'This {_field_} is required'
+});
 ```
 
 And then you can use those rules immediately:


### PR DESCRIPTION
A method to add the input field in the validation message

🔎 __Overview__

> Some times you may want to return the field name under validation. Example **The name field is required** instead of this field is required as in the current docs
