### PR TITLE
Fix typo in "Testing Caveats" doc

### DIFF
--- a/docs/advanced/testing.md
+++ b/docs/advanced/testing.md
@@ -13,7 +13,7 @@ transform: {
   'vee-validate/dist/rules': 'babel-jest',
 },
 transformIgnorePatterns: [
-  '<roodDir>/node_modules/(?!vee-validate/dist/rules)',
+  '<rootDir>/node_modules/(?!vee-validate/dist/rules)',
 ],
 ```
 


### PR DESCRIPTION
🔎 __Overview__

Looks like there was a typo here, and I don't think the directory appreciates being called "rood" :) 

I looked around at docs for a while and tried to make sure that `roodDir` isn't actually a thing, and it does look like it was just a simple typo. Let me know if I missed something here