### PR TITLE
fix: prevent recursive re-render model update

### DIFF
--- a/packages/core/src/Field.ts
+++ b/packages/core/src/Field.ts
@@ -66,6 +66,7 @@ export const Field = defineComponent({
       // Only for checkboxes and radio buttons
       valueProp: ctx.attrs.value,
       label: props.label || props.name,
+      validateOnValueUpdate: false,
     });
 
     // If there is a v-model applied on the component we need to emit the `update:modelValue` whenever the value binding changes

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -163,6 +163,14 @@ export function useForm(opts?: FormOptions) {
 
   const errors = computed(() => {
     return activeFields.value.reduce((acc: Record<string, string>, field) => {
+      // Check if its a grouped field (checkbox/radio)
+      if (Array.isArray(fieldsById.value[field.name])) {
+        const group = fieldsById.value[field.name];
+        acc[field.name] = unwrap((group.find((f: any) => unwrap(f.checked)) || field).errorMessage);
+
+        return acc;
+      }
+
       acc[field.name] = unwrap(field.errorMessage);
 
       return acc;

--- a/packages/core/tests/useField.spec.ts
+++ b/packages/core/tests/useField.spec.ts
@@ -1,0 +1,30 @@
+import flushPromises from 'flush-promises';
+import { useField } from '@vee-validate/core';
+import { mountWithHoc, setValue } from './helpers';
+
+describe('useField()', () => {
+  const REQUIRED_MESSAGE = 'Field is required';
+  test('validates when value changes', async () => {
+    mountWithHoc({
+      setup() {
+        const { value, errorMessage } = useField('field', val => (val ? true : REQUIRED_MESSAGE));
+
+        return {
+          value,
+          errorMessage,
+        };
+      },
+      template: `
+      <input name="field" v-model="value" />
+      <span>{{ errorMessage }}</span>
+    `,
+    });
+
+    const input = document.querySelector('input');
+    const error = document.querySelector('span');
+
+    setValue(input as any, '');
+    await flushPromises();
+    expect(error?.textContent).toBe(REQUIRED_MESSAGE);
+  });
+});


### PR DESCRIPTION
This PR introduces a simple re-render lock in the `<Field />` component to prevent model updates if the most recent update was caused by a value change


closes #2941 