### PR TITLE
feat: initial zod support

### DIFF
--- a/docs/components/DocMenu.vue
+++ b/docs/components/DocMenu.vue
@@ -107,7 +107,7 @@ const GROUPS = [
   },
   {
     name: 'integrations',
-    contentPath: '3rd-party-integrations',
+    contentPath: 'integrations',
   },
   {
     name: 'resources',

--- a/docs/content/guide/components/validation.md
+++ b/docs/content/guide/components/validation.md
@@ -199,8 +199,16 @@ export default {
 
 For more information on the `Form` component, read [the API reference](/api/form).
 
-<doc-tip title="Yup Schema Optimizations">
-  There are a couple of optimization caveats when it comes to using `yup` schemas to validate your forms, be sure to check the [best practices guide](/tutorials/best-practices)
+<doc-tip title="Yup Schema Optimizations" type="warn">
+
+There are a couple of optimization caveats when it comes to using `yup` schemas to validate your forms, be sure to check the [best practices guide](/tutorials/best-practices).
+
+</doc-tip>
+
+<doc-tip title="Zod Schema Plugin">
+
+There is an official integration available for [Zod validation](https://github.com/colinhacks/zod) that you can use as a drop-in replacement for `yup`. Check the [zod integration page](/integrations/zod-schema-validation).
+
 </doc-tip>
 
 ## Validation Behavior

--- a/docs/content/guide/composition-api/validation.md
+++ b/docs/content/guide/composition-api/validation.md
@@ -200,8 +200,16 @@ export default {
 
 For more information on the `useForm` function, read [the API reference](/api/use-form).
 
-<doc-tip title="Yup Schema Optimizations">
-  There are a couple of optimization caveats when it comes to using `yup` schemas to validate your forms, be sure to check the [best practices guide](/tutorials/best-practices)
+<doc-tip title="Yup Schema Optimizations" type="warn">
+
+There are a couple of optimization caveats when it comes to using `yup` schemas to validate your forms, be sure to check the [best practices guide](/tutorials/best-practices).
+
+</doc-tip>
+
+<doc-tip title="Zod Schema Plugin">
+
+There is an official integration available for [Zod validation](https://github.com/colinhacks/zod) that you can use as a drop-in replacement for `yup`. Check the [zod integration page](/integrations/zod-schema-validation).
+
 </doc-tip>
 
 ## Validation Behavior

--- a/docs/content/integrations/3rd-party-integrations.md
+++ b/docs/content/integrations/3rd-party-integrations.md
@@ -1,7 +1,7 @@
 ---
 title: 3rd Party Integrations
 description: Integrations with other libraries and frameworks
-order: 1
+order: 2
 ---
 
 # 3rd Party Integrations

--- a/docs/content/integrations/zod-schema-validation.md
+++ b/docs/content/integrations/zod-schema-validation.md
@@ -1,0 +1,231 @@
+---
+title: Zod Schema Validation
+description: VeeValidate Official Zod Schema Integration
+order: 1
+---
+
+# Zod Schema Validation
+
+<div class="mb-10 w-full flex items-center justify-center">
+  <a href="https://vee-validate.logaretm.com/v4/guide/global-validators" target="_blank">
+    <img class="h-40" src="https://github.com/logaretm/vee-validate/raw/main/logo.png">
+  </a>
+
+  <a class="ml-4" href="https://vee-validate.logaretm.com/v4/guide/global-validators" target="_blank">
+    <img class="h-40" src="https://github.com/colinhacks/zod/raw/master/logo.svg">
+  </a>
+</div>
+
+If you prefer to use [zod](https://github.com/colinhacks/zod) for schema validation instead of [yup](https://github.com/jquense/yup), you can do so with the `@vee-validate/zod` package.
+
+With `@vee-validate/zod` you can use `Zod` typed schemas as drop-in replacements for `yup` schemas.
+
+## Install
+
+To use this plugin, make sure to install these packages `vee-validate`, `zod` and `@vee-validate/zod`.
+
+```sh
+yarn add vee-validate@next zod@beta @vee-validate/zod
+
+# or with NPM
+
+npm install vee-validate@next zod@beta @vee-validate/zod
+```
+
+## Validating with Zod
+
+You can create validation schemas for either field-level validation or form-level validation, the `@vee-validate/zod` exposes two functions that transform Zod's schemas into something that can be understood by `vee-validate` main core and use them to perform validation.
+
+## Field-level Validation
+
+The first function is `toFieldValidator`, which accepts a Zod schema. You can use the converted schema by passing it to the `rules` prop present on the `<Field />` component:
+
+```vue
+<template>
+  <Form>
+    <Field name="email" type="email" :rules="fieldSchema" />
+    <ErrorMessage name="email" />
+  </Form>
+</template>
+
+<script>
+import { Field, Form, ErrorMessage } from 'vee-validate';
+import { toFieldValidator } from '@vee-validate/zod';
+import * as zod from 'zod';
+
+export default {
+  components: {
+    Form,
+    Field,
+  },
+  setup() {
+    const fieldSchema = toFieldValidator(zod.string().nonempty('Field is required').email('Must be a valid email'));
+
+    return {
+      rules,
+    };
+  },
+};
+</script>
+```
+
+If you prefer to use the Composition API, then you can pass the converted schema to the `useField` function:
+
+```vue
+<template>
+  <input name="email" v-model="value" type="email" />
+  <span>{{ errorMessage }}</span>
+</template>
+
+<script>
+import { useField } from 'vee-validate';
+import { toFieldValidator } from '@vee-validate/zod';
+import * as zod from 'zod';
+
+export default {
+  setup() {
+    const fieldSchema = toFieldValidator(
+      zod.string().nonempty('Field is required').email({ message: 'Must be a valid email' })
+    );
+    const { value, errorMessage } = useField('email', fieldSchema);
+
+    return {
+      rules,
+    };
+  },
+};
+</script>
+```
+
+## Form-Level Validation
+
+You can also use Zod's `zod.object` to create validation schemas for your forms instead of individually passing it for each field, this is covered in general in the [form-level validation section](/guide/components/validation).
+
+To be able to use `zod.object` to define form schemas, you need to use another function with is appropriately named `toFormValidator`.
+
+The `toFormValidator` function accepts a Zod object schema and prepares it to be consumed by the vee-validate validation logic.
+
+You can pass the converted schema to the `validation-schema` prop present on the `<Form />` component:
+
+```vue
+<template>
+  <Form :validation-schema="validationSchema" @submit="onSubmit">
+    <Field name="email" type="email" />
+    <ErrorMessage name="email" />
+
+    <Field name="password" type="password" />
+    <ErrorMessage name="password" />
+
+    <button>Submit</button>
+  </Form>
+</template>
+
+<script>
+import { Form, Field, ErrorMessage } from 'vee-validate';
+import { toFormValidator } from '@vee-validate/zod';
+
+export default {
+  components: {
+    Form,
+    Field,
+    ErrorMessage,
+  },
+  setup() {
+    const validationSchema = toFormValidator(
+      zod.object({
+        email: zod.string().nonempty('This is required').email({ message: 'Must be a valid email' }),
+        password: zod.string().nonempty('This is required').min(8, { message: 'Too short' }),
+      })
+    );
+
+    function onSubmit(values) {
+      alert(JSON.stringify(values, null, 2));
+    }
+
+    return {
+      validationSchema,
+      onSubmit,
+    };
+  },
+};
+</script>
+```
+
+Alternatively, if you prefer to use the composition API, you can pass the converted schema as the `validationSchema` option accepted by the `useForm` function:
+
+```vue
+<template>
+  <form @submit="onSubmit">
+    <input name="email" v-model="email" type="email" />
+    <span>{{ errors.email }}</span>
+
+    <input name="password" v-model="password" type="password" />
+    <span>{{ errors.password }}</span>
+
+    <button>Submit</button>
+  </form>
+</template>
+
+<script>
+import { useField, useForm } from 'vee-validate';
+import { toFormValidator } from '@vee-validate/zod';
+
+export default {
+  setup() {
+    const validationSchema = toFormValidator(
+      zod.object({
+        email: zod.string().nonempty('This is required').email({ message: 'Must be a valid email' }),
+        password: zod.string().nonempty('This is required').min(8, { message: 'Too short' }),
+      })
+    );
+
+    const { handleSubmit, errors } = useForm({
+      validationSchema,
+    });
+
+    const { value: email } = useField('email');
+    const { value: password } = useField('password');
+
+    const onSubmit = handleSubmit(values => {
+      alert(JSON.stringify(values, null, 2));
+    });
+
+    return {
+      validationSchema,
+      email,
+      password,
+      errors,
+    };
+  },
+};
+</script>
+```
+
+<doc-tip title="TypeScript Form Values Inference">
+
+vee-validate will try to do its best to infer the types of the form values if you are using the composition API, vee-validate can infer the types of the form values when you provide either a `yup` or a converted `zod` validation schema.
+
+```typescript
+const validationSchema = toFormValidator(
+  zod.object({
+    email: zod.string().nonempty('This is required').email({ message: 'Must be a valid email' }),
+    age: zod.number().min(8, { message: 'Too smol' }),
+  })
+);
+
+const { handleSubmit, errors } = useForm({
+  validationSchema,
+  initialValues: {
+    // You get auto completion and type check for `email` and `age` properties
+  },
+});
+
+// You will get auto completion for possible errors for `email` and `age`
+errors.email;
+
+const onSubmit = handleSubmit(values => {
+  // Values will be typed as { email: string; age: number; }
+});
+```
+
+</doc-tip>

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -1,0 +1,102 @@
+# @vee-validate/zod
+
+<p align="center">
+  <a href="https://vee-validate.logaretm.com/v4/guide/global-validators" target="_blank">
+    <img width="150" src="https://github.com/logaretm/vee-validate/raw/main/logo.png">
+  </a>
+
+  <a href="https://vee-validate.logaretm.com/v4/guide/global-validators" target="_blank">
+    <img width="150" src="https://github.com/colinhacks/zod/raw/master/logo.svg">
+  </a>
+</p>
+
+> Official vee-validate integration with Zod schema validation
+
+## Getting Started
+
+This official vee-validate plugin allows you to use zod schemas as a drop-in replacement for [yup](https://github.com/jquense/yup).
+
+### Install
+
+Install these packages `vee-validate`, `zod` and `@vee-validate/zod`.
+
+```sh
+yarn add vee-validate zod @vee-validate/zod
+
+# or with NPM
+
+npm install vee-validate zod @vee-validate/zod
+```
+
+### Usage
+
+#### Field-level schema
+
+```js
+import { toFieldValidator } from '@vee-validate/zod';
+import * as zod from 'zod';
+
+const fieldSchema = toFieldValidator(zod.string().nonempty(REQUIRED_MSG).min(8, MIN_MSG));
+```
+
+Then use it with `<Field />` component or `useField` function:
+
+```vue
+<Field name="field" :rules="fieldSchema" />
+```
+
+```js
+const { value, errorMessage } = useField('field', fieldSchema);
+```
+
+#### Form-level schema
+
+```js
+import { toFormValidator } from '@vee-validate/zod';
+import * as zod from 'zod';
+
+const schema = toFormValidator(
+  zod
+    .object({
+      password: zod.string(),
+      confirmation: zod.string(),
+    })
+    .refine(data => data.confirmation === data.password, {
+      message: CONFIRM_MSG,
+      path: ['confirmation'],
+    })
+);
+```
+
+Then use it with `<Form />` component or `useForm` function:
+
+```vue
+<Form :validation-schema="schema">
+  ...
+</Form>
+```
+
+```js
+const { errors } = useForm({
+  validationSchema: schema,
+});
+```
+
+### Limitations
+
+Under the hood, this plugin converts zod schemas to `yup` schemas by wrapping them with a similar API, this means there are some limitations.
+
+- No type safety with form's `initialValues` or `setValues`
+- Some features of `zod` may not be supported
+
+As this plugin progresses it will be decided if it should join the main repo or not which would eliminate these limitations. It depends on the popularity of zod and this plugin.
+
+### Documentation
+
+You can find more information over at [vee-validate documentation here](https://vee-validate.logaretm.com/v4).
+
+For how to use zod, check [their repository](https://github.com/colinhacks/zod).
+
+### License
+
+MIT

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -84,12 +84,9 @@ const { errors } = useForm({
 
 ### Limitations
 
-Under the hood, this plugin converts zod schemas to `yup` schemas by wrapping them with a similar API, this means there are some limitations.
+Under the hood, this plugin converts zod schemas to `yup` schemas by wrapping them with a similar API, this means there are some limitations, if you encounter unexpected behaviors or type issues please report them.
 
-- No type safety with form's `initialValues` or `setValues`
-- Some features of `zod` may not be supported
-
-As this plugin progresses it will be decided if it should join the main repo or not which would eliminate these limitations. It depends on the popularity of zod and this plugin.
+At the moment there are no known limitations.
 
 ### Documentation
 

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -24,8 +24,8 @@
     "dist/*.d.ts"
   ],
   "peerDependencies": {
-    "zod": "^2.0.0-beta.29",
-    "vee-validate": "^4.1.18"
+    "vee-validate": "^4.1.18",
+    "zod": "^2.0.0-beta.29"
   },
   "devDependencies": {
     "zod": "^2.0.0-beta.29"

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vee-validate/zod",
-  "version": "1.0.0",
-  "description": "vee-validate integration with zod validation",
+  "version": "4.1.18",
+  "description": "vee-validate integration with zod schema validation",
   "author": "Abdelrahman Awad <logaretm1@gmail.com>",
   "license": "MIT",
   "module": "dist/vee-validate-zod.esm.js",
@@ -23,8 +23,9 @@
     "dist/*.js",
     "dist/*.d.ts"
   ],
-  "dependencies": {
-    "vee-validate": "^4.1.0"
+  "peerDependencies": {
+    "zod": "^2.0.0-beta.29",
+    "vee-validate": "^4.1.18"
   },
   "devDependencies": {
     "zod": "^2.0.0-beta.29"

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@vee-validate/zod",
+  "version": "1.0.0",
+  "description": "vee-validate integration with zod validation",
+  "author": "Abdelrahman Awad <logaretm1@gmail.com>",
+  "license": "MIT",
+  "module": "dist/vee-validate-zod.esm.js",
+  "unpkg": "dist/vee-validate-zod.js",
+  "main": "dist/vee-validate-zod.js",
+  "types": "dist/vee-validate-zod.d.ts",
+  "homepage": "https://vee-validate.logaretm.com/v4/guide/global-validators",
+  "repository": "https://github.com/logaretm/vee-validate",
+  "sideEffects": false,
+  "keywords": [
+    "VueJS",
+    "Vue",
+    "validation",
+    "validator",
+    "inputs",
+    "form"
+  ],
+  "files": [
+    "dist/*.js",
+    "dist/*.d.ts"
+  ],
+  "dependencies": {
+    "vee-validate": "^4.1.0"
+  },
+  "devDependencies": {
+    "zod": "^2.0.0-beta.29"
+  }
+}

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -31,7 +31,6 @@ export function toSchemaValidator<TValues extends Record<string, any>>(zodSchema
       }
 
       const errorsByField = result.error.formErrors.fieldErrors;
-      console.log(result.error.formErrors);
 
       const errors = Object.keys(errorsByField).reduce((acc, path) => {
         acc.push({ path, errors: errorsByField[path] });

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,0 +1,49 @@
+import type { ZodObject, ZodTypeAny } from 'zod';
+
+export function toFieldValidator(zodSchema: ZodTypeAny) {
+  return {
+    async validate(value: any) {
+      const result = await zodSchema.safeParseAsync(value);
+      if (result.success) {
+        return true;
+      }
+
+      const error: Error & { errors?: string[] } = new Error(result.error.message);
+      error.name = 'ValidationError';
+      error.errors = result.error.formErrors.formErrors;
+
+      throw error;
+    },
+  };
+}
+
+interface AggregatedZodError {
+  path: string;
+  errors: string[];
+}
+
+export function toSchemaValidator<TValues extends Record<string, any>>(zodSchema: ZodObject<TValues>) {
+  return {
+    async validate(value: TValues) {
+      const result = await zodSchema.safeParseAsync(value);
+      if (result.success) {
+        return true;
+      }
+
+      const errorsByField = result.error.formErrors.fieldErrors;
+      console.log(result.error.formErrors);
+
+      const errors = Object.keys(errorsByField).reduce((acc, path) => {
+        acc.push({ path, errors: errorsByField[path] });
+
+        return acc;
+      }, [] as AggregatedZodError[]);
+
+      const error: Error & { inner?: AggregatedZodError[] } = new Error(result.error.message);
+      error.name = 'ValidationError';
+      error.inner = errors;
+
+      throw error;
+    },
+  };
+}

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -22,7 +22,7 @@ interface AggregatedZodError {
   errors: string[];
 }
 
-export function toSchemaValidator<TValues extends Record<string, any>>(zodSchema: ZodObject<TValues>) {
+export function toFormValidator<TValues extends Record<string, any>>(zodSchema: ZodObject<TValues>) {
   return {
     async validate(value: TValues) {
       const result = await zodSchema.safeParseAsync(value);

--- a/packages/zod/tests/zod.spec.ts
+++ b/packages/zod/tests/zod.spec.ts
@@ -1,0 +1,94 @@
+import { mountWithHoc, setValue } from '../../vee-validate/tests/helpers';
+import * as zod from 'zod';
+import flushPromises from 'flush-promises';
+import { toFieldValidator, toSchemaValidator } from '../src/index';
+
+const REQUIRED_MSG = 'field is required';
+const MIN_MSG = 'field is too short';
+const EMAIL_MSG = 'field must be a valid email';
+
+test('validates field with zod', async () => {
+  const wrapper = mountWithHoc({
+    setup() {
+      const rules = toFieldValidator(zod.string().nonempty(REQUIRED_MSG).min(8, MIN_MSG));
+
+      return {
+        rules,
+      };
+    },
+    template: `
+      <div>
+        <Field name="field" :rules="rules" v-slot="{ field, errors }">
+          <input v-bind="field" type="text">
+          <p>{{ errors[0] }}</p>
+        </Field>
+      </div>
+    `,
+  });
+
+  const input = wrapper.$el.querySelector('input');
+  const error = wrapper.$el.querySelector('p');
+
+  setValue(input, '');
+  await flushPromises();
+  expect(error.textContent).toBe(REQUIRED_MSG);
+  setValue(input, '12');
+  await flushPromises();
+  expect(error.textContent).toBe(MIN_MSG);
+  setValue(input, '12345678');
+  await flushPromises();
+  expect(error.textContent).toBe('');
+});
+
+test.skip('validates form with zod', async () => {
+  const wrapper = mountWithHoc({
+    setup() {
+      const schema = toSchemaValidator(
+        zod.object({
+          email: zod.string().nonempty(REQUIRED_MSG).email(EMAIL_MSG),
+          password: zod.string().nonempty(REQUIRED_MSG).min(8, MIN_MSG),
+        })
+      );
+
+      return {
+        schema,
+      };
+    },
+    template: `
+      <VForm as="form" :validationSchema="schema" v-slot="{ errors }">
+        <Field id="email" name="email" as="input" />
+        <span id="emailErr">{{ errors.email }}</span>
+
+        <Field id="password" name="password" as="input" type="password" />
+        <span id="passwordErr">{{ errors.password }}</span>
+
+        <button>Validate</button>
+      </VForm>
+    `,
+  });
+
+  const email = wrapper.$el.querySelector('#email');
+  const password = wrapper.$el.querySelector('#password');
+  const emailError = wrapper.$el.querySelector('#emailErr');
+  const passwordError = wrapper.$el.querySelector('#passwordErr');
+
+  wrapper.$el.querySelector('button').click();
+  await flushPromises();
+
+  expect(emailError.textContent).toBe(REQUIRED_MSG);
+  expect(passwordError.textContent).toBe(REQUIRED_MSG);
+
+  setValue(email, 'hello@');
+  setValue(password, '1234');
+  await flushPromises();
+
+  expect(emailError.textContent).toBe(EMAIL_MSG);
+  expect(passwordError.textContent).toBe(MIN_MSG);
+
+  setValue(email, 'hello@email.com');
+  setValue(password, '12346789');
+  await flushPromises();
+
+  expect(emailError.textContent).toBe('');
+  expect(passwordError.textContent).toBe('');
+});

--- a/packages/zod/tests/zod.spec.ts
+++ b/packages/zod/tests/zod.spec.ts
@@ -1,7 +1,7 @@
 import { mountWithHoc, setValue, setChecked } from '../../vee-validate/tests/helpers';
 import * as zod from 'zod';
 import flushPromises from 'flush-promises';
-import { toFieldValidator, toSchemaValidator } from '../src/index';
+import { toFieldValidator, toFormValidator } from '../src/index';
 
 const REQUIRED_MSG = 'field is required';
 const MIN_MSG = 'field is too short';
@@ -43,7 +43,7 @@ test('validates field with zod', async () => {
 test('validates form with zod', async () => {
   const wrapper = mountWithHoc({
     setup() {
-      const schema = toSchemaValidator(
+      const schema = toFormValidator(
         zod.object({
           email: zod.string().nonempty(REQUIRED_MSG).email({ message: EMAIL_MSG }),
           password: zod.string().nonempty(REQUIRED_MSG).min(8, { message: MIN_MSG }),
@@ -103,7 +103,7 @@ test('cross field validation with zod', async () => {
   const CONFIRM_MSG = "Passwords don't match";
   const wrapper = mountWithHoc({
     setup() {
-      const schema = toSchemaValidator(
+      const schema = toFormValidator(
         zod
           .object({
             password: zod.string(),
@@ -159,7 +159,7 @@ test('cross field validation with zod', async () => {
 test('checkboxes with zod schema', async () => {
   const wrapper = mountWithHoc({
     setup() {
-      const schema = toSchemaValidator(
+      const schema = toFormValidator(
         zod.object({
           drink: zod.array(zod.string()).min(1, REQUIRED_MSG),
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8834,3 +8834,8 @@ yup@^0.32.8:
     nanoclone "^0.2.1"
     property-expr "^2.0.4"
     toposort "^2.0.2"
+
+zod@^2.0.0-beta.29:
+  version "2.0.0-beta.29"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-2.0.0-beta.29.tgz#153b5ca799def7f9f6e49a925bc992f8d5793d57"
+  integrity sha512-sKQv8DTkZ8WcuikGPBT/UIpXmzfmyux9RgngeCHhq9x8QUEpjxVLSY7dowNJt3eLzEl98Wa/ClKEzdc1mA4igQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8836,6 +8836,6 @@ yup@^0.32.8:
     toposort "^2.0.2"
 
 zod@^2.0.0-beta.29:
-  version "2.0.0-beta.29"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-2.0.0-beta.29.tgz#153b5ca799def7f9f6e49a925bc992f8d5793d57"
-  integrity sha512-sKQv8DTkZ8WcuikGPBT/UIpXmzfmyux9RgngeCHhq9x8QUEpjxVLSY7dowNJt3eLzEl98Wa/ClKEzdc1mA4igQ==
+  version "2.0.0-beta.30"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-2.0.0-beta.30.tgz#67ec3305c4a106a7bf9ef72078de72892d485dbe"
+  integrity sha512-nwCSRXRy1jt0872mMXT2E6VVHXr2hO7jGEtwc/TDqOBb7gGodwAjsQ6UCS4XJLUmjVvmqLsuPvAIN8oL26weCQ==


### PR DESCRIPTION
🔎 __Overview__

Add support for zod schemas by adding a new "resolver" package that converts them to `yup`-like schemas.

🤓 __Code snippets/examples (if applicable)__

```js
import { toFormValidator } from '@vee-validate/zod';
import * as zod from 'zod';
import { toFieldValidator } from '@vee-validate/zod';

// Field schema to be used with `Field.rules` prop or `useField`
const fieldSchema = toFieldValidator(zod.string().nonempty(REQUIRED_MSG).min(8, MIN_MSG));

// Field schema to be used with as form validation schema
const schema = toFormValidator(
  zod
    .object({
      password: zod.string(),
      confirmation: zod.string(),
    })
    .refine(data => data.confirmation === data.password, {
      message: CONFIRM_MSG,
      path: ['confirmation'],
    })
);
```

✔ __Issues affected__

closes #3160 
