### PR TITLE
docs: fix titles

### DIFF
--- a/packages/docs/content/api/error-message.md
+++ b/packages/docs/content/api/error-message.md
@@ -1,7 +1,7 @@
 ---
 title: ErrorMessage
 description: API reference for the ErrorMessage component
-menuTitle: 'ErrorMessage />'
+menuTitle: '<ErrorMessage />'
 ---
 
 # ErrorMessage

--- a/packages/docs/content/api/form.md
+++ b/packages/docs/content/api/form.md
@@ -1,7 +1,7 @@
 ---
 title: Form
 description: API reference for the Form component
-menuTitle: '<Field />'
+menuTitle: '<Form />'
 ---
 
 # Form


### PR DESCRIPTION
🔎 __Overview__

The `Form` and `ErrorMessage` components docs currently contain typos in their titles.
