### PR TITLE
added is_not translation

### DIFF
--- a/locale/pt_PT.js
+++ b/locale/pt_PT.js
@@ -22,6 +22,7 @@ const messages = {
   included: (field) => `O campo ${field} deve ter um valor válido`,
   ip: (field) => `O campo ${field} deve ser um endereço IP válido`,
   is: (field) => `O valor inserido no campo ${field} não é válido`,
+  is_not: (field) => `O valor inserido no campo ${field} não é válido`,
   max: (field, [length]) => `O campo ${field} não deve ter mais que ${length} caracteres`,
   max_value: (field, [max]) => `O campo ${field} precisa ser ${max} ou menor`,
   mimes: (field) => `O campo ${field} deve ser um tipo de ficheiro válido`,


### PR DESCRIPTION
🔎 __Overview__

The "is_not" translation was missing. I added it to the list and kept the same translation as the "is".

✔ __Issues affected__

list of issues formatted like this:

none available
