### PR TITLE
wrong rule applied?

### DIFF
--- a/packages/rules/src/regex.ts
+++ b/packages/rules/src/regex.ts
@@ -3,7 +3,7 @@ import { getSingleParam } from './utils';
 const regexValidator = (value: any, params?: any[] | Record<string, any>): boolean => {
   let regex = getSingleParam(params, 'regex');
   if (typeof regex === 'string') {
-    regex = new RegExp(value);
+    regex = new RegExp(regex);
   }
 
   if (Array.isArray(value)) {


### PR DESCRIPTION

🔎 __Overview__
Regex validator seems to be generating regex formula from the wrong parameter.
new RegExp() receives the input value and not regex formula 