### PR TITLE
rule's name typo

### DIFF
--- a/docs/guide/rules.md
+++ b/docs/guide/rules.md
@@ -4,7 +4,7 @@ The following are the validation rules available for you, **remember that they a
 
 ## Importing The Rules
 
-Validation rules are available as an ES6 exports at `vee-validate/dist/rules`, if you are using an IDE or VSCode you should have a small peek on what rules are available when you are importing them, here is how to import some common rules like `required` and `min`.
+Validation rules are available as an ES6 exports at `vee-validate/dist/rules`, if you are using an IDE or VSCode you should have a small peek on what rules are available when you are importing them, here is how to import some common rules like `required` and `email`.
 
 ```js
 import { extend } from 'vee-validate';


### PR DESCRIPTION
here is how to import some common rules like `required` and `min` should be here is how to import some common rules like `required` and `email`

🔎 __Overview__

this PR correct a typo in the rule name been imported in de code sample, in code you're importing required and email, but in the previous paragraph you're saying that the rules beeing imported are required and min rules 
