### PR TITLE
fix safari sidemenu scroll issue

### DIFF
--- a/docs/components/DocMenu.vue
+++ b/docs/components/DocMenu.vue
@@ -74,7 +74,7 @@ export default {
 
 <style lang="postcss" scoped>
 nav {
-  max-height: 80vh;
+  max-height: calc(80vh - 96px);
   a {
     @screen motion {
       transition: color 0.2s ease-in-out;

--- a/docs/components/DocMenu.vue
+++ b/docs/components/DocMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <aside class="px-6 pt-24">
-    <nav class="space-y-8 text-sm overflow-y-auto">
+    <nav class="space-y-8 text-sm overflow-y-auto overscroll-y-contain">
       <div v-for="category in categories" :key="category.title">
         <p class="text-xs font-bold text-gray-400 uppercase">{{ category.title }}</p>
         <ul class="mt-3 space-y-2">

--- a/docs/components/SideMenu.vue
+++ b/docs/components/SideMenu.vue
@@ -46,6 +46,7 @@ export default {
 <style lang="postcss" scoped>
 .SideMenu {
   @apply fixed h-screen w-screen inset-0 z-20 overflow-y-auto bg-white text-gray-700 flex flex-col;
+  height: -webkit-fill-available;
 }
 
 .dark {

--- a/docs/components/SideMenu.vue
+++ b/docs/components/SideMenu.vue
@@ -46,7 +46,6 @@ export default {
 <style lang="postcss" scoped>
 .SideMenu {
   @apply fixed h-screen w-screen inset-0 z-20 overflow-y-auto bg-white text-gray-700 flex flex-col;
-  height: -webkit-fill-available;
 }
 
 .dark {


### PR DESCRIPTION
🔎 __Overview__

Fixed scrolling menu in mobile safari.

Ex (Feat):
It is currently impossible to scroll the menu to the end. Adjusted the maximum height of the menu to have a bottom gap. Also add `overscroll-behavior-y` to get rid of the underlying page scroll chaining.

