### PR TITLE
Default with field translation?

### DIFF
--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -206,7 +206,10 @@ import { configure } from 'vee-validate';
 
 configure({
   // this will be used to generate messages.
-  defaultMessage: (_, values) => i18n.t(`validations.${values._rule_}`, values)
+  defaultMessage: (field, values) => {
+    values._field_ = i18n.t(`fields.${field}`);
+    return i18n.t(`validations.${values._rule_}`, values);
+  }
 });
 ```
 


### PR DESCRIPTION
I stumbled above this origin example and used it with vue-i18n plugin. I was wondering why the localization worked almost, but the field didn't get translated. In the other sandbox for LingUI i found what i was looking for and added this line to the defaultMessage function for the fields translation. It think i would help others.

🔎 __Overview__

Explain the premise for adding this PR and why is it important.

Ex (Feat):
> This PR improves the documentation.

🤓 __Code snippets/examples (if applicable)__
Changed this: 
```js
configure({
  // this will be used to generate messages.
  defaultMessage: (_, values) => i18n.t(`validations.${values._rule_}`, values)
});
```
to this
```js
configure({
  // this will be used to generate messages.
  defaultMessage: (field, values) => {
    values._field_ = i18n.t(`fields.${field}`);
    return i18n.t(`validations.${values._rule_}`, values);
  }
});
```

✔ __Issues affected__

list of issues formatted like this:

> closes #{issue id}
