### PR TITLE
Doc: Use tip instead of hint?

### DIFF
--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -30,7 +30,7 @@ For example: setting the `touched` and `dirty` flags to `false` and clearing all
 
 @[example](form-reset)
 
-:::hint
+:::tip
 The ValidationObserver `reset` method does not reset the values of the child fields, this is up to you.
 :::
 
@@ -43,12 +43,12 @@ Here is an example that handles validation before submit and then resetting usin
 
 @[example](form-refs)
 
-:::hint
+:::tip
 Using `refs` gives you full access to the `ValidationObserver` component API, but it is recommended that you only use the documented API as any of the internals are subject to change.
 See the [ValidationObserver Public API](../api/validation-observer.md).
 :::
 
-:::hint TypeScript
+:::tip TypeScript
 
 When using `$refs` with TypeScript, you have to provide the typings for the `ValidationObserver` or `ValidationProvider` instances which can be done using `InstanceType` utility type. Use it like the following snippet:
 
@@ -96,7 +96,7 @@ Here is an example that employs `keep-alive` to keep `ValidationProvider` state 
 
 @[example](persist-provider)
 
-:::hint
+:::tip
 Even when fields are hidden/unmounted, as long as they wrapped with `keep-alive` their state will also be affected by `validate` and `reset` calls.
 :::
 

--- a/docs/guide/forms.md
+++ b/docs/guide/forms.md
@@ -52,6 +52,8 @@ See the [ValidationObserver Public API](../api/validation-observer.md).
 
 When using `$refs` with TypeScript, you have to provide the typings for the `ValidationObserver` or `ValidationProvider` instances which can be done using `InstanceType` utility type. Use it like the following snippet:
 
+:::
+
 ```ts
 import { ValidationObserver } from 'vee-validate';
 
@@ -66,7 +68,6 @@ export default class App extends Vue {
 }
 ```
 
-:::
 
 ## Initial State Validation
 


### PR DESCRIPTION
Does `hint` actually exist? Either way, it's broken currently. It also seems like this was supposed to be a tip.

![image](https://user-images.githubusercontent.com/6721822/77689143-22780280-6fdc-11ea-9643-d11a29467a8b.png)

Relevant page link:
https://logaretm.github.io/vee-validate/guide/forms.html#resetting-forms