### PR TITLE
feat: add `initialErrors` prop

### DIFF
--- a/docs/content/api/form.md
+++ b/docs/content/api/form.md
@@ -104,6 +104,7 @@ While not recommended, you can make the `Form` component a renderless component 
 | as               | `string`                             | `"form"`    | The element to render as a root node                                                                         |
 | validationSchema | `Record<string, string \| Function>` | `undefined` | An object describing a schema to validate fields with, can be a plain object or a `yup` object schema        |
 | initialValues    | `Record<string, any>`                | `undefined` | Initial values to fill the fields with, when provided the fields will be validated on mounted                |
+| initialErrors    | `Record<string, string>`             | `undefined` | Initial form errors to fill the fields with, the errors will be added when the form component is mounted     |
 | validateOnMount  | `boolean`                            | `false`     | If true, the fields currently present in the form will be validated when the `<Form />` component is mounted |
 
 ### Slots

--- a/docs/content/api/use-form.md
+++ b/docs/content/api/use-form.md
@@ -38,6 +38,7 @@ The full signature of the `useForm` function looks like this:
 interface FormOptions {
   validationSchema?: any; // A yup schema, or a Record<string, any> containing valid rules as `useField`
   initialValues?: Record<string, any>;
+  initialErrors?: Record<string, string>; // a map of the form's initial error messages
   validateOnMount?: boolean;
 }
 

--- a/docs/content/guide/handling-forms.md
+++ b/docs/content/guide/handling-forms.md
@@ -557,6 +557,45 @@ export default {
 
 Note that setting any field's value using this way will trigger validation
 
+## Initial Errors
+
+If you are building a non-SPA application it is very common to pre-fill form errors using server-side rendering, frameworks like Laravel make this very easy to do. vee-validate supports filling the errors initially before any validation is done using the `initialErrors` prop which is both present on `useForm()` function and the `<Form />` component.
+
+The `initialErrors` property accepts an object containing the field names as keys with their corresponding error message string.
+
+```vue
+<template>
+  <Form :initial-errors="initialErrors">
+    <Field name="email" as="input" />
+    <ErrorMessage name="email" />
+
+    <Field name="password" as="input" />
+    <ErrorMessage name="password" />
+
+    <button>Submit</button>
+  </Form>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    initialErrors: {
+      email: 'This email is already taken',
+      password: 'The password is too short',
+    },
+  }),
+};
+</script>
+```
+
+<doc-tip>
+
+`initialErrors` are applied once the `Form` component is mounted and is ignored after, so any changes to the `initialErrors` props won't affect the messages.
+
+See the next section for setting errors manually.
+
+</doc-tip>
+
 ## Setting Errors Manually
 
 Quite often you will find yourself unable to replicate some validation rules on the client-side due to natural limitations. For example a `unique` email validation is complex to implement on the client-side, which is why the `<Form />` component and `useForm()` function allow you to set errors manually.

--- a/packages/core/src/Form.ts
+++ b/packages/core/src/Form.ts
@@ -19,6 +19,10 @@ export const Form = defineComponent({
       type: Object,
       default: undefined,
     },
+    initialErrors: {
+      type: Object,
+      default: undefined,
+    },
     validateOnMount: {
       type: Boolean,
       default: false,
@@ -46,6 +50,7 @@ export const Form = defineComponent({
     } = useForm({
       validationSchema: props.validationSchema,
       initialValues,
+      initialErrors: props.initialErrors,
       validateOnMount: props.validateOnMount,
     });
 

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -18,6 +18,7 @@ interface FormOptions<TValues extends Record<string, any>> {
     | Record<keyof TValues, GenericValidateFunction | string | Record<string, any>>
     | ObjectSchema<TValues>;
   initialValues?: MaybeReactive<TValues>;
+  initialErrors?: Record<keyof TValues, string | undefined>;
   validateOnMount?: boolean;
 }
 
@@ -327,6 +328,10 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
 
   // Trigger initial validation
   onMounted(() => {
+    if (opts?.initialErrors) {
+      setErrors(opts.initialErrors);
+    }
+
     if (opts?.validateOnMount) {
       validate();
     }

--- a/packages/core/tests/Form.spec.ts
+++ b/packages/core/tests/Form.spec.ts
@@ -1353,4 +1353,32 @@ describe('<Form />', () => {
     await flushPromises();
     expect(meta?.textContent).toBe('true');
   });
+
+  test('sets initial errors with initialErrors', async () => {
+    const errors = {
+      password: 'too short',
+      email: 'wrong',
+    };
+    const wrapper = mountWithHoc({
+      setup() {
+        return {
+          errors,
+        };
+      },
+      template: `
+      <VForm ref="form" :initial-errors="errors">
+        <Field id="email" name="email" as="input" />
+        <ErrorMessage name="email" />
+        <Field id="password" name="password" as="input" />
+        <ErrorMessage name="password" />
+      </VForm>
+    `,
+    });
+
+    await flushPromises();
+    const errorEls = wrapper.$el.querySelectorAll('span');
+    await flushPromises();
+    expect(errorEls[0].textContent).toBe(errors.email);
+    expect(errorEls[1].textContent).toBe(errors.password);
+  });
 });

--- a/packages/core/tests/helpers/index.ts
+++ b/packages/core/tests/helpers/index.ts
@@ -1,5 +1,5 @@
 import { createApp, ComponentPublicInstance } from 'vue';
-import { Field, Form } from '@vee-validate/core';
+import { Field, Form, ErrorMessage } from '@vee-validate/core';
 
 export function mount(component: Record<string, any>) {
   const app = createApp(component);
@@ -15,6 +15,7 @@ export function mountWithHoc(component: Record<string, any>) {
     ...(component.components || {}),
     Field,
     VForm: Form,
+    ErrorMessage,
   };
 
   return mount(component);


### PR DESCRIPTION
🔎 __Overview__

This PR adds `initalErrors` prop that prefills form's errors and updates their validation state.

This is useful for Non-Nodejs SSR like Laravel to easily add error messages to their forms after flashing them to session from the previous response.