### PR TITLE
fix: added emits and onSubmit custom prop

### DIFF
--- a/packages/vee-validate/src/Form.ts
+++ b/packages/vee-validate/src/Form.ts
@@ -1,6 +1,6 @@
-import { h, defineComponent, toRef, resolveDynamicComponent, computed } from 'vue';
+import { h, defineComponent, toRef, resolveDynamicComponent, computed, PropType } from 'vue';
 import { useForm } from './useForm';
-import { SubmissionHandler } from './types';
+import { SubmissionContext, SubmissionHandler } from './types';
 import { isEvent, normalizeChildren } from './utils';
 
 export const Form = defineComponent({
@@ -35,6 +35,14 @@ export const Form = defineComponent({
       type: Boolean,
       default: false,
     },
+    onSubmit: {
+      type: Function as PropType<SubmissionHandler>,
+      default: undefined,
+    },
+  },
+  emits: {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    submit: (values: Record<string, any>, actions: SubmissionContext) => true,
   },
   setup(props, ctx) {
     const initialValues = toRef(props, 'initialValues');
@@ -66,7 +74,7 @@ export const Form = defineComponent({
       validateOnMount: props.validateOnMount,
     });
 
-    const onSubmit = ctx.attrs.onSubmit ? handleSubmit(ctx.attrs.onSubmit as SubmissionHandler) : submitForm;
+    const onSubmit = props.onSubmit ? handleSubmit(props.onSubmit) : submitForm;
     function handleFormReset(e?: Event) {
       if (isEvent(e)) {
         // Prevent default form reset behavior

--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -59,7 +59,8 @@ export interface FormValidationResult<TValues> {
   valid: boolean;
 }
 
-interface SubmissionContext<TValues extends Record<string, any> = Record<string, any>> extends FormActions<TValues> {
+export interface SubmissionContext<TValues extends Record<string, any> = Record<string, any>>
+  extends FormActions<TValues> {
   evt: SubmitEvent;
 }
 

--- a/packages/vee-validate/src/utils/vnode.ts
+++ b/packages/vee-validate/src/utils/vnode.ts
@@ -1,6 +1,6 @@
 import { SetupContext } from 'vue';
 
-export const normalizeChildren = (context: SetupContext, slotProps: any) => {
+export const normalizeChildren = (context: SetupContext<any>, slotProps: any) => {
   if (!context.slots.default) {
     return context.slots.default;
   }


### PR DESCRIPTION
🔎 __Overview__

The `Form` component emitting `submit` event with different signature than the default event handlers.

This PR adds `onSubmit` prop and `emits` prop so tools like `volar` and `vue-dx` can pick up the types correctly.

https://github.com/johnsoncodehk/volar/issues/41

closes #3114