### PR TITLE
feat: new meta tags API

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,15 +16,9 @@ export type KnownKeys<T> = {
   : never;
 
 export interface ValidationFlags {
-  untouched: boolean;
   touched: boolean;
   dirty: boolean;
-  pristine: boolean;
   valid: boolean;
-  invalid: boolean;
-  passed: boolean;
-  failed: boolean;
-  validated: boolean;
   pending: boolean;
   changed: boolean;
 }
@@ -35,18 +29,7 @@ export type SubmitEvent = Event & { target: HTMLFormElement };
 
 export type GenericValidateFunction = (value: any) => boolean | string | Promise<boolean | string>;
 
-export type Flag =
-  | 'untouched'
-  | 'touched'
-  | 'dirty'
-  | 'pristine'
-  | 'valid'
-  | 'invalid'
-  | 'passed'
-  | 'failed'
-  | 'validated'
-  | 'pending'
-  | 'changed';
+export type Flag = keyof ValidationFlags;
 
 export interface FormController {
   register(field: any): void;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,12 +15,12 @@ export type KnownKeys<T> = {
   ? U
   : never;
 
-export interface ValidationFlags {
+export interface FieldMeta {
   touched: boolean;
   dirty: boolean;
   valid: boolean;
   pending: boolean;
-  changed: boolean;
+  initialValue?: any;
 }
 
 export type MaybeReactive<T> = Ref<T> | ComputedRef<T> | T;
@@ -28,8 +28,6 @@ export type MaybeReactive<T> = Ref<T> | ComputedRef<T> | T;
 export type SubmitEvent = Event & { target: HTMLFormElement };
 
 export type GenericValidateFunction = (value: any) => boolean | string | Promise<boolean | string>;
-
-export type Flag = keyof ValidationFlags;
 
 export interface FormController {
   register(field: any): void;

--- a/packages/core/src/useField.ts
+++ b/packages/core/src/useField.ts
@@ -44,7 +44,7 @@ export function useField(name: string, rules: RuleExpression, opts?: Partial<Fie
     validateOnValueUpdate,
   } = normalizeOptions(name, opts);
 
-  const { meta, errors, handleBlur, handleInput, reset, patch, value, checked } = useValidationState({
+  const { meta, errors, handleBlur, handleInput, reset, setValidationState, value, checked } = useValidationState({
     name,
     // make sure to unwrap initial value because of possible refs passed in
     initValue: unwrap(initialValue),
@@ -73,7 +73,7 @@ export function useField(name: string, rules: RuleExpression, opts?: Partial<Fie
 
     meta.pending = false;
 
-    return patch(result);
+    return setValidationState(result);
   };
 
   // Common input/change event handler
@@ -113,7 +113,7 @@ export function useField(name: string, rules: RuleExpression, opts?: Partial<Fie
     handleChange,
     handleBlur,
     handleInput,
-    setValidationState: patch,
+    setValidationState,
   };
 
   if (validateOnValueUpdate) {
@@ -262,7 +262,7 @@ function useValidationState({
   };
 
   // Updates the validation state with the validation result
-  function patch(result: ValidationResult) {
+  function setValidationState(result: ValidationResult) {
     errors.value = result.errors;
     meta.valid = !result.errors.length;
 
@@ -278,7 +278,7 @@ function useValidationState({
   return {
     meta,
     errors,
-    patch,
+    setValidationState,
     reset,
     handleBlur,
     handleInput,

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -194,17 +194,14 @@ export function useForm(opts?: FormOptions) {
   const errors = computed(() => {
     return activeFields.value.reduce((acc: Record<string, string>, field) => {
       // Check if its a grouped field (checkbox/radio)
+      let message: string | undefined;
       if (Array.isArray(fieldsById.value[field.name])) {
         const group = fieldsById.value[field.name];
-        const message = unwrap((group.find((f: any) => unwrap(f.checked)) || field).errorMessage);
-        if (message) {
-          acc[field.name] = message;
-        }
-
-        return acc;
+        message = unwrap((group.find((f: any) => unwrap(f.checked)) || field).errorMessage);
+      } else {
+        message = unwrap(field.errorMessage);
       }
 
-      const message = unwrap(field.errorMessage);
       if (message) {
         acc[field.name] = message;
       }

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -320,16 +320,10 @@ export function useForm(opts?: FormOptions) {
 
 const MERGE_STRATEGIES: Record<Flag, 'every' | 'some'> = {
   valid: 'every',
-  invalid: 'some',
   dirty: 'some',
-  pristine: 'every',
   touched: 'some',
-  untouched: 'every',
   pending: 'some',
-  validated: 'every',
   changed: 'some',
-  passed: 'every',
-  failed: 'some',
 };
 
 function useFormMeta(fields: Ref<any[]>) {
@@ -380,7 +374,7 @@ async function validateYupSchema(
 
     result[fieldId] = fieldResult;
     const isGroup = Array.isArray(field);
-    const touched = isGroup ? field.some((f: any) => f.meta.validated) : field.meta.validated;
+    const touched = isGroup ? field.some((f: any) => f.meta.dirty) : field.meta.dirty;
     if (!shouldMutate && !touched) {
       return result;
     }

--- a/packages/core/src/utils/common.ts
+++ b/packages/core/src/utils/common.ts
@@ -112,3 +112,10 @@ export function unsetPath(object: Record<string, any>, path: string): void {
     unset(pathValues[i - 1], keys[i - 1]);
   }
 }
+
+/**
+ * A typed version of Object.keys
+ */
+export function keysOf<TRecord extends Record<string, any>>(record: TRecord): (keyof TRecord)[] {
+  return Object.keys(record);
+}

--- a/packages/core/tests/Field.spec.ts
+++ b/packages/core/tests/Field.spec.ts
@@ -153,17 +153,14 @@ describe('<Field />', () => {
     const input = wrapper.$el.querySelector('input');
     const pre = wrapper.$el.querySelector('pre');
 
-    expect(pre.textContent).toContain('"untouched": true');
-    expect(pre.textContent).toContain('"pristine": true');
+    expect(pre.textContent).toContain('"touched": false');
+    expect(pre.textContent).toContain('"dirty": false');
     dispatchEvent(input, 'blur');
     await flushPromises();
     expect(pre.textContent).toContain('"touched": true');
-    expect(pre.textContent).toContain('"untouched": false');
-    expect(pre.textContent).toContain('"pristine": true');
+    expect(pre.textContent).toContain('"dirty": false');
     dispatchEvent(input, 'input');
     await flushPromises();
-    // eslint-disable-next-line jest/valid-expect
-    expect(pre.textContent).toContain('"pristine": false');
     expect(pre.textContent).toContain('"dirty": true');
   });
 

--- a/packages/core/tests/Form.spec.ts
+++ b/packages/core/tests/Form.spec.ts
@@ -973,7 +973,7 @@ describe('<Form />', () => {
       <VForm v-slot="{ meta }">
         <Field name="field" as="input" rules="required"  />
 
-        <button :disabled="meta.invalid" id="submit">Submit</button>
+        <button :disabled="!meta.valid" id="submit">Submit</button>
       </VForm>
     `,
     });


### PR DESCRIPTION
🔎 __Overview__

The meta tags API wasn't updated or revised since v2 releases. Here are the various problems I see with it:

- Redundant opposite flags (vaid x invalid, dirty x pristine, touched x untouched)
- Confusing flags `valid` vs `passed` and `invalid` vs `failed`
- Some flags are impossible to be accurate (`changed`) which will make immutable fields with arrays or objects as values impossible to be accurate.
- Possibly remove the `valid` flag, you can always check error messages as an alternative

#### opposite flags

The new API removes a bunch of flags: `untouched`, `pristine`, `invalid`, `passed`, `failed`, `validated`, and `changed`. All of these flags information can be inferred from their opposite one and a combination of one or more.

#### Combined flags

For example, the `passed` flag is just `dirty` and `valid`, `changed` is a simple comparison of the initial value and current value. And for complex fields, you can use 3rd party libraries for recursive comparisons.

#### `valid` flag

Also, there is the topic of the initial `valid` flag, the problem with this flag is that it is confusing to use. I've found myself using the error message to check if a field is valid or not rather than `valid`. Because initially, you could have an invalid field but since no validation was done it is impossible to tell. 

So we actually have 3 states, `false`, `true`, and `undefined` as in we don't know yet. This is also problematic because `undefined` and `false` work pretty much the same as they are both falsy values. So introducing `undefined` like in `v2` will be very confusing.

So checking for error messages works for all purposes of the naive `valid` flag.

I'm now considering between removing the `valid` flag completely and changing its behavior to work like `passed` to make it more accurate, but that would make the two states `false` and `undefined` both as `false` so users of the library must be aware of that caveat.