### PR TITLE
feat: added validate field function to form and useForm

### DIFF
--- a/docs/content/api/form.md
+++ b/docs/content/api/form.md
@@ -244,6 +244,14 @@ Validates all the fields and populates the `errors` object, returns a promise th
 
 <code-title level="4">
 
+`validateField: (field: string) => Promise<{ valid: boolean; errors: string[] }>`
+
+</code-title>
+
+Validates a specific field inside the form, returns a promise that resolves to an object containing the validation result.
+
+<code-title level="4">
+
 `handleSubmit: (evt: Event, cb: (values: Record<string, any>, ctx: SubmissionContext) => any) => Promise<void>`
 
 </code-title>

--- a/docs/content/api/use-form.md
+++ b/docs/content/api/use-form.md
@@ -117,6 +117,7 @@ type useForm = (
   setFieldValue: (field: string, value: any) => void; // Sets a field value
   setValues: (fields: Record<string, any>) => void; // Sets multiple fields values
   validate: () => Promise<{ errors: Record<string, string>; valid: boolean; }>; // validates the form fields and returns the overall result
+  validateField: (field: string) => Promise<{ errors: string[]; valid: boolean; }>; // validates the form fields and returns the overall result
   handleSubmit: (cb: (values: Record<string, any>, ctx: SubmissionContext)) => () => void; // Creates a submission handler that calls the cb only after successful validation with the form values
   submitForm: (e: Event) => void; // Forces submission of a form after successful validation (calls e.target.submit())
   handleReset: () => void; // Resets all fields' errors and meta and their values
@@ -440,7 +441,21 @@ Validates all the fields and populates the `errors` object, returns a promise th
 ```js
 const { validate } = useForm();
 
-await validate();
+const { valid, errors } = await validate();
+```
+
+<code-title level="4">
+
+`validateField: (field: string) => Promise<{ valid: boolean; errors: string[] }>`
+
+</code-title>
+
+Validates a specific field inside the form, returns a promise that resolves to an object containing the validation result.
+
+```js
+const { validateField } = useForm();
+
+const { valid, errors } = await validateField('email');
 ```
 
 <code-title level="4">

--- a/packages/vee-validate/src/Form.ts
+++ b/packages/vee-validate/src/Form.ts
@@ -53,6 +53,7 @@ export const Form = defineComponent({
       isSubmitting,
       submitCount,
       validate,
+      validateField,
       handleReset,
       resetForm,
       handleSubmit,
@@ -101,6 +102,7 @@ export const Form = defineComponent({
         isSubmitting: isSubmitting.value,
         submitCount: submitCount.value,
         validate,
+        validateField,
         handleSubmit: handleScopedSlotSubmit,
         handleReset,
         submitForm,
@@ -131,6 +133,7 @@ export const Form = defineComponent({
         this.setTouched = setTouched;
         this.resetForm = resetForm;
         this.validate = validate;
+        this.validateField = validateField;
       }
 
       const children = normalizeChildren(ctx, slotProps.value);

--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -78,6 +78,7 @@ export interface FormContext<TValues extends Record<string, any> = Record<string
   schema?: Record<keyof TValues, GenericValidateFunction | string | Record<string, any>> | SchemaOf<TValues>;
   validateSchema?: (shouldMutate?: boolean) => Promise<Record<keyof TValues, ValidationResult>>;
   validate(): Promise<FormValidationResult<TValues>>;
+  validateField(field: keyof TValues): Promise<ValidationResult>;
   meta: ComputedRef<{
     dirty: boolean;
     touched: boolean;

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -1,4 +1,4 @@
-import { computed, ref, Ref, provide, reactive, onMounted, isRef, watch, unref, nextTick } from 'vue';
+import { computed, ref, Ref, provide, reactive, onMounted, isRef, watch, unref, nextTick, warn } from 'vue';
 import type { SchemaOf, ValidationError } from 'yup';
 import type { useField } from './useField';
 import {
@@ -341,6 +341,17 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     return results.reduce(resultReducer, { errors: {}, valid: true });
   }
 
+  async function validateField(field: keyof TValues): Promise<ValidationResult> {
+    const fieldInstance = fieldsById.value[field];
+    if (!fieldInstance) {
+      warn(`field with name ${field} was not found`);
+
+      return Promise.resolve({ errors: [], valid: true });
+    }
+
+    return fieldInstance.validate();
+  }
+
   const handleSubmit = (fn?: SubmissionHandler<TValues>) => {
     return function submissionHandler(e: unknown) {
       if (e instanceof Event) {
@@ -394,6 +405,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
         }
       : undefined,
     validate,
+    validateField,
     setFieldValue,
     setValues,
     setErrors,
@@ -452,6 +464,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     isSubmitting,
     submitCount,
     validate,
+    validateField,
     handleReset: () => resetForm(),
     resetForm,
     handleSubmit,

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -2,6 +2,7 @@ import flushPromises from 'flush-promises';
 import { useField, useForm } from '@/vee-validate';
 import { mountWithHoc } from './helpers';
 import * as yup from 'yup';
+import { doc } from 'prettier';
 
 describe('useForm()', () => {
   const REQUIRED_MESSAGE = 'Field is required';
@@ -245,5 +246,33 @@ describe('useForm()', () => {
         field2: REQUIRED_MESSAGE,
       },
     });
+  });
+
+  test('has a validateField() method that validates a specific field', async () => {
+    let validateField: any;
+    mountWithHoc({
+      setup() {
+        const form = useForm();
+        validateField = form.validateField;
+        const { errorMessage: f1 } = useField('field1', val => (val ? true : REQUIRED_MESSAGE));
+        const { errorMessage: f2 } = useField('field2', val => (val ? true : REQUIRED_MESSAGE));
+
+        return { f1, f2 };
+      },
+      template: `<div>
+        <span id="f1">{{ f1 }}</span>
+        <span id="f2">{{ f2 }}</span>
+      </div>`,
+    });
+
+    await flushPromises();
+    const result = await validateField('field2');
+    expect(result).toEqual({
+      valid: false,
+      errors: [REQUIRED_MESSAGE],
+    });
+
+    expect(document.querySelector('#f2')?.textContent).toBe(REQUIRED_MESSAGE);
+    expect(document.querySelector('#f1')?.textContent).toBe('');
   });
 });

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -275,4 +275,29 @@ describe('useForm()', () => {
     expect(document.querySelector('#f2')?.textContent).toBe(REQUIRED_MESSAGE);
     expect(document.querySelector('#f1')?.textContent).toBe('');
   });
+
+  test('warns when validateField() is called on a non-existent field', async () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+
+    let validateField: any;
+    mountWithHoc({
+      setup() {
+        const form = useForm();
+        validateField = form.validateField;
+
+        return {};
+      },
+      template: `<div></div>`,
+    });
+
+    await flushPromises();
+    const result = await validateField('field2');
+    expect(result).toEqual({
+      valid: true,
+      errors: [],
+    });
+
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
 });


### PR DESCRIPTION
This PR adds a `validateField` method on both `Form` component and `useForm` function, this allows validating a single field.

```js
import { useForm } from 'vee-validate';

const { validateField } = useForm();

const { valid, errors } = await validateField('email');
```

```vue
<Form v-slot="{ validateField }">
   <!-- ... -->
  <button @click="validateField('email')">Validate Email</button>
</Form>
```


As mentioned in #3131