### PR TITLE
Fix issue with Form and Field as radio

### DIFF
--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -97,8 +97,7 @@ export function useForm(opts?: FormOptions) {
       if (valueIdx === -1) {
         return;
       }
-
-      _values[fieldName].splice(valueIdx, 1);
+      delete _values[fieldName]
     },
     fields: fieldsById,
     values: _values,


### PR DESCRIPTION
_values is not an array but object.

change line _values[fieldName].splice(valueIdx, 1); 
into delete _values[fieldName] in unRegister function

🔎 __Overview__
When submitting a Form with a Field as radio the following error occus:
`
Uncaught (in promise) TypeError: _values[fieldName].splice is not a function at Object.unregister (vee-validate.esm.js:777) at vee-validate.esm.js:421 at callWithErrorHandling (vue.js:1257) at callWithAsyncErrorHandling (vue.js:1266) at Array.hook.__weh.hook.__weh (vue.js:3451) at invokeArrayFns (vue.js:263) at unmountComponent (vue.js:5884) at unmount (vue.js:5798) at unmountChildren (vue.js:5930) at unmount (vue.js:5813)
`

Fixes #2883

