### PR TITLE
chore: added docs deploy script

### DIFF
--- a/docs/content/api/use-form.md
+++ b/docs/content/api/use-form.md
@@ -96,5 +96,7 @@ type useForm = (
   handleReset: (e: Event) => void; // Resets all fields' errors and meta
   handleSubmit: (cb: Function) => () => void; // Creates a submission handler that calls the cb only after successful validation with the form values
   submitForm: (e: Event) => void; // Forces submission of a form after successful validation (calls e.target.submit())
+  setErrors: (errors: Record<string, string>) => void; // Sets error messages for fields
+  setFieldError: (field: string, errorMessage: string) => void; // Sets an error message for a field
 };
 ```

--- a/docs/content/guide/handling-forms.md
+++ b/docs/content/guide/handling-forms.md
@@ -380,4 +380,113 @@ If you are using the composition API with `setup` function, you could create the
 
 </doc-tip>
 
+## Setting Errors Manually
+
+Quite often you will find yourself unable to replicate some validation rules on the client-side due to natural limitations. For example a `unique` email validation is complex to implement on the client-side, which is why the `<Form />` component and `useForm()` function allow you to set errors manually.
+
+You can set messages for fields by using either `setFieldError` which sets an error message for one field at a time, and the `setErrors` function which allows you set error messages for multiple fields at once.
+
+Both functions are available as a return value from `useForm` and on the `Form` component scoped slot props, and also on the `Form` component instance which enables you to use it with template `$refs`, and also for added convenience on the `submit` event handler since it would be the most common place for its usage.
+
+Here are a few snippets showcasing it's usage in these various scenarios:
+
+**Using scoped slot props (recommended)**
+
+```vue
+<Form v-slot="{ setFieldError, setErrors }">
+  <Field name="email" as="input">
+  <ErrorMessage name="email" />
+
+  <Field name="password" as="input">
+  <ErrorMessage name="password" />
+
+  <button type="button" @click="setFieldError('email', 'nope')">Set Single Error</button>
+  <button type="button" @click="setErrors({ email: 'nope', password: 'wrong' })">
+    Set Multiple Errors
+  </button>
+</Form>
+```
+
+**Using submit callback (recommended)**
+
+```vue
+<template>
+<Form @submit="onSubmit">
+  <Field name="email" as="input">
+  <ErrorMessage name="email" />
+
+  <Field name="password" as="input">
+  <ErrorMessage name="password" />
+
+  <button>Submit</button>
+</Form>
+</template>
+
+<script>
+export default {
+  // ...
+  methods :{
+    onSubmit(values, { form }) {
+      // Submit the values...
+
+      // set single field error
+      form.setFieldError('email', 'this email is already taken');
+
+      // set multiple errors
+      form.setErrors({
+        email: 'this field is already taken',
+        password: 'someone already has this password',
+      });
+    }
+  }
+};
+</script>
+```
+
+**Using template `$refs`**
+
+```vue
+<template>
+<Form @submit="onSubmit" ref="myForm">
+  <Field name="email" as="input">
+  <ErrorMessage name="email" />
+
+  <Field name="password" as="input">
+  <ErrorMessage name="password" />
+
+  <button>Submit</button>
+</Form>
+</template>
+
+<script>
+export default {
+  // ...
+  methods :{
+    onSubmit(values) {
+      // Submit the values...
+
+      // if API returns errors
+      this.$refs.myForm.setFieldError('email', 'this email is already taken');
+      this.$refs.myForm.setErrors({
+        email: 'this field is already taken',
+        password: 'someone already has this password',
+      });
+    }
+  }
+};
+</script>
+```
+
+<doc-tip title="Avoid Template $refs" type="warn">
+
+Always try to avoid using the template `$refs` to gain access to the `<Form />` component methods, template `$refs` are designed to be an escape hatch of sorts when all else fails.
+
+So treat them as such and don't reach out for template `$refs` if you can help it.
+
+</doc-tip>
+
+**With useForm composable**
+
+For information on how to use `setErrors` and `setFieldError` with `useForm` composable function, [check the API reference](/api/use-form)
+
 <script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/packages/core/src/Form.ts
+++ b/packages/core/src/Form.ts
@@ -51,7 +51,16 @@ export const Form = defineComponent({
       }
     }
 
-    return () => {
+    return function renderForm(this: any) {
+      // FIXME: Hacky but cute way to expose some stuff to the rendered instance
+      // getCurrentInstance doesn't work with render fns, it returns the wrong instance
+      // we want to expose setFieldError and setErrors
+      if (!this.setErrors) {
+        console.log('Setting it');
+        this.setFieldError = setFieldError;
+        this.setErrors = setErrors;
+      }
+
       const children = normalizeChildren(ctx, {
         meta: meta.value,
         errors: errors.value,

--- a/packages/core/src/Form.ts
+++ b/packages/core/src/Form.ts
@@ -56,7 +56,6 @@ export const Form = defineComponent({
       // getCurrentInstance doesn't work with render fns, it returns the wrong instance
       // we want to expose setFieldError and setErrors
       if (!this.setErrors) {
-        console.log('Setting it');
         this.setFieldError = setFieldError;
         this.setErrors = setErrors;
       }

--- a/packages/core/src/Form.ts
+++ b/packages/core/src/Form.ts
@@ -26,7 +26,18 @@ export const Form = defineComponent({
   },
   setup(props, ctx) {
     const initialValues = toRef(props, 'initialValues');
-    const { errors, validate, handleSubmit, handleReset, values, meta, isSubmitting, submitForm } = useForm({
+    const {
+      errors,
+      validate,
+      handleSubmit,
+      handleReset,
+      values,
+      meta,
+      isSubmitting,
+      submitForm,
+      setErrors,
+      setFieldError,
+    } = useForm({
       validationSchema: props.validationSchema,
       initialValues,
       validateOnMount: props.validateOnMount,
@@ -50,6 +61,8 @@ export const Form = defineComponent({
         handleSubmit,
         handleReset,
         submitForm,
+        setErrors,
+        setFieldError,
       });
 
       if (!props.as) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -33,8 +33,6 @@ export type MaybeReactive<T> = Ref<T> | ComputedRef<T> | T;
 
 export type SubmitEvent = Event & { target: HTMLFormElement };
 
-export type SubmissionHandler = (values: Record<string, any>, evt?: SubmitEvent) => any;
-
 export type GenericValidateFunction = (value: any) => boolean | string | Promise<boolean | string>;
 
 export type Flag =
@@ -58,4 +56,10 @@ export interface FormController {
   schema?: Record<string, GenericValidateFunction | string | Record<string, any>>;
   validateSchema?: (shouldMutate?: boolean) => Promise<Record<string, ValidationResult>>;
   setFieldValue: (path: string, value: any) => void;
+  setFieldError: (field: string, message: string) => void;
+  setErrors: (errors: Record<string, string>) => void;
 }
+
+type SubmissionContext = { evt: SubmitEvent; form: FormController };
+
+export type SubmissionHandler = (values: Record<string, any>, ctx: SubmissionContext) => any;

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -57,13 +57,16 @@ export function useForm(opts?: FormOptions) {
    * Manually sets an error message on a specific field
    */
   function setFieldError(field: string, message: string) {
-    let fieldInstance = fieldsById.value[field];
+    const fieldInstance = fieldsById.value[field];
     if (!fieldInstance) {
       return;
     }
 
     if (Array.isArray(fieldInstance)) {
-      fieldInstance = fieldInstance[0];
+      fieldInstance.forEach(instance => {
+        instance.setValidationState({ errors: [message] });
+      });
+      return;
     }
 
     fieldInstance.setValidationState({ errors: [message] });

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -242,11 +242,37 @@ export function useForm(opts?: FormOptions) {
     }
   );
 
+  // Trigger initial validation
   onMounted(() => {
     if (opts?.validateOnMount) {
       validate();
     }
   });
+
+  /**
+   * Manually sets an error message on a specific field
+   */
+  function setFieldError(field: string, message: string) {
+    let fieldInstance = fieldsById.value[field];
+    if (!fieldInstance) {
+      return;
+    }
+
+    if (Array.isArray(fieldInstance)) {
+      fieldInstance = fieldInstance[0];
+    }
+
+    fieldInstance.setValidationState({ errors: [message] });
+  }
+
+  /**
+   * Sets errors for the fields specified in the object
+   */
+  function setErrors(fields: Record<string, string>) {
+    Object.keys(fields).forEach(field => {
+      setFieldError(field, fields[field]);
+    });
+  }
 
   return {
     errors,
@@ -258,6 +284,8 @@ export function useForm(opts?: FormOptions) {
     handleReset,
     handleSubmit,
     submitForm,
+    setFieldError,
+    setErrors,
   };
 }
 

--- a/packages/core/tests/Form.spec.ts
+++ b/packages/core/tests/Form.spec.ts
@@ -1196,4 +1196,24 @@ describe('<Form />', () => {
     expect(emailError.textContent).toBe('WRONG');
     expect(passwordError.textContent).toBe('WRONG AGAIN');
   });
+
+  test('sets error message with setFieldError for checkboxes', async () => {
+    const wrapper = mountWithHoc({
+      template: `
+      <VForm ref="form" v-slot="{ errors }">
+        <Field name="drink" type="checkbox" value="" /> Coffee
+        <Field name="drink" type="checkbox" value="Tea" /> Tea
+        <Field name="drink" type="checkbox" value="Coke" /> Coke
+
+        <span id="err">{{ errors.drink }}</span>
+      </VForm>
+    `,
+    });
+
+    await flushPromises();
+    const error = wrapper.$el.querySelector('#err');
+    (wrapper.$refs as any)?.form.setFieldError('drink', 'WRONG');
+    await flushPromises();
+    expect(error.textContent).toBe('WRONG');
+  });
 });

--- a/packages/core/tests/Form.spec.ts
+++ b/packages/core/tests/Form.spec.ts
@@ -1151,4 +1151,49 @@ describe('<Form />', () => {
     expect(emailError.textContent).toBe('email is a required field');
     expect(passwordError.textContent).toBe('password is a required field');
   });
+
+  test('sets individual field error message with setFieldError()', async () => {
+    const wrapper = mountWithHoc({
+      template: `
+      <VForm ref="form" v-slot="{ errors }">
+        <Field id="email" name="email" as="input" />
+        <span id="emailErr">{{ errors.email }}</span>
+      </VForm>
+    `,
+    });
+
+    await flushPromises();
+    const emailError = wrapper.$el.querySelector('#emailErr');
+    (wrapper.$refs as any)?.form.setFieldError('email', 'WRONG');
+    await flushPromises();
+
+    expect(emailError.textContent).toBe('WRONG');
+  });
+
+  test('sets multiple field error messages with setErrors()', async () => {
+    const wrapper = mountWithHoc({
+      template: `
+      <VForm ref="form" v-slot="{ errors }">
+        <Field id="email" name="email" as="input" />
+        <span id="emailErr">{{ errors.email }}</span>
+
+        <Field id="password" name="password" as="input" type="password" />
+        <span id="passwordErr">{{ errors.password }}</span>
+      </VForm>
+    `,
+    });
+
+    await flushPromises();
+    const emailError = wrapper.$el.querySelector('#emailErr');
+    const passwordError = wrapper.$el.querySelector('#passwordErr');
+
+    (wrapper.$refs as any)?.form.setErrors({
+      email: 'WRONG',
+      password: 'WRONG AGAIN',
+    });
+    await flushPromises();
+
+    expect(emailError.textContent).toBe('WRONG');
+    expect(passwordError.textContent).toBe('WRONG AGAIN');
+  });
 });

--- a/packages/core/tests/useForm.spec.ts
+++ b/packages/core/tests/useForm.spec.ts
@@ -1,0 +1,62 @@
+import flushPromises from 'flush-promises';
+import { useField, useForm } from '@vee-validate/core';
+import { mountWithHoc } from './helpers';
+
+describe('useForm()', () => {
+  const REQUIRED_MESSAGE = 'Field is required';
+
+  test('sets individual field errors', async () => {
+    mountWithHoc({
+      setup() {
+        const { setFieldError } = useForm();
+        const { errorMessage } = useField('field', val => (val ? true : REQUIRED_MESSAGE));
+
+        return {
+          errorMessage,
+          setFieldError,
+        };
+      },
+      template: `
+      <span>{{ errorMessage }}</span>
+      <button @click="setFieldError('field', 'WRONG')">Set Field Error</button>
+    `,
+    });
+
+    const error = document.querySelector('span');
+    await flushPromises();
+    expect(error?.textContent).toBe('');
+    document.querySelector('button')?.click();
+    await flushPromises();
+    expect(error?.textContent).toBe('WRONG');
+  });
+
+  test('sets multiple field errors', async () => {
+    mountWithHoc({
+      setup() {
+        const { setErrors } = useForm();
+        const { errorMessage: err1 } = useField('field1', val => (val ? true : REQUIRED_MESSAGE));
+        const { errorMessage: err2 } = useField('field2', val => (val ? true : REQUIRED_MESSAGE));
+
+        return {
+          err1,
+          err2,
+          setErrors,
+        };
+      },
+      template: `
+      <span>{{ err1 }}</span>
+      <span>{{ err2 }}</span>
+      <button @click="setErrors({ field1: 'WRONG', field2: 'WRONG AGAIN' })">Set Field Error</button>
+    `,
+    });
+
+    const errors = document.querySelectorAll('span');
+    await flushPromises();
+    expect(errors[0]?.textContent).toBe('');
+    expect(errors[1]?.textContent).toBe('');
+    document.querySelector('button')?.click();
+    await flushPromises();
+    expect(errors[0]?.textContent).toBe('WRONG');
+    expect(errors[1]?.textContent).toBe('WRONG AGAIN');
+  });
+});

--- a/packages/core/tests/useForm.spec.ts
+++ b/packages/core/tests/useForm.spec.ts
@@ -46,7 +46,7 @@ describe('useForm()', () => {
       template: `
       <span>{{ err1 }}</span>
       <span>{{ err2 }}</span>
-      <button @click="setErrors({ field1: 'WRONG', field2: 'WRONG AGAIN' })">Set Field Error</button>
+      <button @click="setErrors({ field1: 'WRONG', field2: 'WRONG AGAIN', field3: 'huh' })">Set Field Error</button>
     `,
     });
 

--- a/packages/core/tests/useForm.spec.ts
+++ b/packages/core/tests/useForm.spec.ts
@@ -5,7 +5,7 @@ import { mountWithHoc } from './helpers';
 describe('useForm()', () => {
   const REQUIRED_MESSAGE = 'Field is required';
 
-  test('sets individual field errors', async () => {
+  test('sets individual field error message', async () => {
     mountWithHoc({
       setup() {
         const { setFieldError } = useForm();
@@ -30,7 +30,7 @@ describe('useForm()', () => {
     expect(error?.textContent).toBe('WRONG');
   });
 
-  test('sets multiple field errors', async () => {
+  test('sets multiple field error messages', async () => {
     mountWithHoc({
       setup() {
         const { setErrors } = useForm();


### PR DESCRIPTION
🔎 __Overview__

Currently there is no way to set the fields errors without using `useField`.

This PR adds two new functions:

- `setFieldError`: sets a single field error message
- `setErrors`: sets error messages for multiple fields

Both of these methods are available on the scoped slot props of the `<Form />` component and return value of `useForm` and in the submission callback and as instance methods (with template `$refs`)