### PR TITLE
Fix issue with Form and Field as radio

### DIFF
--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -97,8 +97,7 @@ export function useForm(opts?: FormOptions) {
       if (valueIdx === -1) {
         return;
       }
-
-      _values[fieldName].splice(valueIdx, 1);
+      delete _values[fieldName]
     },
     fields: fieldsById,
     values: _values,

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -97,11 +97,12 @@ export function useForm(opts?: FormOptions) {
       if (valueIdx === -1) {
         return;
       }
+            
       if (Array.isArray(_values[fieldName])) {
         _values[fieldName].splice(valueIdx, 1);
-      } else {
-        delete _values[fieldName];
+        return;
       }
+      delete _values[fieldName];
     },
     fields: fieldsById,
     values: _values,

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -97,7 +97,11 @@ export function useForm(opts?: FormOptions) {
       if (valueIdx === -1) {
         return;
       }
-      delete _values[fieldName]
+      if (Array.isArray(_values[fieldName])) {
+        _values[fieldName].splice(valueIdx, 1);
+      } else {
+        delete _values[fieldName];
+      }
     },
     fields: fieldsById,
     values: _values,

--- a/packages/core/tests/Form.spec.ts
+++ b/packages/core/tests/Form.spec.ts
@@ -418,6 +418,56 @@ describe('<Form />', () => {
     await flushPromises();
     expect(err.textContent).toBe('');
   });
+  
+  test('supports radio inputs with check after submit', async () => {
+    console.log('radios');
+    const initialValues = { test: 'one' };
+
+    const showFields = ref(true);
+    const result = ref();
+
+    const wrapper = mountWithHoc({
+      setup() {
+        const values = ['one', 'two', 'three'];
+        const onSubmit = (formData: Record<string, any>) => {
+          result.value = formData.test;
+        };
+
+        return {
+          values,
+          onSubmit,
+          initialValues,
+          showFields,
+          result,
+        };
+      },
+      template: ` 
+      <VForm  @submit="onSubmit"  >
+      
+      <label v-for="(value, index) in values" v-bind:key="index">
+              <div v-if="showFields">
+
+        <Field name="test" as="input" type="radio" :value="value" /> {{value}}
+        </div>
+              </label>
+    
+        <button>Submit</button>
+        <div>{{$result}}</div>
+      </VForm>
+    `,
+    });
+
+    // const err = wrapper.$el.querySelector('#err');
+    const inputs = wrapper.$el.querySelectorAll('input');
+
+    setChecked(inputs[1]);
+    await flushPromises();
+    wrapper.$el.querySelector('button').click();
+    await flushPromises();
+    showFields.value = false;
+    await flushPromises();
+    expect(result.value).toBe('two');
+  });
 
   test('supports checkboxes inputs', async () => {
     const wrapper = mountWithHoc({


### PR DESCRIPTION
_values is not an array but object.

change line _values[fieldName].splice(valueIdx, 1);
into delete _values[fieldName] in unRegister function

🔎 Overview
When submitting a Form with a Field as radio the following error occus:
Uncaught (in promise) TypeError: _values[fieldName].splice is not a function at Object.unregister (vee-validate.esm.js:777) at vee-validate.esm.js:421 at callWithErrorHandling (vue.js:1257) at callWithAsyncErrorHandling (vue.js:1266) at Array.hook.__weh.hook.__weh (vue.js:3451) at invokeArrayFns (vue.js:263) at unmountComponent (vue.js:5884) at unmount (vue.js:5798) at unmountChildren (vue.js:5930) at unmount (vue.js:5813)

fixes #2883