### PR TITLE
fix: improve useForm meta types

### DIFF
--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -1,4 +1,4 @@
-import { computed, ref, Ref, provide, reactive, onMounted, isRef, watch } from 'vue';
+import { computed, ref, Ref, provide, reactive, onMounted, isRef, watch, ComputedRef } from 'vue';
 import type { ValidationError } from 'yup';
 import type { useField } from './useField';
 import {
@@ -321,14 +321,17 @@ const MERGE_STRATEGIES: Record<keyof Omit<FieldMeta, 'initialValue'>, 'every' | 
   pending: 'some',
 };
 
-function useFormMeta(fields: Ref<any[]>, initialValues: MaybeReactive<Record<string, any>>) {
+function useFormMeta(
+  fields: Ref<any[]>,
+  initialValues: MaybeReactive<Record<string, any>>
+): ComputedRef<FieldMeta & { initialValues: Record<string, any> }> {
   return computed(() => {
     const flags = keysOf(MERGE_STRATEGIES).reduce((acc, flag) => {
       const mergeMethod = MERGE_STRATEGIES[flag];
       acc[flag] = fields.value[mergeMethod](field => field.meta[flag]);
 
       return acc;
-    }, {} as Record<string, boolean>);
+    }, {} as Record<keyof Omit<FieldMeta, 'initialValue'>, boolean>);
 
     return {
       initialValues: unwrap(initialValues),


### PR DESCRIPTION
🔎 __Overview__

Currently the type of `meta` returned by `useForm` is not accurate.

For example in beta 8, we have:

```typescript
meta: ComputedRef<{
  initialValues: Record<string, any>;
}>;
```

This commit should improve the typings to:
```typescript
meta: ComputedRef<{
  valid: boolean;
  dirty: boolean;
  touched: boolean;
  pending: boolean;
  initialValues: Record<string, any>;
}>;
```


