### PR TITLE
feat: reactive initial form values

### DIFF
--- a/docs/content/guide/handling-forms.md
+++ b/docs/content/guide/handling-forms.md
@@ -370,4 +370,14 @@ Doing so will trigger initial validation on the form and it will generate messag
 
 You can use `validateOnMount` prop present on the `<Form />` component to force an initial validation when the component is mounted.
 
+The `initialValues` prop on both the `<Form />` component and `useForm()` function can reactive value, meaning you can change the initial values after your component was created/mounted which is very useful if you are populating form fields from external API.
+
+Note that **only the pristine fields will be updated**. In other words, **only the fields that were not manipulated by the user will be updated**.
+
+<doc-tip title="Composition API">
+
+If you are using the composition API with `setup` function, you could create the `initialValues` prop using both [**reactive()**](https://v3.vuejs.org/api/basic-reactivity.html#reactive) and [**ref()**](https://v3.vuejs.org/api/refs-api.html#ref). vee-validate handles both cases.
+
+</doc-tip>
+
 <script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/packages/core/src/Form.ts
+++ b/packages/core/src/Form.ts
@@ -1,4 +1,4 @@
-import { h, defineComponent } from 'vue';
+import { h, defineComponent, toRef } from 'vue';
 import { useForm } from './useForm';
 import { SubmissionHandler } from './types';
 import { normalizeChildren } from './utils';
@@ -25,9 +25,10 @@ export const Form = defineComponent({
     },
   },
   setup(props, ctx) {
+    const initialValues = toRef(props, 'initialValues');
     const { errors, validate, handleSubmit, handleReset, values, meta, isSubmitting, submitForm } = useForm({
       validationSchema: props.validationSchema,
-      initialValues: props.initialValues,
+      initialValues,
       validateOnMount: props.validateOnMount,
     });
 

--- a/packages/core/src/useField.ts
+++ b/packages/core/src/useField.ts
@@ -244,7 +244,7 @@ function useValidationState({
 }) {
   const errors: Ref<string[]> = ref([]);
   const { reset: resetFlags, meta } = useMeta();
-  const initialValue = getFromPath(inject(FormInitialValues, {}), name) ?? initValue;
+  const initialValue = getFromPath(unwrap(inject(FormInitialValues, {})), name) ?? initValue;
   const value = useFieldValue(initialValue, name, form);
   if (hasCheckedAttr(type) && initialValue) {
     value.value = initialValue;

--- a/packages/core/src/utils/common.ts
+++ b/packages/core/src/utils/common.ts
@@ -16,6 +16,10 @@ function cleanupNonNestedPath(path: string) {
  * Gets a nested property value from an object
  */
 export function getFromPath(object: Record<string, any>, path: string): any {
+  if (!object) {
+    return undefined;
+  }
+
   if (isNotNestedPath(path)) {
     return object[cleanupNonNestedPath(path)];
   }


### PR DESCRIPTION
🔎 __Overview__

The `initialValues` on `Form` and `useForm` is not reactive, which limits it's usefulness. For example, fetching data from an API then populating the form won't be possible.

This PR allows the `initialValues` prop to be reactive and will only update the `pristine` fields (non-dirty) to avoid resetting the values each time.