### PR TITLE
Expose validateWithInfo as Observer slot-prop

### DIFF
--- a/src/components/Observer.ts
+++ b/src/components/Observer.ts
@@ -245,6 +245,7 @@ function prepareSlotProps(vm: ObserverInstance) {
     errors: vm.errors,
     fields: vm.fields,
     validate: vm.validate,
+    validateWithInfo: vm.validateWithInfo,
     passes: vm.handleSubmit,
     handleSubmit: vm.handleSubmit,
     reset: vm.reset


### PR DESCRIPTION
Currently this does not work: 

`<ValidationObserver v-slot="{ validateWithInfo }">`

and instead we can only use the derived version:
`<ValidationObserver v-slot="{ validate }">`

which doesn't provide the error information.  This PR exposes that more powerful validation function.