### PR TITLE
add note to docs that localizing does not work when using the full bu…

### DIFF
--- a/docs/guide/rules.md
+++ b/docs/guide/rules.md
@@ -68,7 +68,7 @@ Object.keys(rules).forEach(rule => {
 
 ### Full Bundle
 
-Another way of doing that is to import vee-validate's full bundle instead of the default one, which comes pre-installed with all the validation rules and their English messages.
+Another way of doing that is to import vee-validate's full bundle instead of the default one, which comes pre-installed with all the validation rules and their English messages. Note that localizing messages will not work when using the full bundle.
 
 ```js
 import { ValidationProvider } from 'vee-validate/dist/vee-validate.full.esm';


### PR DESCRIPTION
🔎 __Overview__

Small documentation update.

I wasted a few hours today trying to get localization to work, only to realize that we where using the full bundle `vee-validate.full.esm`, which seems to ignore all ways to alter the localization messages.

So this PR adds a short note about this.

If it **is** possible to use the bundle and still customize messages, I'd appreciate an hint on how to do this.

Greetings, and thanks for your work,
domm