### PR TITLE
fix: useForm should return the controller

### DIFF
--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -343,6 +343,7 @@ export function useForm(opts?: FormOptions) {
   provide(FormErrorsSymbol, errors);
 
   return {
+    form: controller,
     errors,
     meta,
     values: formValues,


### PR DESCRIPTION
🔎 __Overview__

`beta.9` is broken as `useForm` no longer returns the form controller

I suspect this was removed not on purpose https://github.com/logaretm/vee-validate/commit/41246334b7a999a10b16908debf9ab56642cc722#diff-9945f1daf4294c2daf5224edb9d1f5e206b1ed204e4e920141a0d4a1d2c317b1L359

🤓 __Code snippets/examples (if applicable)__

```
Property 'form' does not exist on type '{ errors: ComputedRef<any>; ... 11 more ...; }'.
> 26 |     const { form, meta: formMeta, values: formValues } = useForm();
     |             ^^^^
```
