### PR TITLE
feat: add invalid event

### DIFF
--- a/packages/core/src/Field.ts
+++ b/packages/core/src/Field.ts
@@ -1,4 +1,4 @@
-import { h, defineComponent, nextTick, toRefs, watch } from 'vue';
+import { h, defineComponent, nextTick, toRef, watch } from 'vue';
 import { getConfig } from './config';
 import { useField } from './useField';
 import { normalizeChildren, isHTMLTag, hasCheckedAttr } from './utils';

--- a/packages/core/src/Field.ts
+++ b/packages/core/src/Field.ts
@@ -1,7 +1,8 @@
-import { h, defineComponent, nextTick, toRefs } from 'vue';
+import { h, defineComponent, nextTick, toRefs, watch } from 'vue';
 import { getConfig } from './config';
 import { useField } from './useField';
 import { normalizeChildren, isHTMLTag, hasCheckedAttr } from './utils';
+import { FieldErrors } from './types';
 
 export const Field = defineComponent({
   name: 'Field',
@@ -61,6 +62,14 @@ export const Field = defineComponent({
       // Only for checkboxes and radio buttons
       valueProp: ctx.attrs.value,
     });
+
+    if (ctx.attrs.onInvalid) {
+      watch(errors, () => {
+        if (errors.value.length !== 0) {
+          (ctx.attrs.onInvalid as (errors: FieldErrors) => any)(errors.value);
+        }
+      });
+    }
 
     // If there is a v-model applied on the component we need to emit the `update:modelValue` whenever the value binding changes
     const onChangeHandler =

--- a/packages/core/src/Form.ts
+++ b/packages/core/src/Form.ts
@@ -29,7 +29,9 @@ export const Form = defineComponent({
     const onSubmit = ctx.attrs.onSubmit ? handleSubmit(ctx.attrs.onSubmit as SubmissionHandler) : submitForm;
     function handleFormReset() {
       handleReset();
-      if (ctx.attrs.onReset) (ctx.attrs.onReset as any)();
+      if (typeof ctx.attrs.onReset === 'function') {
+        ctx.attrs.onReset();
+      }
     }
 
     return () => {

--- a/packages/core/src/Form.ts
+++ b/packages/core/src/Form.ts
@@ -1,4 +1,4 @@
-import { h, defineComponent } from 'vue';
+import { h, defineComponent, SetupContext } from 'vue';
 import { useForm } from './useForm';
 import { SubmissionHandler } from './types';
 import { normalizeChildren } from './utils';
@@ -29,13 +29,11 @@ export const Form = defineComponent({
     const onSubmit = ctx.attrs.onSubmit ? handleSubmit(ctx.attrs.onSubmit as SubmissionHandler) : submitForm;
     function handleFormReset() {
       handleReset();
-      if (typeof ctx.attrs.onReset === 'function') {
-        ctx.attrs.onReset();
-      }
+      if (ctx.attrs.onReset) (ctx.attrs.onReset as any)();
     }
 
     return () => {
-      const children = normalizeChildren(ctx, {
+      const children = normalizeChildren(ctx as SetupContext, {
         meta: meta.value,
         errors: errors.value,
         values: values,

--- a/packages/core/src/Form.ts
+++ b/packages/core/src/Form.ts
@@ -1,4 +1,4 @@
-import { h, defineComponent, SetupContext } from 'vue';
+import { h, defineComponent } from 'vue';
 import { useForm } from './useForm';
 import { SubmissionHandler } from './types';
 import { normalizeChildren } from './utils';
@@ -33,7 +33,7 @@ export const Form = defineComponent({
     }
 
     return () => {
-      const children = normalizeChildren(ctx as SetupContext, {
+      const children = normalizeChildren(ctx, {
         meta: meta.value,
         errors: errors.value,
         values: values,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -59,3 +59,5 @@ export interface FormController {
   validateSchema?: (shouldMutate?: boolean) => Promise<Record<string, ValidationResult>>;
   setFieldValue: (path: string, value: any) => void;
 }
+
+export type FieldErrors = string[];

--- a/packages/core/src/useField.ts
+++ b/packages/core/src/useField.ts
@@ -7,6 +7,7 @@ import {
   GenericValidateFunction,
   Flag,
   ValidationFlags,
+  FieldErrors,
 } from './types';
 import {
   normalizeRules,
@@ -208,7 +209,7 @@ function useValidationState({
   type?: string;
   valueProp: any;
 }) {
-  const errors: Ref<string[]> = ref([]);
+  const errors: Ref<FieldErrors> = ref([]);
   const { onBlur, reset: resetFlags, meta } = useMeta();
   const initialValue = initValue ?? getFromPath(inject(FormInitialValues, {}), unwrap(fieldName));
   const value = useFieldValue(initialValue, fieldName, form);

--- a/packages/core/tests/Field.spec.ts
+++ b/packages/core/tests/Field.spec.ts
@@ -162,6 +162,32 @@ describe('<Field />', () => {
     expect(pre.textContent).toContain('"dirty": true');
   });
 
+  test('emits invalid event', async () => {
+    const onInvalid = jest.fn();
+    const wrapper = mountWithHoc({
+      methods: {
+        onInvalid,
+      },
+      template: `
+      <div>
+        <Field @invalid="onInvalid" name="field" rules="required" v-slot="{ field }">
+          <input v-bind="field" type="text">
+        </Field>
+      </div>
+    `,
+    });
+
+    const input = wrapper.$el.querySelector('input');
+    await flushPromises();
+    expect(onInvalid.mock.calls).toMatchObject([]);
+
+    setValue(input, '12');
+    await flushPromises();
+    setValue(input, '');
+    await flushPromises();
+    expect(onInvalid.mock.calls).toMatchObject([[[REQUIRED_MESSAGE]]]);
+  });
+
   test('listens for change events', async () => {
     const wrapper = mountWithHoc({
       template: `

--- a/packages/core/tests/Form.spec.ts
+++ b/packages/core/tests/Form.spec.ts
@@ -125,6 +125,24 @@ describe('<Form />', () => {
     expect(isReset).toBe(true);
   });
 
+  test('emits reset event', async () => {
+    const onReset = jest.fn();
+    const wrapper = mountWithHoc({
+      methods: {
+        onReset,
+      },
+      template: `
+      <VForm @reset="onReset" as="form">
+        <button id="reset" type="reset">Reset</button>
+      </VForm>
+    `,
+    });
+    wrapper.$el.querySelector('#reset').click();
+    await flushPromises();
+    await flushPromises();
+    expect(onReset.mock.calls).toMatchObject([[]]);
+  });
+
   test('disabled fields do not participate in validation', async () => {
     let isInObject = false;
     const wrapper = mountWithHoc({

--- a/packages/core/tests/Form.spec.ts
+++ b/packages/core/tests/Form.spec.ts
@@ -90,17 +90,13 @@ describe('<Form />', () => {
   });
 
   test('handles reset', async () => {
-    let isReset = false;
+    const onReset = jest.fn();
     const wrapper = mountWithHoc({
-      setup() {
-        return {
-          reset: () => {
-            isReset = true;
-          },
-        };
+      methods: {
+        onReset,
       },
       template: `
-      <VForm @reset="reset" as="form" v-slot="{ errors }">
+      <VForm @reset="onReset" as="form" v-slot="{ errors }">
         <Field rules="required" name="field" as="input"/>
         <span id="error">{{ errors.field }}</span>
 
@@ -122,24 +118,6 @@ describe('<Form />', () => {
     await flushPromises();
 
     expect(error.textContent).toBe('');
-    expect(isReset).toBe(true);
-  });
-
-  test('emits reset event', async () => {
-    const onReset = jest.fn();
-    const wrapper = mountWithHoc({
-      methods: {
-        onReset,
-      },
-      template: `
-      <VForm @reset="onReset" as="form">
-        <button id="reset" type="reset">Reset</button>
-      </VForm>
-    `,
-    });
-    wrapper.$el.querySelector('#reset').click();
-    await flushPromises();
-    await flushPromises();
     expect(onReset.mock.calls).toMatchObject([[]]);
   });
 


### PR DESCRIPTION
🔎 __Overview__

Ex (Feat): This PR adds `invalid` event for `<Field>` component, improves `reset` event test for `<Form>` component.


🤓 __Code snippets/examples (if applicable)__

Will fire each time validation does not pass:
```js
<Field @invalid="onInvalid">
  <Field name="field" rules="required">
    <input v-model="field">
  </Field>
</Field>
```


This PR accompanies https://github.com/logaretm/vee-validate/pull/2757
