### PR TITLE
docs(testing): removed sync mode from vueTestUtils

### DIFF
--- a/docs/advanced/testing.md
+++ b/docs/advanced/testing.md
@@ -25,17 +25,12 @@ transformIgnorePatterns: [
 The following examples will use vue-test-utils API to conduct the tests.
 :::
 
-VeeValidate is primarily asynchronous, so you would need to disable vue-test-utils sync mode. And you will use flush-promises to wait for the updated to take effect.
-
-To disable the sync mode, when mounting the component set the sync option to false in the mounting options.
-
-```js
-const wrapper = mount(MyComponent, { sync: false });
-```
 
 After triggering an event like an input event, make sure to call flushPromises before checking the UI for changes:
 
 ```js
+import flushPromises from 'flush-promises'
+
 await flushPromises();
 ```
 


### PR DESCRIPTION
This PR imporoves the doc, especially the testing part. I removed sync mode from vueTestUtils, since [it has been removed](https://github.com/vuejs/vue-test-utils/issues/1137).
I also add the import of flushPromises(). It took quite some time to find out that it was an external package.

The only way I got my tests working is by adding `beforeEach(() => jest.useFakeTimers())` at the top of my tests. `jest.useFakeTimers()` was not sufficient. But I think it's more related to Jest, or my misknowledge of Jest, so I didn't change this part. But I'm willing to if you think it's worth.
