### PR TITLE
feat: added detectInput

### DIFF
--- a/docs/api/validation-provider.md
+++ b/docs/api/validation-provider.md
@@ -121,6 +121,7 @@ All the following props are optional.
 | bails          | `boolean`                 | `true`                | If true, the validation will stop on the first failing rule.                                        |
 | customMessages | `{ [k: string]: string }` | `{}`                  | Custom error messages, keyed by rule name. These will override any default and configured messages. |
 | debounce       | `number`                  | `0`                   | Debounces the validation for the specified amount of milliseconds.                                  |
+| detectInput    | `boolean`                 | `true`                | If true, the provider will automatically detect an input with `v-model`/`value` to validate.        |
 | disabled       | `boolean`                 | `false`               | If true, the provider will be ignored when `validate` is called by a parent observer.               |
 | immediate      | `boolean`                 | `false`               | If the field should be validated immediately after render (initially).                              |
 | mode           | `string | ModeFactory`    | `config.mode`         | Specifies the [interaction mode](../guide/interaction-and-ux.md) for this provider instance.        |

--- a/tests/providers/provider.js
+++ b/tests/providers/provider.js
@@ -727,6 +727,28 @@ test('setting skipIfEmpty to false runs only the first rule', async () => {
   expect(errors.at(0).text()).toBe('The {field} field must be a valid email');
 });
 
+test('setting detectInput to false disables the v-model autodetection', async () => {
+  const wrapper = mount(
+    {
+      data: () => ({
+        value: ''
+      }),
+      template: `
+        <ValidationProvider :detectInput="false" rules="required" v-slot="{ errors }">
+          <input v-model="value" type="text">
+          <span id="error">{{ errors[0] }}</span>
+        </ValidationProvider>
+      `
+    },
+    { localVue: Vue, sync: false }
+  );
+
+  await flushPromises();
+
+  const error = wrapper.find('#error');
+  expect(error.text()).toBeFalsy();
+});
+
 const sleep = wait => new Promise(resolve => setTimeout(resolve, wait));
 test('validation can be debounced', async () => {
   const wrapper = mount(

--- a/tests/providers/provider.js
+++ b/tests/providers/provider.js
@@ -735,7 +735,7 @@ test('setting detectInput to false disables the v-model autodetection', async ()
       }),
       template: `
         <ValidationProvider :detectInput="false" rules="required" v-slot="{ errors }">
-          <input v-model="value" type="text">
+          <input id="input" v-model="value" type="text">
           <span id="error">{{ errors[0] }}</span>
         </ValidationProvider>
       `
@@ -743,6 +743,8 @@ test('setting detectInput to false disables the v-model autodetection', async ()
     { localVue: Vue, sync: false }
   );
 
+  const input = wrapper.find('#input');
+  input.setValue('');
   await flushPromises();
 
   const error = wrapper.find('#error');


### PR DESCRIPTION
🔎 __Overview__

This PR adds the feature to disable automatic `v-model` detection.

🤓 __Code snippets/examples (if applicable)__

Ignoring the `v-model`ed element and using `validate()` to validate the second input's value instead.
```html
<ValidationProvider v-slot="{ validate }" :detectInput="false">
    <input v-model="field" type="text"> <!-- not detected -->
    <input type="text" @change="validate($event.target.value)">
</ValidationProvider>
```

✔ __Issues affected__
> closes #2979 
