### PR TITLE
fix: limit v-model nodes to only one node

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -92,7 +92,7 @@ module.exports = {
         children: [
           '/advanced/rules-object-expression',
           '/advanced/cross-field-validation',
-          '/advanced/file-validation.md',
+          '/advanced/model-less-validation.md',
           '/advanced/dynamic-rules',
           '/advanced/refactoring-forms',
           '/advanced/server-side-validation',

--- a/docs/advanced/model-less-validation.md
+++ b/docs/advanced/model-less-validation.md
@@ -1,6 +1,6 @@
-# File Validation
+# Model-less Validation
 
-While the `ValidationProvider` requires having `v-model` on your input elements, that does not mean that inputs like `file` inputs cannot be validated.
+The `ValidationProvider` requires having `v-model` on your input elements. However, that does not mean that inputs like `file` inputs cannot be validated.
 
 :::tip
 While the `file` input is the most common field not to use a `v-model`.This guide applies to any type of input, not just the `file` type.

--- a/docs/guide/basics.md
+++ b/docs/guide/basics.md
@@ -51,7 +51,7 @@ After that you can use it in your components templates, typically you **wrap you
 </ValidationProvider>
 ```
 
-For the `input` field or the component acting as an input, it is **recommended to have a `v-model` attached to it**. This is because the `ValidationProvider` searches its own children for inputs, so the <code>v&#8209;model</code> acts as a hint for the `ValidationProvider`.
+For the `input` field or the component acting as an input, it **should have a `v-model` attached to it**. This is because the `ValidationProvider` searches its own children for inputs, so the `v-model` acts as a hint for the `ValidationProvider`.
 
 However, if you do not want to use `v-model` the input needs to have set binding to `value` prop, which in this case serves as a hint for the `ValidationProvider`.
 
@@ -147,7 +147,7 @@ Notice that the `|` pipe character separates the rules, this is inspired by Lara
 The string you sent to the `rules` prop is called a **string expression**.
 
 :::tip
-  There is another advanced expression that you can express your rules with. See [Rules Object Expression](../advanced/rules-object-expression.md).
+There is another advanced expression that you can express your rules with. See [Rules Object Expression](../advanced/rules-object-expression.md).
 :::
 
 The last snippet used a function as the validation rule, there is a more **extended form of rules** that uses objects to include more metadata. The last snippet can also be re-written as:
@@ -238,10 +238,7 @@ extend('minmax', {
 To use this rule, you pass the `minmax` rule to the `rules` prop of the `ValidationProvider` and you supply the arguments as a **comma separated list**:
 
 ```vue{2}
-<ValidationProvider
-  rules="minmax:3,8"
-  v-slot="{ errors }"
->
+<ValidationProvider rules="minmax:3,8" v-slot="{ errors }">
   <input v-model="value" type="text">
   <span>{{ errors[0] }}</span>
 </ValidationProvider>
@@ -250,7 +247,7 @@ To use this rule, you pass the `minmax` rule to the `rules` prop of the `Validat
 Now the field will be valid when the value is a string having a length between 3 and 8.
 
 :::tip
-  Arguments **must follow** the same order they were defined in as in the `params` array.
+Arguments **must follow** the same order they were defined in as in the `params` array.
 :::
 
 ### Infinite Arguments
@@ -338,11 +335,7 @@ extend('positive', value => {
 To display the field name, you set the `name` prop on the validation provider:
 
 ```vue{2}
-<ValidationProvider
-  name="age"
-  rules="positive"
-  v-slot="{ errors }"
->
+<ValidationProvider name="age" rules="positive" v-slot="{ errors }">
   <input v-model="value" type="text">
   <span>{{ errors[0] }}</span>
 </ValidationProvider>
@@ -353,10 +346,7 @@ Additionally, the field name can be automatically picked up from `name` or `id` 
 Here since a `name` prop is not set, vee-validate uses the `name` attribute on the input tag as a field name.
 
 ```vue{5}
-<ValidationProvider
-  rules="positive"
-  v-slot="{ errors }"
->
+<ValidationProvider rules="positive" v-slot="{ errors }">
   <input v-model="value" name="age" type="text">
   <span>{{ errors[0] }}</span>
 </ValidationProvider>
@@ -365,10 +355,7 @@ Here since a `name` prop is not set, vee-validate uses the `name` attribute on t
 Here since a `name` prop is not set nor a `name` attribute on the input, vee-validate uses the `id` attribute on the input tag as a field name.
 
 ```vue{5}
-<ValidationProvider
-  rules="positive"
-  v-slot="{ errors }"
->
+<ValidationProvider rules="positive" v-slot="{ errors }">
   <input v-model="value" id="age" type="text">
   <span>{{ errors[0] }}</span>
 </ValidationProvider>
@@ -417,7 +404,7 @@ extend('minmax', {
   },
   params: ['min', 'max'],
   message: (fieldName, placeholders) => {
-    return `The ${fieldName} field must have at least ${placeholders.min} characters and ${placeholders.max} characters at most`
+    return `The ${fieldName} field must have at least ${placeholders.min} characters and ${placeholders.max} characters at most`;
   }
 });
 ```
@@ -426,8 +413,8 @@ This allows you to manually interpolate or generate messages depending on your n
 
 For reference these are the contents of the `placeholders` object:
 
-| Prop      |Description                                 |
-|-----------|--------------------------------------------|
+| Prop      | Description                                |
+| --------- | ------------------------------------------ |
 | `_field_` | The field name.                            |
 | `_value_` | The field value that was validated.        |
 | `_rule_`  | The rule name that triggered this message. |
@@ -443,11 +430,7 @@ You could then be wondering why `errors` is an array when vee-validate only gene
 You could configure the `ValidationProvider` component to run all the rules by setting the `bails` prop to `false`:
 
 ```vue{3}
-<ValidationProvider
-  rules="positive|odd|prime|fib"
-  :bails="false"
-  v-slot="{ errors }"
->
+<ValidationProvider rules="positive|odd|prime|fib" :bails="false" v-slot="{ errors }">
   <input v-model="value" type="text">
   <ul>
     <li v-for="error in errors">{{ error }}</li>

--- a/docs/guide/basics.md
+++ b/docs/guide/basics.md
@@ -53,13 +53,17 @@ After that you can use it in your components templates, typically you **wrap you
 
 For the `input` field or the component acting as an input, it **should have a `v-model` attached to it**. This is because the `ValidationProvider` searches its own children for inputs, so the `v-model` acts as a hint for the `ValidationProvider`.
 
-However, if you do not want to use `v-model` the input needs to have set binding to `value` prop, which in this case serves as a hint for the `ValidationProvider`.
+However, if you cannot use `v-model` on the input, then you also could set binding to `value` prop, which in this case serves as a hint for the `ValidationProvider`.
 
 ```vue
 <ValidationProvider v-slot="v">
   <input :value="value" @change="onInputChanged" type="text">
 </ValidationProvider>
 ```
+
+:::warning
+If you cannot use neither `v-model` or a `value` binding on your inputs, you can still validate your fields. For example a `file` type input usually doesn't use `v-mode`. To validate such fields, visit the [model-less validation guide](../advanced/model-less-validation.md).
+:::
 
 If you are using a CDN with vee-validate you may have to use the `kebab` case as HTML is case insensitive, so you need to reference the `ValidationProvider` as `validation-provider`.
 

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -164,7 +164,7 @@ function loadLocale(code) {
 }
 ```
 
-:::warn `defaultMessage` Config
+:::warning `defaultMessage` Config
 Avoid setting the `defaultMessage` config after using `localize` as it will conflict with the internal working of the basic dictionary.
 :::
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,7 +4,15 @@ sidebarDepth: 1
 
 # Migration Guide
 
-This document should help you navigate the tricky path of migrating between major versions of `vee-validate` that introduced breaking changes:
+This document should help you navigate the tricky path of migrating between different versions of `vee-validate` that introduced breaking changes:
+
+## Migrating from 3.2.x to 3.3.0
+
+Only 1 minor change was introduced which could be breaking to some edge cases.
+
+### `v-model` detection limited to 1 Node
+
+Starting from 3.3.0, the `ValidationProvider` will only look for exactly 1 node with the `v-model` attached to it. This shouldn't affect you as usually you had 1:1 input to `ValidationProvider` relation, but in some cases when you have more complex template inside the `ValidationProvider`, you should make sure your input that will be validated will come first in the tree.
 
 ## Migrating from 3.0.x to 3.1.0
 

--- a/src/components/Provider.ts
+++ b/src/components/Provider.ts
@@ -2,7 +2,7 @@ import Vue, { CreateElement, VNode, VueConstructor } from 'vue';
 import { normalizeRules, extractLocators } from '../utils/rules';
 import { normalizeEventValue } from '../utils/events';
 import { findInputNode, normalizeChildren, resolveRules, isHTMLNode } from '../utils/vnode';
-import { isCallable, isEqual, isNullOrUndefined, createFlags, warn } from '../utils';
+import { isCallable, isEqual, isNullOrUndefined, createFlags } from '../utils';
 import { getConfig, ValidationClassMap } from '../config';
 import { validate } from '../validate';
 import { RuleContainer } from '../extend';

--- a/src/utils/vnode.ts
+++ b/src/utils/vnode.ts
@@ -82,21 +82,19 @@ function extractChildren(vnode: VNode | VNode[]): VNode[] {
   return [];
 }
 
-export function extractVNodes(vnode: VNode | VNode[]): VNode[] {
+export function findInputNode(vnode: VNode | VNode[]): VNode | null {
   if (!Array.isArray(vnode) && findValue(vnode) !== undefined) {
-    return [vnode];
+    return vnode;
   }
 
   const children = extractChildren(vnode);
-
-  return children.reduce((nodes: VNode[], node): VNode[] => {
-    const candidates = extractVNodes(node);
-    if (candidates.length) {
-      nodes.push(...candidates);
+  return children.reduce((candidate: VNode | null, node): VNode | null => {
+    if (candidate) {
+      return candidate;
     }
 
-    return nodes;
-  }, []);
+    return findInputNode(node);
+  }, null);
 }
 
 // Resolves v-model config if exists.


### PR DESCRIPTION
### Overview

This PR adds a limit to the `ValidationProvider` tree traversal to only one input `VNode` which solves infinite loop issues where multiple providers could exist within one another and other possible edge cases with multiple `v-models`.

Overall this improves performance as well since the traversal doesn't navigate the entire tree but should be minimal as it's unlikely that large trees would exist in `ValidationProvider` slot.

### 💀 Breaking Changes

This would make `Radio` inputs harder to validate as they will no longer be treated as the same input, the recommended workaround is to wrap radio inputs in a `RadioGroup` component. I will investigate better workarounds in the future.

closes #2638
closes #2470