### PR TITLE
fix: unicode characters not counted correctly in length rule

### DIFF
--- a/src/rules/length.ts
+++ b/src/rules/length.ts
@@ -10,6 +10,10 @@ const validate = (value: string | number | string[], { length }: Record<string, 
     value = String(value);
   }
 
+  if (typeof value === 'string') {
+    value = Array.from(value);
+  }
+
   if (!value.length) {
     value = toArray(value);
   }

--- a/tests/modes.spec.js
+++ b/tests/modes.spec.js
@@ -13,6 +13,9 @@ beforeEach(() => {
 });
 
 test('aggressive mode', async () => {
+  const div = document.createElement('div');
+  div.id = 'root';
+  document.body.appendChild(div);
   const wrapper = mount(
     {
       data: () => ({
@@ -33,7 +36,7 @@ test('aggressive mode', async () => {
         </div>
       `
     },
-    { localVue: Vue, sync: false, attachToDocument: true }
+    { localVue: Vue, sync: false, attachTo: '#root' }
   );
   const error = wrapper.find('#error');
   const input = wrapper.find('input');

--- a/tests/providers/provider.js
+++ b/tests/providers/provider.js
@@ -4,6 +4,7 @@ import { ValidationProvider, ValidationObserver, extend, withValidation, configu
 import InputWithoutValidation from './components/Input';
 import InputWithSlot from './components/InputWithSlot';
 import ModelComp from './../helpers/ModelComp';
+import { template } from '@babel/core';
 
 const Vue = createLocalVue();
 Vue.component('ValidationProvider', ValidationProvider);
@@ -324,6 +325,9 @@ test('validates on rule change: testing NaN', async () => {
 });
 
 test('validates components on input by default', async () => {
+  const div = document.createElement('div');
+  div.id = 'root';
+  document.body.appendChild(div);
   const wrapper = mount(
     {
       data: () => ({
@@ -340,7 +344,7 @@ test('validates components on input by default', async () => {
         }
       },
       template: `
-        <div>
+        <div id="root">
           <ValidationProvider rules="required" v-slot="{ errors }">
             <TextInput v-model="value" ref="input"></TextInput>
             <span id="error">{{ errors && errors[0] }}</span>
@@ -348,7 +352,7 @@ test('validates components on input by default', async () => {
         </div>
       `
     },
-    { localVue: Vue, sync: false, attachToDocument: true }
+    { localVue: Vue, sync: false, attachTo: '#root' }
   );
 
   const error = wrapper.find('#error');
@@ -385,7 +389,7 @@ test('validates components on configured model event', async () => {
         <div>
           <ValidationProvider rules="required" v-slot="{ errors }">
             <TextInput v-model="value" ref="input"></TextInput>
-            <span id="error">{{ errors[0] }}</span>
+            <span ref="error">{{ errors[0] }}</span>
           </ValidationProvider>
         </div>
       `
@@ -393,8 +397,8 @@ test('validates components on configured model event', async () => {
     { localVue: Vue, sync: false }
   );
 
-  const error = wrapper.find('#error');
-  const input = wrapper.find({ ref: 'input' });
+  const error = wrapper.findComponent({ ref: 'error' });
+  const input = wrapper.findComponent({ ref: 'input' });
 
   expect(error.text()).toBe('');
   input.vm.$emit('change', '');
@@ -503,8 +507,8 @@ test('validates file input', async () => {
         file: null
       }),
       template: `
-        <ValidationProvider rules="required|image" v-slot="{ errors }">
-          <input type="file" v-model="file">
+        <ValidationProvider rules="required|image" v-slot="{ errors, validate }">
+          <input type="file"  @change="validate">
           <p id="error">{{ errors[0] }}</p>
         </ValidationProvider>
       `
@@ -597,6 +601,9 @@ test('created HOCs preserves their slots', async () => {
 });
 
 test('resets validation state', async () => {
+  const div = document.createElement('div');
+  div.id = 'root';
+  document.body.appendChild(div);
   const wrapper = mount(
     {
       data: () => ({
@@ -622,7 +629,7 @@ test('resets validation state', async () => {
         </div>
       `
     },
-    { localVue: Vue, sync: false, attachToDocument: true }
+    { localVue: Vue, sync: false, attachTo: '#root' }
   );
 
   const error = wrapper.find('#error');
@@ -771,6 +778,7 @@ test('reset ignores pending validation result', async () => {
   await sleep(40);
   await flushPromises();
   wrapper.vm.$refs.provider.reset();
+  await flushPromises();
   expect(error.text()).toBe('');
   await sleep(10);
   await flushPromises();

--- a/tests/rules/length.js
+++ b/tests/rules/length.js
@@ -27,3 +27,8 @@ test('validates number of elements in an array', () => {
 test('validates strings consisting of numbers', () => {
   expect(validate(123, { length: 3 })).toBe(true);
 });
+
+test('validates strings with multibyte unicode chars', () => {
+  expect(validate('😹🐶😹🐶', { length: 4 })).toBe(true);
+  expect(validate('😹🐶😹🐶', { length: 3 })).toBe(false);
+});


### PR DESCRIPTION
🔎 __Overview__

Explain the premise for adding this PR and why is it important.

This PR counts the length of strings as chars not as bytes.
Some unrelated tests failed. I tried to fix them also.

🤓 __Code snippets/examples (if applicable)__

```js
'𥑮'.length === 2  // true 👎 
Array.from('𥑮').lengts === 1 // true 👍 
```

✔ __Issues affected__

list of issues formatted like this:

> closes # {2876}
