### PR TITLE
feat: meta setters

### DIFF
--- a/docs/content/api/field.md
+++ b/docs/content/api/field.md
@@ -208,6 +208,22 @@ It sets the `touched` meta flag to true
 
 Because this handler doesn't set the field value, it might not report validation correctly if other events are unspecified or disabled.
 
+<code-title level="4">
+
+`setDirty: (isDirty: boolean) => void`
+
+</code-title>
+
+Sets the `dirty` meta flag for this field, useful to create your own `input` or other behaviors handlers
+
+<code-title level="4">
+
+`setTouched: (isTouched: boolean) => void`
+
+</code-title>
+
+Sets the `touched` meta flag for this field, useful to create your own `blur` handlers
+
 #### `field`
 
 Contains a few properties that you can use `v-bind` with to get all vee-validate features on that input. The following is a description of the properties

--- a/docs/content/api/form.md
+++ b/docs/content/api/form.md
@@ -201,6 +201,38 @@ Sets multiple fields values, will trigger validation for all the changed fields.
 
 <code-title level="4">
 
+`setFieldDirty: (field: string, isDirty: boolean) => void`
+
+</code-title>
+
+Sets a field's `dirty` meta flag
+
+<code-title level="4">
+
+`setDirty: (fields: Record<string, boolean>) => void`
+
+</code-title>
+
+Sets multiple fields `dirty` meta flag, does not validate.
+
+<code-title level="4">
+
+`setFieldTouched: (field: string, isTouched: boolean) => void`
+
+</code-title>
+
+Sets a field's `touched` meta flag
+
+<code-title level="4">
+
+`setTouched: (fields: Record<string, boolean>) => void`
+
+</code-title>
+
+Sets multiple fields `touched` meta flag, does not validate.
+
+<code-title level="4">
+
 `validate: () => Promise<boolean>`
 
 </code-title>

--- a/docs/content/api/use-field.md
+++ b/docs/content/api/use-field.md
@@ -361,3 +361,33 @@ setValidationState({ errors: ['something is not right'] });
 // set the field as valid and clears errors
 setValidationState({ errors: [] });
 ```
+
+<code-title level="4">
+
+`setDirty: (isDirty: boolean) => void`
+
+</code-title>
+
+Sets the `dirty` meta flag for this field, useful to create your own `input` or other behaviors handlers
+
+```js
+const { setDirty } = useField('field', value => !!value);
+
+// mark the field as dirty
+setDirty(true);
+```
+
+<code-title level="4">
+
+`setTouched: (isTouched: boolean) => void`
+
+</code-title>
+
+Sets the `touched` meta flag for this field, useful to create your own `blur` handlers
+
+```js
+const { setTouched } = useField('field', value => !!value);
+
+// mark the field as touched
+setTouched(true);
+```

--- a/docs/content/api/use-form.md
+++ b/docs/content/api/use-form.md
@@ -222,6 +222,68 @@ setValues({
 
 <code-title level="4">
 
+`setFieldDirty: (field: string, isDirty: boolean) => void`
+
+</code-title>
+
+Sets a field's `dirty` meta flag
+
+```js
+const { setFieldDirty } = useForm();
+
+setFieldDirty('email', true);
+```
+
+<code-title level="4">
+
+`setDirty: (fields: Record<string, boolean>) => void`
+
+</code-title>
+
+Sets multiple fields `dirty` meta flag, does not validate.
+
+```js
+const { setDirty } = useForm();
+
+setDirty({
+  email: true,
+  password: false,
+});
+```
+
+<code-title level="4">
+
+`setFieldTouched: (field: string, isTouched: boolean) => void`
+
+</code-title>
+
+Sets a field's `touched` meta flag
+
+```js
+const { setFieldTouched } = useForm();
+
+setFieldTouched('email', true);
+```
+
+<code-title level="4">
+
+`setTouched: (fields: Record<string, boolean>) => void`
+
+</code-title>
+
+Sets multiple fields `touched` meta flag, does not validate.
+
+```js
+const { setTouched } = useForm();
+
+setTouched({
+  email: true,
+  password: false,
+});
+```
+
+<code-title level="4">
+
 `validate: () => Promise<boolean>`
 
 </code-title>

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lint-staged": "^10.3.0",
     "prettier": "^2.1.1",
     "raf-stub": "^3.0.0",
-    "rollup": "^2.29.0",
+    "rollup": "^2.30.0",
     "rollup-plugin-dts": "^1.4.12",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-replace": "^2.2.0",

--- a/packages/core/src/Field.ts
+++ b/packages/core/src/Field.ts
@@ -47,6 +47,8 @@ export const Field = defineComponent({
       handleChange,
       handleBlur,
       handleInput,
+      setDirty,
+      setTouched,
       reset,
       meta,
       checked,
@@ -140,6 +142,8 @@ export const Field = defineComponent({
         handleChange: onChangeHandler,
         handleInput: onInputHandler,
         handleBlur,
+        setDirty,
+        setTouched,
       };
     };
 

--- a/packages/core/src/Form.ts
+++ b/packages/core/src/Form.ts
@@ -39,6 +39,10 @@ export const Form = defineComponent({
       setFieldError,
       setFieldValue,
       setValues,
+      setFieldDirty,
+      setDirty,
+      setFieldTouched,
+      setTouched,
     } = useForm({
       validationSchema: props.validationSchema,
       initialValues,
@@ -68,6 +72,10 @@ export const Form = defineComponent({
         this.setErrors = setErrors;
         this.setFieldValue = setFieldValue;
         this.setValues = setValues;
+        this.setFieldDirty = setFieldDirty;
+        this.setDirty = setDirty;
+        this.setFieldTouched = setFieldTouched;
+        this.setTouched = setTouched;
       }
 
       const children = normalizeChildren(ctx, {
@@ -83,6 +91,10 @@ export const Form = defineComponent({
         setFieldError,
         setFieldValue,
         setValues,
+        setFieldDirty,
+        setDirty,
+        setFieldTouched,
+        setTouched,
       });
 
       if (!props.as) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -40,6 +40,10 @@ export interface FormController {
   setFieldError: (field: string, message: string) => void;
   setErrors: (fields: Record<string, string>) => void;
   setValues: (fields: Record<string, any>) => void;
+  setFieldTouched: (field: string, isTouched: boolean) => void;
+  setTouched: (fields: Record<string, boolean>) => void;
+  setFieldDirty: (field: string, isDirty: boolean) => void;
+  setDirty: (fields: Record<string, boolean>) => void;
   reset: () => void;
 }
 

--- a/packages/core/src/useField.ts
+++ b/packages/core/src/useField.ts
@@ -97,6 +97,14 @@ export function useField(name: string, rules: RuleExpression, opts?: Partial<Fie
     return errors.value[0];
   });
 
+  function setTouched(isTouched: boolean) {
+    meta.touched = isTouched;
+  }
+
+  function setDirty(isDirty: boolean) {
+    meta.dirty = isDirty;
+  }
+
   const field = {
     name,
     value: value,
@@ -114,6 +122,8 @@ export function useField(name: string, rules: RuleExpression, opts?: Partial<Fie
     handleBlur,
     handleInput,
     setValidationState,
+    setTouched,
+    setDirty,
   };
 
   if (validateOnValueUpdate) {

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -120,6 +120,10 @@ export function useForm(opts?: FormOptions) {
    */
   function setFieldTouched(field: string, isTouched: boolean) {
     const fieldInstance = fieldsById.value[field];
+    if (!fieldInstance) {
+      return;
+    }
+
     if (Array.isArray(fieldInstance)) {
       fieldInstance.forEach(f => f.setTouched(isTouched));
       return;
@@ -142,6 +146,10 @@ export function useForm(opts?: FormOptions) {
    */
   function setFieldDirty(field: string, isDirty: boolean) {
     const fieldInstance = fieldsById.value[field];
+    if (!fieldInstance) {
+      return;
+    }
+
     if (Array.isArray(fieldInstance)) {
       fieldInstance.forEach(f => f.setDirty(isDirty));
       return;

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -115,6 +115,50 @@ export function useForm(opts?: FormOptions) {
     });
   }
 
+  /**
+   * Sets the touched meta state on a field
+   */
+  function setFieldTouched(field: string, isTouched: boolean) {
+    const fieldInstance = fieldsById.value[field];
+    if (Array.isArray(fieldInstance)) {
+      fieldInstance.forEach(f => f.setTouched(isTouched));
+      return;
+    }
+
+    fieldInstance.setTouched(isTouched);
+  }
+
+  /**
+   * Sets the touched meta state on multiple fields
+   */
+  function setTouched(fields: Record<string, boolean>) {
+    Object.keys(fields).forEach(field => {
+      setFieldTouched(field, fields[field]);
+    });
+  }
+
+  /**
+   * Sets the dirty meta state on a field
+   */
+  function setFieldDirty(field: string, isDirty: boolean) {
+    const fieldInstance = fieldsById.value[field];
+    if (Array.isArray(fieldInstance)) {
+      fieldInstance.forEach(f => f.setDirty(isDirty));
+      return;
+    }
+
+    fieldInstance.setDirty(isDirty);
+  }
+
+  /**
+   * Sets the dirty meta state on multiple fields
+   */
+  function setDirty(fields: Record<string, boolean>) {
+    Object.keys(fields).forEach(field => {
+      setFieldDirty(field, fields[field]);
+    });
+  }
+
   const handleReset = () => {
     fields.value.forEach((f: any) => f.reset());
   };
@@ -172,6 +216,10 @@ export function useForm(opts?: FormOptions) {
     setValues,
     setErrors,
     setFieldError,
+    setFieldTouched,
+    setTouched,
+    setFieldDirty,
+    setDirty,
     reset: handleReset,
   };
 
@@ -311,6 +359,10 @@ export function useForm(opts?: FormOptions) {
     setErrors,
     setFieldValue,
     setValues,
+    setFieldTouched,
+    setTouched,
+    setFieldDirty,
+    setDirty,
   };
 }
 

--- a/packages/core/tests/Field.spec.ts
+++ b/packages/core/tests/Field.spec.ts
@@ -640,4 +640,40 @@ describe('<Field />', () => {
     await flushPromises();
     expect(error.textContent).toBe('nice name is bad');
   });
+
+  test('can set dirty meta', async () => {
+    mountWithHoc({
+      template: `
+      <Field name="field" v-slot="{ meta, setDirty }">
+        <span>{{ meta.dirty }}</span>
+        <button @click="setDirty(true)">Set Meta</button>
+      </Field>
+    `,
+    });
+
+    await flushPromises();
+    const span = document.querySelector('span');
+    expect(span?.textContent).toBe('false');
+    document.querySelector('button')?.click();
+    await flushPromises();
+    expect(span?.textContent).toBe('true');
+  });
+
+  test('can set touched meta', async () => {
+    mountWithHoc({
+      template: `
+      <Field name="field" v-slot="{ meta, setTouched }">
+        <span>{{ meta.touched }}</span>
+        <button @click="setTouched(true)">Set Meta</button>
+      </Field>
+    `,
+    });
+
+    await flushPromises();
+    const span = document.querySelector('span');
+    expect(span?.textContent).toBe('false');
+    document.querySelector('button')?.click();
+    await flushPromises();
+    expect(span?.textContent).toBe('true');
+  });
 });

--- a/packages/core/tests/Form.spec.ts
+++ b/packages/core/tests/Form.spec.ts
@@ -1348,4 +1348,46 @@ describe('<Form />', () => {
     expect(passwordError.textContent).toBe('');
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  test('sets meta touched with setFieldError for checkboxes', async () => {
+    const wrapper = mountWithHoc({
+      template: `
+      <VForm ref="form" v-slot="{ meta }">
+        <Field name="drink" type="checkbox" value="" /> Coffee
+        <Field name="drink" type="checkbox" value="Tea" /> Tea
+        <Field name="drink" type="checkbox" value="Coke" /> Coke
+
+        <span id="meta">{{ meta.touched }}</span>
+      </VForm>
+    `,
+    });
+
+    await flushPromises();
+    const meta = wrapper.$el.querySelector('#meta');
+    expect(meta?.textContent).toBe('false');
+    (wrapper.$refs as any)?.form.setFieldTouched('drink', true);
+    await flushPromises();
+    expect(meta?.textContent).toBe('true');
+  });
+
+  test('sets meta dirty with setFieldError for checkboxes', async () => {
+    const wrapper = mountWithHoc({
+      template: `
+      <VForm ref="form" v-slot="{ meta }">
+        <Field name="drink" type="checkbox" value="" /> Coffee
+        <Field name="drink" type="checkbox" value="Tea" /> Tea
+        <Field name="drink" type="checkbox" value="Coke" /> Coke
+
+        <span id="meta">{{ meta.dirty }}</span>
+      </VForm>
+    `,
+    });
+
+    await flushPromises();
+    const meta = wrapper.$el.querySelector('#meta');
+    expect(meta?.textContent).toBe('false');
+    (wrapper.$refs as any)?.form.setFieldDirty('drink', true);
+    await flushPromises();
+    expect(meta?.textContent).toBe('true');
+  });
 });

--- a/packages/core/tests/useForm.spec.ts
+++ b/packages/core/tests/useForm.spec.ts
@@ -59,4 +59,134 @@ describe('useForm()', () => {
     expect(errors[0]?.textContent).toBe('WRONG');
     expect(errors[1]?.textContent).toBe('WRONG AGAIN');
   });
+
+  test('sets individual field dirty meta', async () => {
+    mountWithHoc({
+      setup() {
+        const { setFieldDirty, meta: formMeta } = useForm();
+        const { meta } = useField('field', val => (val ? true : REQUIRED_MESSAGE));
+
+        return {
+          meta,
+          formMeta,
+          setFieldDirty,
+        };
+      },
+      template: `
+      <span id="field">{{ meta.dirty }}</span>
+      <span id="form">{{ formMeta.dirty }}</span>
+      <button @click="setFieldDirty('field', true)">Set Meta</button>
+    `,
+    });
+
+    const fieldMeta = document.querySelector('#field');
+    const formMeta = document.querySelector('#form');
+    await flushPromises();
+    expect(fieldMeta?.textContent).toBe('false');
+    expect(formMeta?.textContent).toBe('false');
+    document.querySelector('button')?.click();
+    await flushPromises();
+    expect(fieldMeta?.textContent).toBe('true');
+    expect(formMeta?.textContent).toBe('true');
+  });
+
+  test('sets multiple fields dirty meta', async () => {
+    mountWithHoc({
+      setup() {
+        const { setDirty, meta: formMeta } = useForm();
+        const { meta: meta1 } = useField('field1', val => (val ? true : REQUIRED_MESSAGE));
+        const { meta: meta2 } = useField('field2', val => (val ? true : REQUIRED_MESSAGE));
+
+        return {
+          meta1,
+          meta2,
+          formMeta,
+          setDirty,
+        };
+      },
+      template: `
+      <span>{{ meta1.dirty }}</span>
+      <span>{{ meta2.dirty }}</span>
+      <span>{{ formMeta.dirty }}</span>
+      <button @click="setDirty({ field1: true, field2: false, field3: false })">Set Meta</button>
+    `,
+    });
+
+    const meta = document.querySelectorAll('span');
+
+    await flushPromises();
+    expect(meta[0]?.textContent).toBe('false');
+    expect(meta[1]?.textContent).toBe('false');
+    expect(meta[2]?.textContent).toBe('false');
+    document.querySelector('button')?.click();
+    await flushPromises();
+    expect(meta[0]?.textContent).toBe('true');
+    expect(meta[1]?.textContent).toBe('false');
+    expect(meta[2]?.textContent).toBe('true');
+  });
+
+  test('sets individual field touched meta', async () => {
+    mountWithHoc({
+      setup() {
+        const { setFieldTouched, meta: formMeta } = useForm();
+        const { meta } = useField('field', val => (val ? true : REQUIRED_MESSAGE));
+
+        return {
+          meta,
+          formMeta,
+          setFieldTouched,
+        };
+      },
+      template: `
+      <span id="field">{{ meta.touched }}</span>
+      <span id="form">{{ formMeta.touched }}</span>
+      <button @click="setFieldTouched('field', true)">Set Meta</button>
+    `,
+    });
+
+    const fieldMeta = document.querySelector('#field');
+    const formMeta = document.querySelector('#form');
+    await flushPromises();
+    expect(fieldMeta?.textContent).toBe('false');
+    expect(formMeta?.textContent).toBe('false');
+    document.querySelector('button')?.click();
+    await flushPromises();
+    expect(fieldMeta?.textContent).toBe('true');
+    expect(formMeta?.textContent).toBe('true');
+  });
+
+  test('sets multiple fields touched meta', async () => {
+    mountWithHoc({
+      setup() {
+        const { setTouched, meta: formMeta } = useForm();
+        const { meta: meta1 } = useField('field1', val => (val ? true : REQUIRED_MESSAGE));
+        const { meta: meta2 } = useField('field2', val => (val ? true : REQUIRED_MESSAGE));
+
+        return {
+          meta1,
+          meta2,
+          formMeta,
+          setTouched,
+        };
+      },
+      template: `
+      <span>{{ meta1.touched }}</span>
+      <span>{{ meta2.touched }}</span>
+      <span>{{ formMeta.touched }}</span>
+      <button @click="setTouched({ field1: true, field2: false, field3: false })">Set Meta</button>
+    `,
+    });
+
+    const meta = document.querySelectorAll('span');
+
+    await flushPromises();
+    expect(meta[0]?.textContent).toBe('false');
+    expect(meta[1]?.textContent).toBe('false');
+    expect(meta[2]?.textContent).toBe('false');
+    document.querySelector('button')?.click();
+    await flushPromises();
+    expect(meta[0]?.textContent).toBe('true');
+    expect(meta[1]?.textContent).toBe('false');
+    expect(meta[2]?.textContent).toBe('true');
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7326,10 +7326,10 @@ rollup-pluginutils@^2.5.0, rollup-pluginutils@^2.6.0:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.29.0:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.29.0.tgz#0c5c5968530b21ca0e32f8b94b7cd9346cfb0eec"
-  integrity sha512-gtU0sjxMpsVlpuAf4QXienPmUAhd6Kc7owQ4f5lypoxBW18fw2UNYZ4NssLGsri6WhUZkE/Ts3EMRebN+gNLiQ==
+rollup@^2.30.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.30.0.tgz#316a1eb0389dbda4082ef2d191b31488995e4c41"
+  integrity sha512-j4K1hUZfgFM03DUpayd3c7kZW+2wDbI6rj7ssQxpCpL1vsGpaM0vSorxBuePFwQDFq9O2DI6AOQbm174Awsq4w==
   optionalDependencies:
     fsevents "~2.1.2"
 


### PR DESCRIPTION
🔎 __Overview__

Currently, there is no way to set meta tags safely without affecting the value, the field `meta` is marked as read-only in docs.


This PR adds safe setters that can be used on the field and form levels via either flavors of the library