### PR TITLE
feat: field labels

### DIFF
--- a/docs/content/api/field.md
+++ b/docs/content/api/field.md
@@ -74,14 +74,15 @@ When using `v-slot` on the `Field` component you no longer have to provide an `a
 
 ### Props
 
-| Prop      | Type       | Required/Default | Description                                                                           |
-| :-------- | :--------- | :--------------- | :------------------------------------------------------------------------------------ |
-| as        | `string`   | `"span"`         | The element to render as a root node, defaults to `input`                             |
-| name      | `string`   | Required         | The field's name, must be inside `<Form />`                                           |
-| rules     | `object    | string           | Function`                                                                             | `null` | The field's validation rules |
-| immediate | `boolean`  | `false`          | If true, field will be validated on mounted                                           |
-| bails     | `boolean`  | `true`           | Stops validating as soon as a rule fails the validation                               |
-| disabled  | `disabled` | `false`          | Disables validation and the field will no longer participate in the parent form state |
+| Prop      | Type                           | Required/Default | Description                                                                                                          |
+| :-------- | :----------------------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------- |
+| as        | `string`                       | `"span"`         | The element to render as a root node, defaults to `input`                                                            |
+| name      | `string`                       | Required         | The field's name, must be inside `<Form />`                                                                          |
+| rules     | `object \| string \| Function` | `null`           | The field's validation rules                                                                                         |
+| immediate | `boolean`                      | `false`          | If true, field will be validated on mounted                                                                          |
+| bails     | `boolean`                      | `true`           | Stops validating as soon as a rule fails the validation                                                              |
+| disabled  | `disabled`                     | `false`          | Disables validation and the field will no longer participate in the parent form state                                |
+| label     | `string`                       | `undefined`      | A different string to override the field `name` prop in error messages, useful for display better or formatted names |
 
 ### Slots
 

--- a/docs/content/api/use-field.md
+++ b/docs/content/api/use-field.md
@@ -96,11 +96,12 @@ The full signature of the `useField` function looks like this:
 
 ```typescript
 interface FieldOptions {
-  value: Ref<any>; // the initial value, can be a ref
+  initialValue: any; // the initial value, cannot be a ref
   disabled: MaybeReactive<boolean>; // if the input is disabled, can be a ref
   immediate?: boolean; // if the field should be validated on mounted
   bails?: boolean; // if the field validation should run all validations
   form?: FormController; // the Form object returned from `useForm` to associate this field with
+  label?: string; // A friendly name to be used in `generateMessage` config instead of the field name
 }
 
 interface ValidationResult {

--- a/docs/content/guide/i18n.md
+++ b/docs/content/guide/i18n.md
@@ -18,7 +18,7 @@ The message generator function has the following type:
 
 ```typescript
 interface FieldContext {
-  field: string; // The field's name
+  field: string; // The field's name or label (see next section)
   value: any; // the field's current value
   form: Record<string, any>; // other values in the form
   rule: {
@@ -37,10 +37,23 @@ import { configure } from 'vee-validate';
 
 configure({
   generateMessage: context => {
-    return `The field ${context.name} is invalid`;
+    return `The field ${context.field} is invalid`;
   },
 });
 ```
+
+### Custom Labels
+
+If you want to display different field names in your error messages, the `<Field />` component accepts a `label` prop which allows you to display better names for your fields in their generated messages. Here is an example:
+
+```vue
+<Form>
+  <Field name="_bad_field_name" label="nice name" rules="required|email" />
+  <ErrorMessage name="_bad_field_name" />
+</Form>
+```
+
+The generated message will use `nice name` instead of the badly formatted one.
 
 ## Using @vee-validate/i18n
 

--- a/docs/content/guide/validation.md
+++ b/docs/content/guide/validation.md
@@ -373,3 +373,5 @@ const schema = Yup.object().shape({
 Here is a live example:
 
 <code-sandbox id="vee-validate-v4-custom-field-labels-with-yup-qikju" title="Custom Labels with yup"></code-sandbox>
+
+If you are interested on how to do the same for global validators check the [i18n guide](../guide/i18n#custom-labels)

--- a/packages/core/src/Field.ts
+++ b/packages/core/src/Field.ts
@@ -31,6 +31,10 @@ export const Field = defineComponent({
       type: Boolean,
       default: false,
     },
+    label: {
+      type: String,
+      default: undefined,
+    },
   },
   setup(props, ctx) {
     const [disabled, rules] = [toRef(props, 'disabled'), toRef(props, 'rules')];
@@ -61,6 +65,7 @@ export const Field = defineComponent({
         : ctx.attrs.value,
       // Only for checkboxes and radio buttons
       valueProp: ctx.attrs.value,
+      label: props.label || props.name,
     });
 
     // If there is a v-model applied on the component we need to emit the `update:modelValue` whenever the value binding changes

--- a/packages/core/src/useField.ts
+++ b/packages/core/src/useField.ts
@@ -28,6 +28,7 @@ interface FieldOptions {
   form?: FormController;
   type?: string;
   valueProp?: MaybeReactive<any>;
+  label?: string;
 }
 
 type RuleExpression = MaybeReactive<string | Record<string, any> | GenericValidateFunction>;
@@ -36,10 +37,11 @@ type RuleExpression = MaybeReactive<string | Record<string, any> | GenericValida
  * Creates a field composite.
  */
 export function useField(name: string, rules: RuleExpression, opts?: Partial<FieldOptions>) {
-  const { initialValue, form, immediate, bails, disabled, type, valueProp } = normalizeOptions(opts);
+  const { initialValue, form, immediate, bails, disabled, type, valueProp, label } = normalizeOptions(name, opts);
 
   const { meta, errors, handleBlur, handleChange, handleInput, reset, patch, value, checked } = useValidationState({
     name,
+    // make sure to unwrap initial value because of possible refs passed in
     initValue: unwrap(initialValue),
     form,
     type,
@@ -55,7 +57,7 @@ export function useField(name: string, rules: RuleExpression, opts?: Partial<Fie
     meta.pending = true;
     if (!form || !form.validateSchema) {
       const result = await validate(value.value, normalizedRules.value, {
-        name,
+        name: label,
         values: form?.values ?? {},
         bails,
       });
@@ -172,7 +174,7 @@ export function useField(name: string, rules: RuleExpression, opts?: Partial<Fie
 /**
  * Normalizes partial field options to include the full
  */
-function normalizeOptions(opts: Partial<FieldOptions> | undefined): FieldOptions {
+function normalizeOptions(name: string, opts: Partial<FieldOptions> | undefined): FieldOptions {
   const form = inject(FormSymbol, undefined) as FormController | undefined;
 
   const defaults = () => ({
@@ -182,6 +184,7 @@ function normalizeOptions(opts: Partial<FieldOptions> | undefined): FieldOptions
     rules: '',
     disabled: false,
     form,
+    label: name,
   });
 
   if (!opts) {

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -158,6 +158,9 @@ async function _test(field: FieldValidationContext, value: any, rule: { name: st
  */
 function _generateFieldError(fieldCtx: FieldContext) {
   const message = getConfig().generateMessage;
+  if (!message) {
+    return 'Field is invalid';
+  }
 
   return message(fieldCtx);
 }

--- a/packages/core/tests/Field.spec.ts
+++ b/packages/core/tests/Field.spec.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
     validateOnChange: true,
     validateOnInput: false,
     validateOnModelUpdate: true,
+    generateMessage: undefined,
   });
 });
 
@@ -639,5 +640,32 @@ describe('<Field />', () => {
     dispatchEvent(input, 'input');
     await flushPromises();
     expect(error.textContent).toBe(REQUIRED_MESSAGE);
+  });
+
+  test('can show custom labels for fields in messages', async () => {
+    configure({
+      generateMessage: ({ field }) => `${field} is bad`,
+    });
+
+    defineRule('noMessage', value => {
+      return value === 48;
+    });
+
+    const wrapper = mountWithHoc({
+      template: `
+      <div>
+        <Field name="_bad_field_name" label="nice name" rules="noMessage" v-slot="{ field, errors }">
+          <input v-bind="field" type="text">
+          <span id="error">{{ errors[0] }}</span>
+        </Field>
+      </div>
+    `,
+    });
+
+    const error = wrapper.$el.querySelector('#error');
+    const input = wrapper.$el.querySelector('input');
+    setValue(input, '3');
+    await flushPromises();
+    expect(error.textContent).toBe('nice name is bad');
   });
 });


### PR DESCRIPTION
This PR adds a `label` prop on the `Field` component to allow renaming fields.


closes #2831 