### PR TITLE
feat: validation triggers

### DIFF
--- a/packages/core/src/Field.ts
+++ b/packages/core/src/Field.ts
@@ -41,7 +41,8 @@ export const Field = defineComponent({
       errorMessage,
       validate: validateField,
       handleChange,
-      onBlur,
+      handleBlur,
+      handleInput,
       reset,
       meta,
       aria,
@@ -71,15 +72,31 @@ export const Field = defineComponent({
           }
         : handleChange;
 
+    const { validateOnInput, validateOnChange, validateOnBlur, validateOnModelUpdate } = getConfig();
     const makeSlotProps = () => {
       const fieldProps: Record<string, any> = {
         name: props.name,
         disabled: props.disabled,
-        onInput: onChangeHandler,
-        onChange: onChangeHandler,
-        'onUpdate:modelValue': onChangeHandler,
-        onBlur: onBlur,
+        onBlur: [handleBlur],
+        onInput: [handleInput],
+        onChange: [handleInput],
       };
+
+      if (validateOnInput) {
+        fieldProps.onInput.push(onChangeHandler);
+      }
+
+      if (validateOnChange) {
+        fieldProps.onChange.push(onChangeHandler);
+      }
+
+      if (validateOnBlur) {
+        fieldProps.onBlur.push(onChangeHandler);
+      }
+
+      if (validateOnModelUpdate) {
+        fieldProps['onUpdate:modelValue'] = onChangeHandler;
+      }
 
       if (hasCheckedAttr(ctx.attrs.type) && checked) {
         fieldProps.checked = checked.value;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -3,21 +3,27 @@ import { ValidationMessageGenerator } from '../../shared';
 export interface VeeValidateConfig {
   bails: boolean;
   generateMessage: ValidationMessageGenerator;
+  validateOnInput: boolean;
+  validateOnChange: boolean;
+  validateOnBlur: boolean;
+  validateOnModelUpdate: boolean;
 }
 
 const DEFAULT_CONFIG: VeeValidateConfig = {
   generateMessage: ({ field }) => `${field} is not valid.`,
   bails: true,
+  validateOnBlur: true,
+  validateOnChange: true,
+  validateOnInput: false,
+  validateOnModelUpdate: true,
 };
 
 export let currentConfig: VeeValidateConfig = { ...DEFAULT_CONFIG };
 
 export const getConfig = () => currentConfig;
 
-export const setConfig = (newConf: Partial<VeeValidateConfig>) => {
+const setConfig = (newConf: Partial<VeeValidateConfig>) => {
   currentConfig = { ...currentConfig, ...newConf };
 };
 
-export const configure = (cfg: Partial<VeeValidateConfig>) => {
-  setConfig(cfg);
-};
+export const configure = setConfig;

--- a/packages/docs/content/api/configuration.md
+++ b/packages/docs/content/api/configuration.md
@@ -10,10 +10,16 @@ vee-validate exposes global configs to help with a few repeated or certain behav
 
 ## Config Options
 
-| Option          | Type                            | Description                                                                                                                                                                                                                                             |
-| --------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| bails           | `boolean`                       | Whether to run validations to completion or quit on the first, default is `true` error                                                                                                                                                                  |
-| generateMessage | `(ctx: FieldContext) => string` | A message generator function for i18n libraries and a fallback for rules with no messages. For more information about the `FieldContext` type and the purpose of this, see the [Global Message Generator Guide](../guide/i18n#global-message-generator) |
+| Option                | Type                            | Description                                                                                                                                                                                                                                             |
+| --------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| bails                 | `boolean`                       | Whether to run validations to completion or quit on the first, default is `true` error                                                                                                                                                                  |
+| generateMessage       | `(ctx: FieldContext) => string` | A message generator function for i18n libraries and a fallback for rules with no messages. For more information about the `FieldContext` type and the purpose of this, see the [Global Message Generator Guide](../guide/i18n#global-message-generator) |
+| validateOnBlur        | `boolean`                       | If validation should be triggered on `blur` event, default is `true`                                                                                                                                                                                    |
+| validateOnChange      | `boolean`                       | If validation should be triggered on `change` event, default is `true`                                                                                                                                                                                  |
+| validateOnInput       | `boolean`                       | If validation should be triggered on `input` event, default is `false`                                                                                                                                                                                  |
+| validateOnModelUpdate | `boolean`                       | If validation should be triggered on `update:modelValue` (v-model) event, default is `true`                                                                                                                                                             |
+
+This is slightly verbose, but this gives you exact control on which events triggers validation.
 
 ## Updating The Config
 


### PR DESCRIPTION
🔎 __Overview__

In vee-validate v3 we had the `interaction` modes idea that allowed customizing validation events dynamically. This was an overkill because almost always the events are the same `input`, `change` or `blur`.

Instead in v4 this is a more strict version of that, you can only choose to validate on one of those events:

- `change`
- `input`
- `blur`
- `update:modelValue`

By default the new validation events are `change`, `blur` and `update:modelUpdate`, this might be a breaking change because vee-validate will no longer validate on input by default.

Some research showed that almost always people used the `lazy` or `eager` modes, but not the `aggressive` mode which was the default one for `vee-validate@3`.