### PR TITLE
fix typo in docs (initialErrors -> initialValues)

### DIFF
--- a/docs/content/api/use-form.md
+++ b/docs/content/api/use-form.md
@@ -84,7 +84,7 @@ The initial values for the form, can be a reactive object or reference.
 
 ```js
 const { ... } = useForm({
-  initialErrors: {
+  initialValues: {
     email: 'example@gmail.com',
     password: 'p@$$w0rd',
   }


### PR DESCRIPTION
🔎 __Overview__

Fix typo (initialErrors -> initialValues) in Docs.