### PR TITLE
feat: nested objects/arrays

### DIFF
--- a/packages/core/src/Form.ts
+++ b/packages/core/src/Form.ts
@@ -38,7 +38,7 @@ export const Form = defineComponent({
       const children = normalizeChildren(ctx, {
         meta: meta.value,
         errors: errors.value,
-        values: values.value,
+        values: values,
         isSubmitting: isSubmitting.value,
         validate,
         handleSubmit,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -29,6 +29,14 @@ export interface ValidationFlags {
   changed: boolean;
 }
 
+export type MaybeReactive<T> = Ref<T> | ComputedRef<T> | T;
+
+export type SubmitEvent = Event & { target: HTMLFormElement };
+
+export type SubmissionHandler = (values: Record<string, any>, evt?: SubmitEvent) => any;
+
+export type GenericValidateFunction = (value: any) => boolean | string | Promise<boolean | string>;
+
 export type Flag =
   | 'untouched'
   | 'touched'
@@ -51,11 +59,3 @@ export interface FormController {
   validateSchema?: (shouldMutate?: boolean) => Promise<Record<string, ValidationResult>>;
   setFieldValue: (path: string, value: any) => void;
 }
-
-export type MaybeReactive<T> = Ref<T> | ComputedRef<T> | T;
-
-export type SubmitEvent = Event & { target: HTMLFormElement };
-
-export type SubmissionHandler = (values: Record<string, any>, evt?: SubmitEvent) => any;
-
-export type GenericValidateFunction = (value: any) => boolean | string | Promise<boolean | string>;

--- a/packages/core/src/useField.ts
+++ b/packages/core/src/useField.ts
@@ -36,7 +36,13 @@ type RuleExpression = MaybeReactive<string | Record<string, any> | GenericValida
  */
 export function useField(fieldName: MaybeReactive<string>, rules: RuleExpression, opts?: Partial<FieldOptions>) {
   const { initialValue, form, immediate, bails, disabled, type, valueProp } = normalizeOptions(opts);
-  const { meta, errors, onBlur, handleChange, reset, patch, value } = useValidationState(fieldName, initialValue, form);
+  const { meta, errors, onBlur, handleChange, reset, patch, value, checked } = useValidationState({
+    fieldName,
+    initValue: initialValue,
+    form,
+    type,
+    valueProp,
+  });
 
   const nonYupSchemaRules = extractRuleFromSchema(form?.schema, unwrap(fieldName));
   const normalizedRules = computed(() => {
@@ -82,16 +88,6 @@ export function useField(fieldName: MaybeReactive<string>, rules: RuleExpression
   });
 
   const aria = useAriAttrs(fieldName, meta);
-
-  const checked = hasCheckedAttr(type)
-    ? computed(() => {
-        if (Array.isArray(value.value)) {
-          return value.value.includes(unwrap(valueProp));
-        }
-
-        return unwrap(valueProp) === value.value;
-      })
-    : undefined;
 
   const field = {
     name: fieldName,
@@ -198,11 +194,38 @@ function normalizeOptions(opts: Partial<FieldOptions> | undefined): FieldOptions
 /**
  * Manages the validation state of a field.
  */
-function useValidationState(fieldName: MaybeReactive<string>, initValue: any, form?: FormController) {
+function useValidationState({
+  fieldName,
+  initValue,
+  form,
+  type,
+  valueProp,
+}: {
+  fieldName: MaybeReactive<string>;
+  initValue?: any;
+  form?: FormController;
+  type?: string;
+  valueProp: any;
+}) {
   const errors: Ref<string[]> = ref([]);
   const { onBlur, reset: resetFlags, meta } = useMeta();
-  const initialValue = initValue;
+  const initialValue = initValue ?? getFromPath(inject('$_veeFormInitValues', {}), unwrap(fieldName));
   const value = useFieldValue(initialValue, fieldName, form);
+
+  const checked = hasCheckedAttr(type)
+    ? computed(() => {
+        if (Array.isArray(value.value)) {
+          return value.value.includes(unwrap(valueProp));
+        }
+
+        return unwrap(valueProp) === value.value;
+      })
+    : undefined;
+
+  if (checked === undefined || checked.value) {
+    // Set the value without triggering the watcher
+    value.value = initialValue;
+  }
 
   // Common input/change event handler
   const handleChange = (e: Event) => {
@@ -236,6 +259,7 @@ function useValidationState(fieldName: MaybeReactive<string>, initValue: any, fo
     onBlur,
     handleChange,
     value,
+    checked,
   };
 }
 
@@ -333,11 +357,6 @@ function useFieldValue(initialValue: any, path: MaybeReactive<string>, form?: Fo
       form.setFieldValue(unwrap(path), newVal);
     },
   });
-
-  // Set the value without triggering the setter
-  if (initialValue !== undefined) {
-    value.value = initialValue;
-  }
 
   return value;
 }

--- a/packages/core/src/useField.ts
+++ b/packages/core/src/useField.ts
@@ -8,7 +8,15 @@ import {
   Flag,
   ValidationFlags,
 } from './types';
-import { normalizeRules, extractLocators, normalizeEventValue, unwrap, genFieldErrorId, hasCheckedAttr } from './utils';
+import {
+  normalizeRules,
+  extractLocators,
+  normalizeEventValue,
+  unwrap,
+  genFieldErrorId,
+  hasCheckedAttr,
+  getFromPath,
+} from './utils';
 import { isCallable } from '../../shared';
 
 interface FieldOptions {
@@ -319,7 +327,7 @@ function useFieldValue(initialValue: any, path: MaybeReactive<string>, form?: Fo
   // otherwise use a computed setter that triggers the `setFieldValue`
   const value = computed({
     get() {
-      return form.values[unwrap(path)];
+      return getFromPath(form.values, unwrap(path));
     },
     set(newVal) {
       form.setFieldValue(unwrap(path), newVal);

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -10,7 +10,7 @@ import {
   ValidationResult,
 } from './types';
 import { unwrap } from './utils/refs';
-import { getFromPath, isYupValidator, setInPath } from './utils';
+import { getFromPath, isYupValidator, setInPath, unsetPath } from './utils';
 
 interface FormOptions {
   validationSchema?: Record<string, GenericValidateFunction | string | Record<string, any>>;
@@ -74,7 +74,7 @@ export function useForm(opts?: FormOptions) {
       // in this case, this is a single field not a group (checkbox or radio)
       // so remove the field value key immediately
       if (field.idx === -1) {
-        delete formValues[fieldName];
+        unsetPath(formValues, fieldName);
         return;
       }
 
@@ -82,7 +82,8 @@ export function useForm(opts?: FormOptions) {
       const valueIdx: number | undefined = getFromPath(formValues, fieldName)?.indexOf?.(unwrap(field.valueProp));
 
       if (valueIdx === undefined) {
-        delete formValues[fieldName];
+        unsetPath(formValues, fieldName);
+
         return;
       }
 
@@ -91,10 +92,11 @@ export function useForm(opts?: FormOptions) {
       }
 
       if (Array.isArray(formValues[fieldName])) {
-        formValues[fieldName].splice(valueIdx, 1);
+        unsetPath(formValues, `${fieldName}.${valueIdx}`);
         return;
       }
-      delete formValues[fieldName];
+
+      unsetPath(formValues, fieldName);
     },
     fields: fieldsById,
     values: formValues,

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -10,7 +10,7 @@ import {
   ValidationResult,
 } from './types';
 import { unwrap } from './utils/refs';
-import { isYupValidator } from './utils';
+import { isYupValidator, setInPath } from './utils';
 
 interface FormOptions {
   validationSchema?: Record<string, GenericValidateFunction | string | Record<string, any>>;
@@ -117,25 +117,26 @@ export function useForm(opts?: FormOptions) {
 
       // singular inputs fields
       if (!field || (!Array.isArray(field) && field.type !== 'checkbox')) {
-        _values[path] = value;
+        setInPath(_values, path, value);
         return;
       }
 
       // Radio buttons and other unknown group type inputs
       if (Array.isArray(field) && field[0].type !== 'checkbox') {
-        _values[path] = value;
+        setInPath(_values, path, value);
         return;
       }
 
       // Single Checkbox
       if (!Array.isArray(field) && field.type === 'checkbox') {
-        _values[path] = _values[path] === value ? undefined : value;
+        const newVal = _values[path] === value ? undefined : value;
+        setInPath(_values, path, newVal);
         return;
       }
 
       // Multiple Checkboxes but their whole value was updated
       if (Array.isArray(value)) {
-        _values[path] = value;
+        setInPath(_values, path, value);
         return;
       }
 
@@ -145,12 +146,12 @@ export function useForm(opts?: FormOptions) {
         const idx = newVal.indexOf(value);
         newVal.splice(idx, 1);
 
-        _values[path] = newVal;
+        setInPath(_values, path, newVal);
         return;
       }
 
       newVal.push(value);
-      _values[path] = newVal;
+      setInPath(_values, path, newVal);
     },
   };
 

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -54,13 +54,6 @@ export function useForm(opts?: FormOptions) {
   const formValues = reactive<Record<string, any>>({});
   const controller: FormController = {
     register(field: FieldComposite) {
-      const name = unwrap(field.name);
-      // Set the initial value for that field
-      const initialValue = getFromPath(opts?.initialValues || {}, name);
-      if (initialValue !== undefined) {
-        setInPath(formValues, name, initialValue);
-      }
-
       fields.value.push(field);
     },
     unregister(field: FieldComposite) {
@@ -224,6 +217,7 @@ export function useForm(opts?: FormOptions) {
 
   provide('$_veeForm', controller);
   provide('$_veeFormErrors', errors);
+  provide('$_veeFormInitValues', opts?.initialValues || {});
 
   return {
     errors,

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -178,6 +178,14 @@ export function useForm(opts?: FormOptions) {
     fields.value.forEach((f: any) => f.reset());
   };
 
+  const activeFormValues = computed(() => {
+    return activeFields.value.reduce((formData: Record<string, any>, field) => {
+      setInPath(formData, field.name, unwrap(field.value));
+
+      return formData;
+    }, {});
+  });
+
   const handleSubmit = (fn?: SubmissionHandler) => {
     return function submissionHandler(e: unknown) {
       if (e instanceof Event) {
@@ -189,7 +197,7 @@ export function useForm(opts?: FormOptions) {
       return validate()
         .then(result => {
           if (result && typeof fn === 'function') {
-            return fn(formValues, e as SubmitEvent);
+            return fn(activeFormValues.value, e as SubmitEvent);
           }
         })
         .then(

--- a/packages/core/src/utils/assertions.ts
+++ b/packages/core/src/utils/assertions.ts
@@ -1,5 +1,5 @@
 import { Locator } from '../types';
-import { isCallable } from '../../../shared';
+import { isCallable, isObject } from '../../../shared';
 
 export function isLocator(value: unknown): value is Locator {
   return isCallable(value) && !!(value as any).__locatorRef;
@@ -20,4 +20,19 @@ export function isYupValidator(value: unknown): value is YupValidator {
 
 export function hasCheckedAttr(type: unknown) {
   return type === 'checkbox' || type === 'radio';
+}
+
+export function isIndex(value: unknown): value is number {
+  return Number(value) >= 0;
+}
+
+/**
+ * True if the value is an empty object or array
+ */
+export function isEmptyContainer(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  return isObject(value) && Object.keys(value).length === 0;
 }

--- a/packages/core/src/utils/assertions.ts
+++ b/packages/core/src/utils/assertions.ts
@@ -36,3 +36,10 @@ export function isEmptyContainer(value: unknown): boolean {
 
   return isObject(value) && Object.keys(value).length === 0;
 }
+
+/**
+ * Checks if the path opted out of nested fields using `[fieldName]` syntax
+ */
+export function isNotNestedPath(path: string) {
+  return /^\[.+\]$/i.test(path);
+}

--- a/packages/core/src/utils/common.ts
+++ b/packages/core/src/utils/common.ts
@@ -5,7 +5,11 @@ export function genFieldErrorId(fieldName: string): string {
 }
 
 function cleanupNonNestedPath(path: string) {
-  return path.replace(/\[|\]/gi, '');
+  if (isNotNestedPath(path)) {
+    return path.replace(/\[|\]/gi, '');
+  }
+
+  return path;
 }
 
 /**

--- a/packages/core/src/utils/common.ts
+++ b/packages/core/src/utils/common.ts
@@ -1,0 +1,38 @@
+export function genFieldErrorId(fieldName: string): string {
+  return `v_${fieldName}_error`;
+}
+
+/**
+ * Gets a nested property value from an object
+ */
+export function getFromPath(object: Record<string, any>, path: string): any {
+  return path.split('.').reduce((acc, propKey) => {
+    if (acc && acc[propKey]) {
+      return acc[propKey];
+    }
+
+    return undefined;
+  }, object);
+}
+
+/**
+ * Sets a nested property value in a path, creates the path properties if it doesn't exist
+ */
+export function setInPath(object: Record<string, any>, path: string, value: any): void {
+  const keys = path.split('.');
+  let acc = object;
+  for (let i = 0; i < keys.length; i++) {
+    // Last key, set it
+    if (i === keys.length - 1) {
+      acc[keys[i]] = value;
+      break;
+    }
+
+    // Key does not exist, create a container for it
+    if (!(keys[i] in acc)) {
+      acc[keys[i]] = {};
+    }
+
+    acc = acc[keys[i]];
+  }
+}

--- a/packages/core/src/utils/common.ts
+++ b/packages/core/src/utils/common.ts
@@ -1,13 +1,21 @@
-import { isEmptyContainer, isIndex } from './assertions';
+import { isEmptyContainer, isIndex, isNotNestedPath } from './assertions';
 
 export function genFieldErrorId(fieldName: string): string {
   return `v_${fieldName}_error`;
+}
+
+function cleanupNonNestedPath(path: string) {
+  return path.replace(/\[|\]/gi, '');
 }
 
 /**
  * Gets a nested property value from an object
  */
 export function getFromPath(object: Record<string, any>, path: string): any {
+  if (isNotNestedPath(path)) {
+    return object[cleanupNonNestedPath(path)];
+  }
+
   return path.split('.').reduce((acc, propKey) => {
     if (acc && acc[propKey]) {
       return acc[propKey];
@@ -21,6 +29,11 @@ export function getFromPath(object: Record<string, any>, path: string): any {
  * Sets a nested property value in a path, creates the path properties if it doesn't exist
  */
 export function setInPath(object: Record<string, any>, path: string, value: any): void {
+  if (isNotNestedPath(path)) {
+    object[cleanupNonNestedPath(path)] = value;
+    return;
+  }
+
   const keys = path.split('.');
   let acc = object;
   for (let i = 0; i < keys.length; i++) {
@@ -44,6 +57,11 @@ export function setInPath(object: Record<string, any>, path: string, value: any)
  * Removes a nested property from object
  */
 export function unsetPath(object: Record<string, any>, path: string, { keepContainer = false } = {}): void {
+  if (isNotNestedPath(path)) {
+    delete object[cleanupNonNestedPath(path)];
+    return;
+  }
+
   const keys = path.split('.');
   let acc = object;
   for (let i = 0; i < keys.length; i++) {

--- a/packages/core/src/utils/common.ts
+++ b/packages/core/src/utils/common.ts
@@ -63,7 +63,7 @@ export function setInPath(object: Record<string, any>, path: string, value: any)
 /**
  * Removes a nested property from object
  */
-export function unsetPath(object: Record<string, any>, path: string, { keepContainer = false } = {}): void {
+export function unsetPath(object: Record<string, any>, path: string): void {
   if (isNotNestedPath(path)) {
     delete object[cleanupNonNestedPath(path)];
     return;
@@ -89,10 +89,6 @@ export function unsetPath(object: Record<string, any>, path: string, { keepConta
     }
 
     acc = acc[keys[i]];
-  }
-
-  if (keepContainer) {
-    return;
   }
 
   acc = object;

--- a/packages/core/src/utils/common.ts
+++ b/packages/core/src/utils/common.ts
@@ -20,13 +20,16 @@ export function getFromPath(object: Record<string, any>, path: string): any {
     return object[cleanupNonNestedPath(path)];
   }
 
-  return path.split('.').reduce((acc, propKey) => {
-    if (acc && acc[propKey]) {
-      return acc[propKey];
-    }
+  return path
+    .split(/\.|\[(\d+)\]/)
+    .filter(Boolean)
+    .reduce((acc, propKey) => {
+      if (acc && acc[propKey]) {
+        return acc[propKey];
+      }
 
-    return undefined;
-  }, object);
+      return undefined;
+    }, object);
 }
 
 /**
@@ -38,7 +41,7 @@ export function setInPath(object: Record<string, any>, path: string, value: any)
     return;
   }
 
-  const keys = path.split('.');
+  const keys = path.split(/\.|\[(\d+)\]/).filter(Boolean);
   let acc = object;
   for (let i = 0; i < keys.length; i++) {
     // Last key, set it
@@ -66,7 +69,7 @@ export function unsetPath(object: Record<string, any>, path: string, { keepConta
     return;
   }
 
-  const keys = path.split('.');
+  const keys = path.split(/\.|\[(\d+)\]/).filter(Boolean);
   let acc = object;
   for (let i = 0; i < keys.length; i++) {
     // Last key, unset it

--- a/packages/core/src/utils/consts.ts
+++ b/packages/core/src/utils/consts.ts
@@ -1,3 +1,0 @@
-export function genFieldErrorId(fieldName: string): string {
-  return `v_${fieldName}_error`;
-}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,5 +1,5 @@
 export * from './assertions';
-export * from './consts';
+export * from './common';
 export * from './events';
 export * from './refs';
 export * from './rules';

--- a/packages/core/tests/Field.spec.ts
+++ b/packages/core/tests/Field.spec.ts
@@ -329,7 +329,7 @@ describe('<Field />', () => {
     const wrapper = mountWithHoc({
       template: `
       <div>
-        <Field rules="required|atLeastOne" v-slot="{ field, errors }">
+        <Field name="field" rules="required|atLeastOne" v-slot="{ field, errors }">
           <input type="file" v-bind="field">
           <p id="error">{{ errors[0] }}</p>
         </Field>

--- a/packages/core/tests/Form.spec.ts
+++ b/packages/core/tests/Form.spec.ts
@@ -578,6 +578,7 @@ describe('<Form />', () => {
         <template v-if="showFields">
           <Field name="field" as="input" />          
           <Field name="nested.field" />
+          <Field name="[non-nested.field]" />
           <Field name="drink" as="input" type="checkbox" value="" /> Coffee
           <Field name="drink" as="input" type="checkbox" value="Tea" /> Tea
         </template>
@@ -599,12 +600,18 @@ describe('<Form />', () => {
     wrapper.$el.querySelector('button').click();
     await flushPromises();
     expect(errors.textContent).toBeTruthy();
-    setChecked(inputs[3]);
     setChecked(inputs[4]);
+    setChecked(inputs[5]);
     setValue(inputs[0], 'test');
     setValue(inputs[1], '12');
+    setValue(inputs[2], '12');
     await flushPromises();
-    expect(JSON.parse(values.textContent)).toEqual({ drink: ['Tea', 'Coke'], field: 'test', nested: { field: '12' } });
+    expect(JSON.parse(values.textContent)).toEqual({
+      drink: ['Tea', 'Coke'],
+      field: 'test',
+      'non-nested.field': '12',
+      nested: { field: '12' },
+    });
 
     showFields.value = false;
     await flushPromises();

--- a/packages/core/tests/Form.spec.ts
+++ b/packages/core/tests/Form.spec.ts
@@ -845,9 +845,9 @@ describe('<Form />', () => {
       },
       template: `
       <VForm @submit="onSubmit" v-slot="{ errors }">
-        <Field name="user.name" as="input" rules="required"  />
+        <Field name="user.name" as="input" />
         <span id="nameErr">{{ errors['user.name'] }}</span>
-        <Field name="user.addresses.0" as="input" id="address" rules="required"  />
+        <Field name="user.addresses.0" as="input" id="address" />
         <span id="addrErr">{{ errors['user.addresses.0'] }}</span>
 
         <button id="submit">Submit</button>

--- a/packages/core/tests/Form.spec.ts
+++ b/packages/core/tests/Form.spec.ts
@@ -578,6 +578,7 @@ describe('<Form />', () => {
       <VForm @submit="submit" as="form" :validationSchema="schema" v-slot="{ errors, values }">
         <template v-if="showFields">
           <Field name="field" as="input" />          
+          <Field name="nested.field" />
           <Field name="drink" as="input" type="checkbox" value="" /> Coffee
           <Field name="drink" as="input" type="checkbox" value="Tea" /> Tea
         </template>
@@ -599,9 +600,14 @@ describe('<Form />', () => {
     wrapper.$el.querySelector('button').click();
     await flushPromises();
     expect(errors.textContent).toBeTruthy();
-    setChecked(inputs[2]);
     setChecked(inputs[3]);
+    setChecked(inputs[4]);
+    setValue(inputs[0], 'test');
+    setValue(inputs[1], '12');
     await flushPromises();
+    expect(values.textContent).toBe(
+      JSON.stringify({ drink: ['Tea', 'Coke'], field: 'test', nested: { field: '12' } }, null, 2)
+    );
 
     showFields.value = false;
     await flushPromises();
@@ -801,6 +807,7 @@ describe('<Form />', () => {
       template: `
       <VForm @submit="onSubmit" v-slot="{ values }">
         <Field name="user.name" as="input" rules="required"  />
+        <Field name="user.addresses.0" as="input" id="address" rules="required"  />
         <pre>{{ values }}</pre>
 
         <button id="submit">Submit</button>
@@ -809,13 +816,15 @@ describe('<Form />', () => {
     });
 
     const submitBtn = wrapper.$el.querySelector('#submit');
-    const input = wrapper.$el.querySelector('input');
+    const name = wrapper.$el.querySelector('input');
+    const address = wrapper.$el.querySelector('#address');
     const pre = wrapper.$el.querySelector('pre');
-    setValue(input, '12');
+    setValue(name, '12');
+    setValue(address, 'abc');
     await flushPromises();
-    expect(pre.textContent).toBe(JSON.stringify({ user: { name: '12' } }, null, 2));
+    expect(pre.textContent).toBe(JSON.stringify({ user: { name: '12', addresses: ['abc'] } }, null, 2));
     submitBtn.click();
     await flushPromises();
-    expect(fn).toHaveBeenCalledWith({ user: { name: '12' } });
+    expect(fn).toHaveBeenCalledWith({ user: { name: '12', addresses: ['abc'] } });
   });
 });

--- a/packages/core/tests/Form.spec.ts
+++ b/packages/core/tests/Form.spec.ts
@@ -787,4 +787,35 @@ describe('<Form />', () => {
     await flushPromises();
     expect(submitBtn.disabled).toBe(false);
   });
+
+  test('nested object fields', async () => {
+    const fn = jest.fn();
+    const wrapper = mountWithHoc({
+      setup() {
+        return {
+          onSubmit(values: any) {
+            fn(values);
+          },
+        };
+      },
+      template: `
+      <VForm @submit="onSubmit" v-slot="{ values }">
+        <Field name="user.name" as="input" rules="required"  />
+        <pre>{{ values }}</pre>
+
+        <button id="submit">Submit</button>
+      </VForm>
+    `,
+    });
+
+    const submitBtn = wrapper.$el.querySelector('#submit');
+    const input = wrapper.$el.querySelector('input');
+    const pre = wrapper.$el.querySelector('pre');
+    setValue(input, '12');
+    await flushPromises();
+    expect(pre.textContent).toBe(JSON.stringify({ user: { name: '12' } }, null, 2));
+    submitBtn.click();
+    await flushPromises();
+    expect(fn).toHaveBeenCalledWith({ user: { name: '12' } });
+  });
 });

--- a/packages/core/tests/Form.spec.ts
+++ b/packages/core/tests/Form.spec.ts
@@ -604,14 +604,12 @@ describe('<Form />', () => {
     setValue(inputs[0], 'test');
     setValue(inputs[1], '12');
     await flushPromises();
-    expect(values.textContent).toBe(
-      JSON.stringify({ drink: ['Tea', 'Coke'], field: 'test', nested: { field: '12' } }, null, 2)
-    );
+    expect(JSON.parse(values.textContent)).toEqual({ drink: ['Tea', 'Coke'], field: 'test', nested: { field: '12' } });
 
     showFields.value = false;
     await flushPromises();
     expect(errors.textContent).toBe('{}');
-    expect(values.textContent).toBe(JSON.stringify({ drink: ['Coke'] }, null, 2));
+    expect(JSON.parse(values.textContent)).toEqual({ drink: ['Coke'] });
   });
 
   test('checkboxes with yup schema', async () => {
@@ -835,7 +833,7 @@ describe('<Form />', () => {
           schema: yup.object({
             user: yup.object({
               name: yup.string().required(),
-              addresses: yup.array().of(yup.string().required()),
+              addresses: yup.array().of(yup.string().required().min(3)).required(),
             }),
           }),
           onSubmit(values: any) {
@@ -844,11 +842,11 @@ describe('<Form />', () => {
         };
       },
       template: `
-      <VForm @submit="onSubmit" v-slot="{ errors }">
+      <VForm @submit="onSubmit" v-slot="{ errors }" :validation-schema="schema">
         <Field name="user.name" as="input" />
         <span id="nameErr">{{ errors['user.name'] }}</span>
-        <Field name="user.addresses.0" as="input" id="address" />
-        <span id="addrErr">{{ errors['user.addresses.0'] }}</span>
+        <Field name="user.addresses[0]" as="input" id="address" />
+        <span id="addrErr">{{ errors['user.addresses[0]'] }}</span>
 
         <button id="submit">Submit</button>
       </VForm>
@@ -863,9 +861,9 @@ describe('<Form />', () => {
     submitBtn.click();
     await flushPromises();
 
+    expect(fn).not.toHaveBeenCalled();
     expect(nameErr.textContent).toBeTruthy();
     expect(addrErr.textContent).toBeTruthy();
-    expect(fn).not.toHaveBeenCalled();
     setValue(name, '12');
     setValue(address, 'abc');
     await flushPromises();

--- a/packages/docs/components/DocMenu.vue
+++ b/packages/docs/components/DocMenu.vue
@@ -24,6 +24,7 @@ export default {
           '/guide/overview',
           '/guide/validation',
           '/guide/handling-forms',
+          '/guide/nested-objects-and-arrays',
           '/guide/global-validators',
           '/guide/i18n',
         ],

--- a/packages/docs/content/guide/nested-objects-and-arrays.md
+++ b/packages/docs/content/guide/nested-objects-and-arrays.md
@@ -1,0 +1,131 @@
+---
+title: Nested Objects and Arrays
+description: Structuring forms in nested paths in objects or arrays
+---
+
+# Nested Objects and Arrays
+
+vee-validate supports nested objects and arrays, using field names syntaxes to indicate a field's path. This allows you to structure forms easily to make data mapping straightforward without having to deal with flat form values.
+
+## Nested Objects
+
+You can specify a field to be nested in an object using dot paths, like what you would normally do in JavaScript do access a nested property. The field `name` prop acts as the path for that field:
+
+```vue
+<template>
+  <Form @submit="onSubmit">
+    <Field name="links.twitter" type="url" />
+    <Field name="links.github" type="url" />
+
+    <button>Submit</button>
+  </Form>
+</template>
+
+<script>
+export default {
+  methods: {
+    onSubmit(values) {
+      alert(JSON.stringify(values, null, 2));
+    },
+  },
+};
+</script>
+```
+
+Submitting the previous form would result in the following values being passed to your handler:
+
+```js
+{
+  "links": {
+    "twitter": "https://twitter.com/logaretm",
+    "github": "https://github.com/logaretm"
+  }
+}
+```
+
+You are not limited to a specific depth, you can nest as much as you like.
+
+## Nested Arrays
+
+Similar to objects, you can also nested your values in an array, using dot paths as well but using numbers as property key instead.
+
+Here is the same example as above but in array format:
+
+```vue
+<template>
+  <Form @submit="onSubmit">
+    <Field name="links.0" type="url" />
+    <Field name="links.1" type="url" />
+
+    <button>Submit</button>
+  </Form>
+</template>
+
+<script>
+export default {
+  methods: {
+    onSubmit(values) {
+      alert(JSON.stringify(values, null, 2));
+    },
+  },
+};
+</script>
+```
+
+Submitting the previous form would result in the following values being passed to your handler:
+
+```js
+{
+  "links": [
+    "https://twitter.com/logaretm",
+    "https://github.com/logaretm"
+  ]
+}
+```
+
+<doc-tip type="warn">
+
+vee-validate will only create nested arrays if the path expression is a complete number, for example paths like `some.nested.0path` will not create any arrays because the `0path` key is not a number. However `some.nested.0.path` will create the array with an object as the first item.
+
+</doc-top>
+
+## Avoiding Nesting
+
+If your fields' names are using the dot notation and you want to avoid the nesting behavior which is enabled by default, all you need to do is wrap your field names in square brackets (`[]`) to disable nesting for those fields.
+
+```vue
+<template>
+  <Form @submit="onSubmit">
+    <Field name="[links.twitter]" type="url" />
+    <Field name="[links.github]" type="url" />
+
+    <button>Submit</button>
+  </Form>
+</template>
+
+<script>
+export default {
+  methods: {
+    onSubmit(values) {
+      alert(JSON.stringify(values, null, 2));
+    },
+  },
+};
+</script>
+```
+
+Submitting the previous form would result in the following values being passed to your handler:
+
+```js
+{
+  "links.twitter": "https://twitter.com/logaretm",
+   "links.github": "https://github.com/logaretm"
+  ]
+}
+```
+
+## Caveats
+
+- vee-validate creates the paths inside the form data automatically but lazily, so initially your form values won't contain the fields values unless you provide initial values for them. It might be worthwhile to provide initial data for your forms with nested paths.
+- When fields get unmounted like in the case of conditional rendered fields with `v-if` or `v-for`, their path will be destroyed just as it was created if they are the last field in that path. So you need to be careful while accessing the nested field in `values` inside your submission handler or the `Form` component or `useForm` composable.
+- When referencing errors using `errors` object on the `Form` slot props or the `ErrorMessage` component, make sure to reference the field name in the exact same way you set it on the `name` prop for that field. So even if you avoid nesting you should always include the square brackets.

--- a/packages/docs/content/guide/nested-objects-and-arrays.md
+++ b/packages/docs/content/guide/nested-objects-and-arrays.md
@@ -47,15 +47,15 @@ You are not limited to a specific depth, you can nest as much as you like.
 
 ## Nested Arrays
 
-Similar to objects, you can also nested your values in an array, using dot paths as well but using numbers as property key instead.
+Similar to objects, you can also nested your values in an array, using square brackets just like how you would do it in JavaScript.
 
 Here is the same example as above but in array format:
 
 ```vue
 <template>
   <Form @submit="onSubmit">
-    <Field name="links.0" type="url" />
-    <Field name="links.1" type="url" />
+    <Field name="links[0]" type="url" />
+    <Field name="links[1]" type="url" />
 
     <button>Submit</button>
   </Form>
@@ -85,7 +85,7 @@ Submitting the previous form would result in the following values being passed t
 
 <doc-tip type="warn">
 
-vee-validate will only create nested arrays if the path expression is a complete number, for example paths like `some.nested.0path` will not create any arrays because the `0path` key is not a number. However `some.nested.0.path` will create the array with an object as the first item.
+vee-validate will only create nested arrays if the path expression is a complete number, for example paths like `some.nested[0path]` will not create any arrays because the `0path` key is not a number. However `some.nested[0].path` will create the array with an object as the first item.
 
 </doc-top>
 
@@ -126,6 +126,51 @@ Submitting the previous form would result in the following values being passed t
 
 ## Caveats
 
-- vee-validate creates the paths inside the form data automatically but lazily, so initially your form values won't contain the fields values unless you provide initial values for them. It might be worthwhile to provide initial data for your forms with nested paths.
-- When fields get unmounted like in the case of conditional rendered fields with `v-if` or `v-for`, their path will be destroyed just as it was created if they are the last field in that path. So you need to be careful while accessing the nested field in `values` inside your submission handler or the `Form` component or `useForm` composable.
-- When referencing errors using `errors` object on the `Form` slot props or the `ErrorMessage` component, make sure to reference the field name in the exact same way you set it on the `name` prop for that field. So even if you avoid nesting you should always include the square brackets.
+### Paths creation and destruction
+
+vee-validate creates the paths inside the form data automatically but lazily, so initially your form values won't contain the fields values unless you provide initial values for them. It might be worthwhile to provide initial data for your forms with nested paths.
+
+When fields get unmounted like in the case of conditional rendered fields with `v-if` or `v-for`, their path will be destroyed just as it was created if they are the last field in that path. So you need to be careful while accessing the nested field in `values` inside your submission handler or the `Form` component or `useForm` composable.
+
+### Referencing Errors
+
+When referencing errors using `errors` object on the `Form` slot props or the `ErrorMessage` component, make sure to reference the field name in the exact same way you set it on the `name` prop for that field. So even if you avoid nesting you should always include the square brackets. In other words `errors` do not get nested, they are always flat.
+
+### Referencing In Validation Schema
+
+Since vee-validate supports [form-level validation](./validation#form-level-validation), referncing the nested fields may vary depending on how you are specifying the schema.
+
+#### Using Yup
+
+If you are using yup, you can utilize the nested `yup.object` or `yup.array` schemas to provide validation for your nested fields, here is a quick example:
+
+```vue
+<template>
+  <Form @submit="onSubmit" v-slot="{ errors }">
+    <Field name="user.name" as="input" />
+    <span id="nameErr">{{ errors['user.name'] }}</span>
+    <Field name="user.addresses[0]" as="input" id="address" />
+    <span id="addrErr">{{ errors['user.addresses[0]'] }}</span>
+
+    <button id="submit">Submit</button>
+  </Form>
+</template>
+
+<script>
+export default {
+  setup() {
+    return {
+      schema: yup.object({
+        user: yup.object({
+          name: yup.string().required(),
+          addresses: yup.array().of(yup.string().required()),
+        }),
+      }),
+      onSubmit(values: any) {
+        fn(values);
+      },
+    };
+  },
+};
+</script>
+```


### PR DESCRIPTION
🔎 __Overview__

This PR adds the ability to structure form fields into nested objects #2890 

Todo:

- [x] Nested Objects
- [x] Support for initial values
- [x] Nested Arrays
- [x] Cleaning up nested values (after unmount)
- [x] A way to opt-out of the nesting
- [x] Write Docs

Example:

```vue
<Form @submit="onSubmit">
  <Field name="user.name" rules="required"  />
  <Field name="user.password" type="password" rules="required"  />
  <Field name="user.social[0]" type="url" rules="required"  />
  <Field name="user.social[1]" type="url" rules="required"  />

  <button id="submit">Submit</button>
</Form>
```

Submitting the above form will result in the following `values`:

```js
{
  user: {
    name: "John Doe",
    password: "123456",
    social: [
       "link1",
       "link2"
    ]
  }
}
```

✔ __Issues affected__

closes #2890
