### PR TITLE
docs: Update Parameter for VueI18n Translation Function Parameter

### DIFF
--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -187,8 +187,10 @@ import validationMessages from 'vee-validate/dist/locale/en';
 // you can merge them if needed.
 const i18n = new VueI18n({
   locale: 'en',
-  en: {
-    validations: validationMessages
+  messages: {
+    en: {
+      validations: validationMessages
+    }
   }
 });
 

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -195,7 +195,7 @@ const i18n = new VueI18n({
 extend('required', {
   ...required,
   // the values param is the placeholders values
-  message: (_, values) => i18n.$t('validations.required', values)
+  message: (_, values) => i18n.$t('validations.messages.required', values)
 });
 ```
 
@@ -208,7 +208,7 @@ configure({
   // this will be used to generate messages.
   defaultMessage: (field, values) => {
     values._field_ = i18n.t(`fields.${field}`);
-    return i18n.t(`validations.${values._rule_}`, values);
+    return i18n.t(`validations.messages.${values._rule_}`, values);
   }
 });
 ```


### PR DESCRIPTION
🔎  __Overview__

## Background

Since the structure of `locale/<anything>.json` is

```json
{
  "code":  "en",
  "messages": {
    "required": "The {_field_} field is required"
  }
}
```

and on the example we instantiate VueI18n this way

```javascript
const i18n = new VueI18n({
  locale: 'en',
  en: {
    validations: validationMessages
  }
});
```

I think the correct parameter for translation function is `$t('validations.messages.required', values)`

✔ __Issues affected__

Nothing
