### PR TITLE
docs: remove duplicated isSubmitting option

### DIFF
--- a/packages/docs/content/api/form.md
+++ b/packages/docs/content/api/form.md
@@ -115,7 +115,6 @@ The default slot gives you access to the following props:
 | meta         | `Record<string, boolean>`    | An aggregate of the [FieldMeta](./api/field#fieldmeta) for the fields within the form                                     |
 | values       | `Record<string, any>`        | The current field values                                                                                                  |
 | isSubmitting | `boolean`                    | True while the submission handler for the form is being executed                                                          |
-| isSubmitting | `boolean`                    | True while the submission handler for the form is being executed                                                          |
 | validate     | `Function`                   | Validates the form                                                                                                        |
 | handleSubmit | `(cb: Function) => Function` | Creates a submission handler that disables the native form submissions and executes the callback if the validation passes |
 | handleReset  | `Function`                   | Resets and form and executes any `onReset` listeners on the component                                                     |


### PR DESCRIPTION
🔎 __Overview__

A tiny fix in the Form docs.