### PR TITLE
feat: set pause to field or form

### DIFF
--- a/packages/vee-validate/src/Field.ts
+++ b/packages/vee-validate/src/Field.ts
@@ -79,6 +79,7 @@ export const Field = defineComponent({
       handleBlur,
       handleInput,
       setDirty,
+      setPaused,
       setTouched,
       resetField,
       handleReset,
@@ -168,6 +169,7 @@ export const Field = defineComponent({
         handleReset,
         handleBlur,
         setDirty,
+        setPaused,
         setTouched,
       };
     });

--- a/packages/vee-validate/src/Form.ts
+++ b/packages/vee-validate/src/Form.ts
@@ -64,6 +64,9 @@ export const Form = defineComponent({
       setValues,
       setFieldDirty,
       setDirty,
+      setFieldPaused,
+      setPaused,
+      setFormPaused,
       setFieldTouched,
       setTouched,
     } = useForm({
@@ -112,6 +115,9 @@ export const Form = defineComponent({
         setValues,
         setFieldDirty,
         setDirty,
+        setFieldPaused,
+        setPaused,
+        setFormPaused,
         setFieldTouched,
         setTouched,
         resetForm,
@@ -129,6 +135,9 @@ export const Form = defineComponent({
         this.setValues = setValues;
         this.setFieldDirty = setFieldDirty;
         this.setDirty = setDirty;
+        this.setFieldPaused = setFieldPaused;
+        this.setPaused = setPaused;
+        this.setFormPaused = setFormPaused;
         this.setFieldTouched = setFieldTouched;
         this.setTouched = setTouched;
         this.resetForm = resetForm;

--- a/packages/vee-validate/src/index.ts
+++ b/packages/vee-validate/src/index.ts
@@ -24,6 +24,8 @@ export { useValidateField } from './useValidateField';
 export { useIsFormDirty } from './useIsFormDirty';
 export { useIsFormTouched } from './useIsFormTouched';
 export { useIsFormValid } from './useIsFormValid';
+export { useIsFieldPaused } from './useIsFieldPaused';
+export { useIsFormPaused } from './useIsFormPaused';
 export { useValidateForm } from './useValidateForm';
 export { useSubmitCount } from './useSubmitCount';
 export { useFieldValue } from './useFieldValue';

--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -22,6 +22,7 @@ export interface FieldMeta {
   dirty: boolean;
   valid: boolean;
   pending: boolean;
+  paused: boolean;
   initialValue?: any;
 }
 
@@ -35,6 +36,7 @@ export interface FormState<TValues> {
   values: TValues;
   errors: Partial<Record<keyof TValues, string | undefined>>;
   dirty: Partial<Record<keyof TValues, boolean>>;
+  paused: Partial<Record<keyof TValues, boolean>>;
   touched: Partial<Record<keyof TValues, boolean>>;
   submitCount: number;
 }
@@ -51,6 +53,9 @@ export interface FormActions<TValues> {
   setTouched: (fields: Partial<Record<keyof TValues, boolean>>) => void;
   setFieldDirty: (field: keyof TValues, isDirty: boolean) => void;
   setDirty: (fields: Partial<Record<keyof TValues, boolean>>) => void;
+  setFieldPaused: (field: keyof TValues, isDirty: boolean) => void;
+  setPaused: (fields: Partial<Record<keyof TValues, boolean>>) => void;
+  setFormPaused: (isPaused: boolean) => void;
   resetForm: (state?: Partial<FormState<TValues>>) => void;
 }
 
@@ -84,6 +89,7 @@ export interface FormContext<TValues extends Record<string, any> = Record<string
     touched: boolean;
     valid: boolean;
     pending: boolean;
+    paused: boolean;
     initialValues: TValues;
   }>;
   isSubmitting: Ref<boolean>;

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -231,6 +231,41 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
   }
 
   /**
+   * Sets the paused meta state on a field
+   */
+  function setFieldPaused(field: keyof TValues, isPaused: boolean) {
+    const fieldInstance = fieldsById.value[field];
+    if (!fieldInstance) {
+      return;
+    }
+
+    if (Array.isArray(fieldInstance)) {
+      fieldInstance.forEach(f => f.setPaused(isPaused));
+      return;
+    }
+
+    fieldInstance.setPaused(isPaused);
+  }
+
+  /**
+   * Sets the paused meta state on multiple fields
+   */
+  function setPaused(fields: Partial<Record<keyof TValues, boolean>>) {
+    keysOf(fields).forEach(field => {
+      setFieldPaused(field, !!fields[field]);
+    });
+  }
+
+  /**
+   * Sets the paused meta state on all fields
+   */
+  function setFormPaused(isPaused: boolean) {
+    keysOf(fieldsById.value).forEach(field => {
+      setFieldPaused(field, isPaused);
+    });
+  }
+
+  /**
    * Resets all fields
    */
   const resetForm = (state?: Partial<FormState<TValues>>) => {
@@ -251,6 +286,9 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     }
     if (state?.errors) {
       setErrors(state.errors);
+    }
+    if (state?.paused) {
+      setPaused(state.paused);
     }
 
     submitCount.value = state?.submitCount || 0;
@@ -378,6 +416,9 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
               evt: e as SubmitEvent,
               setDirty,
               setFieldDirty,
+              setPaused,
+              setFieldPaused,
+              setFormPaused,
               setErrors,
               setFieldError,
               setTouched,
@@ -424,6 +465,9 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     setTouched,
     setFieldDirty,
     setDirty,
+    setFieldPaused,
+    setPaused,
+    setFormPaused,
     resetForm,
     meta,
     isSubmitting,
@@ -487,6 +531,9 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     setTouched,
     setFieldDirty,
     setDirty,
+    setFieldPaused,
+    setPaused,
+    setFormPaused,
   };
 }
 
@@ -499,6 +546,7 @@ function useFormMeta<TValues>(fields: Ref<any[]>, initialValues: MaybeReactive<T
     dirty: 'some',
     touched: 'some',
     pending: 'some',
+    paused: 'some',
   };
 
   return computed(() => {

--- a/packages/vee-validate/src/useIsFieldPaused.ts
+++ b/packages/vee-validate/src/useIsFieldPaused.ts
@@ -1,0 +1,26 @@
+import { computed, inject, unref } from 'vue';
+import { FieldContextSymbol, FormContextSymbol } from './symbols';
+import { MaybeReactive } from './types';
+import { injectWithSelf, normalizeField, warn } from './utils';
+
+/**
+ * If a field is paused or not
+ */
+export function useIsFieldPaused(path?: MaybeReactive<string>) {
+  const form = injectWithSelf(FormContextSymbol);
+  let field = path ? undefined : inject(FieldContextSymbol);
+
+  return computed(() => {
+    if (path) {
+      field = normalizeField(form?.fields.value[unref(path)]);
+    }
+
+    if (!field) {
+      warn(`field with name ${unref(path)} was not found`);
+
+      return false;
+    }
+
+    return field.meta.paused;
+  });
+}

--- a/packages/vee-validate/src/useIsFormPaused.ts
+++ b/packages/vee-validate/src/useIsFormPaused.ts
@@ -1,0 +1,17 @@
+import { computed } from 'vue';
+import { FormContextSymbol } from './symbols';
+import { injectWithSelf, warn } from './utils';
+
+/**
+ * If the form is dirty or not
+ */
+export function useIsFormPaused() {
+  const form = injectWithSelf(FormContextSymbol);
+  if (!form) {
+    warn('No vee-validate <Form /> or `useForm` was detected in the component tree');
+  }
+
+  return computed(() => {
+    return form?.meta.value.paused ?? false;
+  });
+}

--- a/packages/vee-validate/tests/Form.spec.ts
+++ b/packages/vee-validate/tests/Form.spec.ts
@@ -142,9 +142,10 @@ describe('<Form />', () => {
         <span id="error">{{ errors.field }}</span>
         <span id="dirty">{{ meta.dirty.toString() }}</span>
         <span id="touched">{{ meta.touched.toString() }}</span>
+        <span id="paused">{{ meta.paused.toString() }}</span>
 
         <button id="submit">Validate</button>
-        <button id="reset" type="button" @click="resetForm({ values: { field: '${resetValue}' }, errors: { field: '${resetError}' }, touched: { field: true }, dirty: { field: true } })">Reset</button>
+        <button id="reset" type="button" @click="resetForm({ values: { field: '${resetValue}' }, errors: { field: '${resetError}' }, touched: { field: true }, dirty: { field: true }, paused: { field: true }})">Reset</button>
       </VForm>
     `,
     });
@@ -170,6 +171,7 @@ describe('<Form />', () => {
     expect(error.textContent).toBe(resetError);
     expect(wrapper.$el.querySelector('#dirty').textContent).toBe('true');
     expect(wrapper.$el.querySelector('#touched').textContent).toBe('true');
+    expect(wrapper.$el.querySelector('#paused').textContent).toBe('true');
   });
 
   test('initial values can be set with initialValues prop', async () => {
@@ -1397,6 +1399,27 @@ describe('<Form />', () => {
     const meta = wrapper.$el.querySelector('#meta');
     expect(meta?.textContent).toBe('false');
     (wrapper.$refs as any)?.form.setFieldDirty('drink', true);
+    await flushPromises();
+    expect(meta?.textContent).toBe('true');
+  });
+
+  test('sets meta paused with setFieldPaused for checkboxes', async () => {
+    const wrapper = mountWithHoc({
+      template: `
+      <VForm ref="form" v-slot="{ meta }">
+        <Field name="drink" type="checkbox" value="" /> Coffee
+        <Field name="drink" type="checkbox" value="Tea" /> Tea
+        <Field name="drink" type="checkbox" value="Coke" /> Coke
+
+        <span id="meta">{{ meta.paused }}</span>
+      </VForm>
+    `,
+    });
+
+    await flushPromises();
+    const meta = wrapper.$el.querySelector('#meta');
+    expect(meta?.textContent).toBe('false');
+    (wrapper.$refs as any)?.form.setFieldPaused('drink', true);
     await flushPromises();
     expect(meta?.textContent).toBe('true');
   });

--- a/packages/vee-validate/tests/useField.spec.ts
+++ b/packages/vee-validate/tests/useField.spec.ts
@@ -27,4 +27,28 @@ describe('useField()', () => {
     await flushPromises();
     expect(error?.textContent).toBe(REQUIRED_MESSAGE);
   });
+
+  test('doesnt validate when value changes and its paussed', async () => {
+    mountWithHoc({
+      setup() {
+        const { value, errorMessage, setPaused } = useField('field', val => (val ? true : REQUIRED_MESSAGE));
+        setPaused(true);
+        return {
+          value,
+          errorMessage,
+        };
+      },
+      template: `
+      <input name="field" v-model="value" />
+      <span>{{ errorMessage }}</span>
+    `,
+    });
+
+    const input = document.querySelector('input');
+    const error = document.querySelector('span');
+
+    setValue(input as any, '');
+    await flushPromises();
+    expect(error?.textContent).toBe('');
+  });
 });

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -127,6 +127,113 @@ describe('useForm()', () => {
     expect(meta[2]?.textContent).toBe('true');
   });
 
+  test('sets individual field paused meta', async () => {
+    mountWithHoc({
+      setup() {
+        const { setFieldPaused, meta: formMeta } = useForm();
+        const { meta } = useField('field', val => (val ? true : REQUIRED_MESSAGE));
+
+        return {
+          meta,
+          formMeta,
+          setFieldPaused,
+        };
+      },
+      template: `
+      <span id="field">{{ meta.paused }}</span>
+      <span id="form">{{ formMeta.paused }}</span>
+      <button @click="setFieldPaused('field', true)">Set Meta</button>
+    `,
+    });
+
+    const fieldMeta = document.querySelector('#field');
+    const formMeta = document.querySelector('#form');
+
+    await flushPromises();
+
+    expect(fieldMeta?.textContent).toBe('false');
+    expect(formMeta?.textContent).toBe('false');
+    document.querySelector('button')?.click();
+
+    await flushPromises();
+
+    expect(fieldMeta?.textContent).toBe('true');
+    expect(formMeta?.textContent).toBe('true');
+  });
+
+  test('sets multiple fields paused meta', async () => {
+    mountWithHoc({
+      setup() {
+        const { setPaused, meta: formMeta } = useForm();
+        const { meta: meta1 } = useField('field1', val => (val ? true : REQUIRED_MESSAGE));
+        const { meta: meta2 } = useField('field2', val => (val ? true : REQUIRED_MESSAGE));
+
+        return {
+          meta1,
+          meta2,
+          formMeta,
+          setPaused,
+        };
+      },
+      template: `
+      <span>{{ meta1.paused }}</span>
+      <span>{{ meta2.paused }}</span>
+      <span>{{ formMeta.paused }}</span>
+      <button @click="setPaused({ field1: true, field2: false, field3: false })">Set Meta</button>
+    `,
+    });
+
+    const meta = document.querySelectorAll('span');
+
+    await flushPromises();
+    expect(meta[0]?.textContent).toBe('false');
+    expect(meta[1]?.textContent).toBe('false');
+    expect(meta[2]?.textContent).toBe('false');
+    document.querySelector('button')?.click();
+    await flushPromises();
+    expect(meta[0]?.textContent).toBe('true');
+    expect(meta[1]?.textContent).toBe('false');
+    expect(meta[2]?.textContent).toBe('true');
+  });
+
+  test('sets all fields paused meta', async () => {
+    mountWithHoc({
+      setup() {
+        const { setFormPaused, meta: formMeta } = useForm();
+        const { meta: meta1 } = useField('field1', val => (val ? true : REQUIRED_MESSAGE));
+        const { meta: meta2 } = useField('field2', val => (val ? true : REQUIRED_MESSAGE));
+
+        return {
+          meta1,
+          meta2,
+          formMeta,
+          setFormPaused,
+        };
+      },
+      template: `
+      <span>{{ meta1.paused }}</span>
+      <span>{{ meta2.paused }}</span>
+      <span>{{ formMeta.paused }}</span>
+      <button @click="setFormPaused(true)">Pause form</button>
+    `,
+    });
+
+    const meta = document.querySelectorAll('span');
+
+    await flushPromises();
+
+    expect(meta[0]?.textContent).toBe('false');
+    expect(meta[1]?.textContent).toBe('false');
+    expect(meta[2]?.textContent).toBe('false');
+    document.querySelector('button')?.click();
+
+    await flushPromises();
+
+    expect(meta[0]?.textContent).toBe('true');
+    expect(meta[1]?.textContent).toBe('true');
+    expect(meta[2]?.textContent).toBe('true');
+  });
+
   test('sets individual field touched meta', async () => {
     mountWithHoc({
       setup() {

--- a/packages/vee-validate/tests/useIsFieldPaused.spec.ts
+++ b/packages/vee-validate/tests/useIsFieldPaused.spec.ts
@@ -1,0 +1,170 @@
+import flushPromises from 'flush-promises';
+import { useField, useForm, useIsFieldPaused, useIsFieldValid, useIsFieldDirty } from '@/vee-validate';
+import { mountWithHoc, setValue } from './helpers';
+import { defineComponent } from 'vue';
+
+describe('useIsFieldPaused()', () => {
+  test('gives access to a single field isPaused status', async () => {
+    mountWithHoc({
+      setup() {
+        useForm();
+        const { value, handleInput, setPaused } = useField('test', () => true);
+        const isPaused = useIsFieldPaused('test');
+        const isValid = useIsFieldValid('test');
+        const isDirty = useIsFieldDirty('test');
+
+        setPaused(true);
+
+        return {
+          value,
+          isPaused,
+          isValid,
+          isDirty,
+          handleInput,
+        };
+      },
+      template: `
+      <input name="field" v-model="value" @input="handleInput" />
+      <span class="isPaused">{{ isPaused.toString() }}</span>
+      <span class="isValid">{{ isValid.toString() }}</span>
+      <span class="isDirty">{{ isDirty.toString() }}</span>
+    `,
+    });
+
+    await flushPromises();
+
+    const input = document.querySelector('input');
+    const isPaused = document.querySelector('.isPaused');
+    const isValid = document.querySelector('.isValid');
+    const isDirty = document.querySelector('.isDirty');
+
+    expect(isPaused?.textContent).toBe('true');
+
+    setValue(input as any, '123');
+
+    await flushPromises();
+
+    expect(isValid?.textContent).toBe('false');
+    expect(isDirty?.textContent).toBe('true');
+  });
+
+  test('gives access to a single field isPaused status in a child component without specifying a path', async () => {
+    const PausedIcon = defineComponent({
+      template: '<span>{{ isPaused.toString() }}</span>',
+      setup() {
+        const isPaused = useIsFieldPaused();
+
+        return {
+          isPaused,
+        };
+      },
+    });
+    mountWithHoc({
+      components: {
+        PausedIcon,
+      },
+      setup() {
+        useForm();
+        const { value, handleInput, setPaused } = useField('test');
+        return {
+          value,
+          handleInput,
+          setPaused,
+        };
+      },
+      template: `
+        <input name="field" v-model="value" @input="handleInput" />
+        <PausedIcon />
+        <button @click="setPaused(true)">setPaused</button>
+      `,
+    });
+
+    await flushPromises();
+    const error = document.querySelector('span');
+    expect(error?.textContent).toBe('false');
+
+    document.querySelector('button')?.click();
+
+    await flushPromises();
+    expect(error?.textContent).toBe('true');
+  });
+
+  test('gives access to array fields isPaused status', async () => {
+    mountWithHoc({
+      setup() {
+        useForm();
+        const { value, handleInput, setPaused } = useField('test');
+        useField('test');
+        const isPaused = useIsFieldPaused('test');
+
+        return {
+          value,
+          isPaused,
+          handleInput,
+          setPaused,
+        };
+      },
+      template: `
+      <input name="field" v-model="value" @input="handleInput" />
+      <span>{{ isPaused.toString() }}</span>
+      <button @click="setPaused(true)">setPaused</button>
+    `,
+    });
+    await flushPromises();
+
+    const error = document.querySelector('span');
+    expect(error?.textContent).toBe('false');
+
+    document.querySelector('button')?.click();
+
+    await flushPromises();
+    expect(error?.textContent).toBe('true');
+  });
+
+  test('returns false and warns if field does not exist', async () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+
+    mountWithHoc({
+      setup() {
+        useForm();
+        const isPaused = useIsFieldPaused('something');
+
+        return {
+          isPaused,
+        };
+      },
+      template: `
+      <span>{{ isPaused.toString() }}</span>
+    `,
+    });
+
+    await flushPromises();
+    const error = document.querySelector('span');
+    expect(error?.textContent).toBe('false');
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  test('returns false and warns if form does not exist', async () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+
+    mountWithHoc({
+      setup() {
+        const isPaused = useIsFieldPaused('something');
+
+        return {
+          isPaused,
+        };
+      },
+      template: `
+      <span>{{ isPaused.toString() }}</span>
+    `,
+    });
+
+    await flushPromises();
+    const error = document.querySelector('span');
+    expect(error?.textContent).toBe('false');
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/packages/vee-validate/tests/useIsFormPaused.spec.ts
+++ b/packages/vee-validate/tests/useIsFormPaused.spec.ts
@@ -1,0 +1,51 @@
+import flushPromises from 'flush-promises';
+import { useField, useForm, useIsFormPaused } from '@/vee-validate';
+import { mountWithHoc } from './helpers';
+
+describe('useIsFormPaused()', () => {
+  test('gives access to the forms isPaused status', async () => {
+    mountWithHoc({
+      setup() {
+        useForm();
+        const { value, handleInput, setPaused } = useField('test');
+        setPaused(true);
+        const isPaused = useIsFormPaused();
+        return {
+          value,
+          isPaused,
+          handleInput,
+        };
+      },
+      template: `
+      <span>{{ isPaused.toString()  }}</span>
+    `,
+    });
+
+    const error = document.querySelector('span');
+    expect(error?.textContent).toBe('true');
+  });
+
+  test('returns false and warns if form is not found', async () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+
+    mountWithHoc({
+      setup() {
+        const isPaused = useIsFormPaused();
+
+        return {
+          isPaused,
+        };
+      },
+      template: `
+      <span>{{ isPaused.toString() }}</span>
+    `,
+    });
+
+    const error = document.querySelector('span');
+
+    await flushPromises();
+    expect(error?.textContent).toBe('false');
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/yalc.lock
+++ b/yalc.lock
@@ -1,4 +1,0 @@
-{
-  "version": "v1",
-  "packages": {}
-}

--- a/yalc.lock
+++ b/yalc.lock
@@ -1,0 +1,4 @@
+{
+  "version": "v1",
+  "packages": {}
+}


### PR DESCRIPTION
🔎 __Overview__

I wanted to upgrade this package to v4 in our company and saw that the `pause` method was missing. After I wrote some helpers inside the project to fulfill this obstacle it looked hacky, so I thought it should be a part of v4 instead of a helper function for every project that uses v4.

Saw some issues about  it #3066