### PR TITLE
Feat/adjust valid flag behavior

### DIFF
--- a/docs/content/api/field.md
+++ b/docs/content/api/field.md
@@ -165,9 +165,9 @@ interface FieldMeta {
 
 <doc-tip title="The valid flag">
 
-The `valid` flag on the meta object can be tricky, because by default it stars off with `true` until the field has been validated, only then it is updated to its proper state.
+The `valid` flag on the meta object can be tricky, because by default it stars off with `true` for a few moments, only then it is updated to its proper state.
 
-Combining your `valid` flag checks with `dirty` will yield the expected result based on user interaction. Otherwise you may use `validateOnMount` to make sure the field is validated immediately.
+Combining your `valid` flag checks with `dirty` will yield the expected result based on user interaction.
 
 </doc-tip>
 
@@ -250,8 +250,6 @@ await validate();
 
 Updates the field value, and validates the field. Can be used as an event handler to bind on the field. If the passed argument isn't an event object it will be used as the new value for that field.
 
-It sets the `dirty` meta flag to true
-
 <code-title level="4">
 
 `handleInput: (evt: Event | any) => void`
@@ -259,8 +257,6 @@ It sets the `dirty` meta flag to true
 </code-title>
 
 Updates the field value, **but does not validate the field**. Can be used as an event handler to bind on the field. If the passed argument isn't an event object it will be used as the new value for that field.
-
-It sets the `dirty` meta flag to true
 
 <code-title level="4">
 

--- a/docs/content/api/field.md
+++ b/docs/content/api/field.md
@@ -272,14 +272,6 @@ Because this handler doesn't set the field value, it might not report validation
 
 <code-title level="4">
 
-`setDirty: (isDirty: boolean) => void`
-
-</code-title>
-
-Sets the `dirty` meta flag for this field, useful to create your own `input` or other behaviors handlers
-
-<code-title level="4">
-
 `setTouched: (isTouched: boolean) => void`
 
 </code-title>

--- a/docs/content/api/form.md
+++ b/docs/content/api/form.md
@@ -204,22 +204,6 @@ Sets multiple fields values, will trigger validation for all the changed fields.
 
 <code-title level="4">
 
-`setFieldDirty: (field: string, isDirty: boolean) => void`
-
-</code-title>
-
-Sets a field's `dirty` meta flag
-
-<code-title level="4">
-
-`setDirty: (fields: Record<string, boolean>) => void`
-
-</code-title>
-
-Sets multiple fields `dirty` meta flag, does not validate.
-
-<code-title level="4">
-
 `setFieldTouched: (field: string, isTouched: boolean) => void`
 
 </code-title>
@@ -302,8 +286,6 @@ This is the shape of the `state` object:
 interface FormState {
   // any error messages
   errors: Record<string, string>;
-  // dirty meta flags
-  dirty: Record<string, boolean>;
   // touched meta flags
   touched: Record<string, boolean>;
   // Form Values

--- a/docs/content/api/use-field.md
+++ b/docs/content/api/use-field.md
@@ -406,21 +406,6 @@ setValidationState({ errors: [] });
 
 <code-title level="4">
 
-`setDirty: (isDirty: boolean) => void`
-
-</code-title>
-
-Sets the `dirty` meta flag for this field, useful to create your own `input` or other behaviors handlers
-
-```js
-const { setDirty } = useField('field', value => !!value);
-
-// mark the field as dirty
-setDirty(true);
-```
-
-<code-title level="4">
-
 `setTouched: (isTouched: boolean) => void`
 
 </code-title>

--- a/docs/content/api/use-field.md
+++ b/docs/content/api/use-field.md
@@ -197,9 +197,9 @@ interface FieldMeta {
 
 <doc-tip title="The valid flag">
 
-The `valid` flag on the meta object can be tricky, because by default it stars off with `true` until the field has been validated, only then it is updated to its proper state.
+The `valid` flag on the meta object can be tricky, because by default it stars off with `true` for a few moments, only then it is updated to its proper state.
 
-Combining your `valid` flag checks with `dirty` will yield the expected result based on user interaction. Otherwise you may use `validateOnMount` to make sure the field is validated immediately.
+Combining your `valid` flag checks with `dirty` will yield the expected result based on user interaction.
 
 </doc-tip>
 

--- a/docs/content/api/use-form.md
+++ b/docs/content/api/use-form.md
@@ -370,37 +370,6 @@ setValues({
 
 <code-title level="4">
 
-`setFieldDirty: (field: string, isDirty: boolean) => void`
-
-</code-title>
-
-Sets a field's `dirty` meta flag
-
-```js
-const { setFieldDirty } = useForm();
-
-setFieldDirty('email', true);
-```
-
-<code-title level="4">
-
-`setDirty: (fields: Record<string, boolean>) => void`
-
-</code-title>
-
-Sets multiple fields `dirty` meta flag, does not validate.
-
-```js
-const { setDirty } = useForm();
-
-setDirty({
-  email: true,
-  password: false,
-});
-```
-
-<code-title level="4">
-
 `setFieldTouched: (field: string, isTouched: boolean) => void`
 
 </code-title>
@@ -576,14 +545,11 @@ Clears error messages, resets the meta state for all fields and reverts their va
 This is the `FormState` interface:
 
 ```typescript
-type DirtyFlags = { [k: string]: boolean };
 type TouchedFlags = { [k: string]: boolean };
 
 interface FormState {
   // any error messages
   errors: Record<string, string>;
-  // dirty meta flags
-  dirty: DirtyFlags;
   // touched meta flags
   touched: TouchedFlags;
   // Form Values

--- a/docs/content/guide/components/handling-forms.md
+++ b/docs/content/guide/components/handling-forms.md
@@ -491,8 +491,6 @@ export interface FormActions {
   setValues: (fields: Partial<Record<T, any>>) => void;
   setFieldTouched: (field: string, isTouched: boolean) => void;
   setTouched: (fields: Partial<Record<string, boolean>>) => void;
-  setFieldDirty: (field: string, isDirty: boolean) => void;
-  setDirty: (fields: Partial<Record<string, boolean>>) => void;
   resetForm: (state?: Partial<FormState>) => void;
 }
 ```

--- a/docs/content/guide/components/validation.md
+++ b/docs/content/guide/components/validation.md
@@ -238,8 +238,8 @@ Note that `input` event is not considered to be a trigger because it would make 
 
 By default vee-validate adds multiple event listeners to your fields:
 
-- **input:** Adds a `handleInput` handler that updates the `meta.dirty` flag and updates the field value.
-- **change:** Adds a `handleInput` handler just like the input event but also adds a `handleChange` event that updates the field value and validates the field
+- **input:** Adds a `handleInput` handler that updates the field value (may update `meta.dirty` flag if the value changed).
+- **change:** Adds a `handleInput` handler that updates the field value and validates the field (may update `meta.dirty` flag if the value changed).
 - **blur:** Adds a `handleBlur` handler that updates the `meta.touched` flag.
 - **update:modelValue** Adds a `handleChange` handler to components emitting the `update:modelValue` event
 
@@ -391,7 +391,7 @@ If you are interested on how to do the same for global validators check the [i18
 
 Each field has meta data associated with it, the `meta` property available on the `<Field />` component contains additional information about the field:
 
-- `valid`: The current field validity, will be `true` if there are no messages inside the `errors` array. Note that `true` could either mean the field is valid or **that it was not validated yet**.
+- `valid`: The current field validity, will be `true` if there are no messages inside the `errors` array initially, but will be updated once the field is mounted.
 - `touched`: If the field was blurred (unfocused), updated by the `handleBlur` function.
 - `dirty`: If the field value was updated, both `handleChange` and `handleInput` update this flag.
 - `pending`: If the field's validations are still running, useful for long running async validation.
@@ -453,7 +453,7 @@ Forms also have their own `meta` value containing useful information about the f
 
 The form's meta data properties are:
 
-- `valid`: The form's validity status, will be `true` if the errors array is empty. Note that `true` could either mean the form doesn't have any errors or that the **form was not validated yet**.
+- `valid`: The form's validity status, will be `true` if the errors array is empty. After the form is mounted, vee-validate will update the flag to it's accurate state
 - `touched`: If at least one field was blurred (unfocused) inside the form.
 - `dirty`: If at least one field's value was updated.
 - `pending`: If at least one field's validation is still pending.

--- a/docs/content/guide/composition-api/handling-forms.md
+++ b/docs/content/guide/composition-api/handling-forms.md
@@ -303,8 +303,6 @@ export interface FormActions {
   setValues: (fields: Partial<Record<T, any>>) => void;
   setFieldTouched: (field: string, isTouched: boolean) => void;
   setTouched: (fields: Partial<Record<string, boolean>>) => void;
-  setFieldDirty: (field: string, isDirty: boolean) => void;
-  setDirty: (fields: Partial<Record<string, boolean>>) => void;
   resetForm: (state?: Partial<FormState>) => void;
 }
 ```

--- a/docs/content/guide/composition-api/validation.md
+++ b/docs/content/guide/composition-api/validation.md
@@ -248,7 +248,7 @@ The `useField` function exposes some handler functions, each handles a specific 
 
 - `handleChange`: Updates the field value, triggers validation in all cases.
 - `handleInput`: Updates the field value, triggers validation if `validateOnValueUpdate` option is enabled.
-- `handleBlur`: Updates some metadata, doesn't trigger validation.
+- `handleBlur`: Updates the `meta.touched` flag, doesn't trigger validation.
 
 ```js
 const { handleChange, handleBlur, handleInput } = useField('someField');
@@ -525,7 +525,7 @@ If you are interested on how to do the same for global validators check the [i18
 
 Each field has meta data associated with it, the `meta` property returned from `useField` contains information about the field:
 
-- `valid`: The current field validity, note that `true` could either mean the field is valid or **that it was not validated yet**.
+- `valid`: The current field validity, it starts off with `true` until the field is validated on mounted which will then reflect it's actual state
 - `touched`: If the field was blurred (unfocused), updated by the `handleBlur` function.
 - `dirty`: If the field value was updated, both `handleChange` and `handleInput` update this flag.
 - `pending`: If the field's validations are still running, useful for long running async validation.
@@ -597,7 +597,7 @@ To reduce the verbosity of adding an `initialValue` prop to each field, you coul
   
 Since the `meta.valid` flag is initially `true` (because it just means there are no errors yet), it would cause problems if you have a "success" UI state an indicator.
 
-To avoid this case you should combine the `valid` flag with either `meta.dirty` or `meta.touched` to get accurate representation:
+To avoid this case you should combine the `valid` flag with either `meta.dirty` or `meta.touched` to get accurate representation.
 
 </doc-tip>
 
@@ -615,7 +615,7 @@ meta.value.valid;
 meta.value.initialValues;
 ```
 
-- `valid`: The form's validity status, will be `true` if the errors array is empty. Note that `true` could either mean the form doesn't have any errors or that the **form was not validated yet**.
+- `valid`: The form's validity status, will be `true` if the errors array is empty initially, but will be updated once the form is mounted.
 - `touched`: If at least one field was blurred (unfocused) inside the form.
 - `dirty`: If at least one field's value was updated.
 - `pending`: If at least one field's validation is still pending.

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -172,11 +172,9 @@ export function useField<TValue = unknown>(
 
   let unwatchValue: WatchStopHandle;
   function watchValue() {
-    if (validateOnValueUpdate) {
-      unwatchValue = watch(value, validateWithStateMutation, {
-        deep: true,
-      });
-    }
+    unwatchValue = watch(value, validateOnValueUpdate ? validateWithStateMutation : validateValidStateOnly, {
+      deep: true,
+    });
   }
 
   watchValue();

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -164,9 +164,7 @@ export function useField<TValue = unknown>(
     }
   };
 
-  if (validateOnMount) {
-    onMounted(validateWithStateMutation);
-  }
+  onMounted(validateOnMount ? validateWithStateMutation : validateValidStateOnly);
 
   function setTouched(isTouched: boolean) {
     meta.touched = isTouched;

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -164,7 +164,18 @@ export function useField<TValue = unknown>(
     }
   };
 
-  onMounted(validateOnMount ? validateWithStateMutation : validateValidStateOnly);
+  // Runs the initial validation
+  onMounted(() => {
+    if (validateOnMount) {
+      return validateWithStateMutation();
+    }
+
+    // validate self initially if no form was handling this
+    // forms should have their own initial silent validation run to make things more efficient
+    if (!form || !form.validateSchema) {
+      validateValidStateOnly();
+    }
+  });
 
   function setTouched(isTouched: boolean) {
     meta.touched = isTouched;

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -483,19 +483,11 @@ function useFormMeta<TValues extends Record<string, unknown>>(
   currentValues: TValues,
   initialValues: MaybeReactive<TValues>
 ) {
-  const MERGE_STRATEGIES: Record<keyof Pick<FieldMeta<unknown>, 'touched' | 'pending'>, 'every' | 'some'> = {
+  const MERGE_STRATEGIES: Record<keyof Pick<FieldMeta<unknown>, 'touched' | 'pending' | 'valid'>, 'every' | 'some'> = {
     touched: 'some',
     pending: 'some',
+    valid: 'every',
   };
-
-  const isValid = computed(() => {
-    const keys = keysOf(errors.value);
-    if (!keys.length) {
-      return true;
-    }
-
-    return keys.every(key => !errors.value[key]);
-  });
 
   const isDirty = computed(() => {
     return !isEqual(currentValues, unref(initialValues));
@@ -513,7 +505,6 @@ function useFormMeta<TValues extends Record<string, unknown>>(
       initialValues: unref(initialValues) as TValues,
       ...flags,
       dirty: isDirty.value,
-      valid: isValid.value,
     };
   });
 }

--- a/packages/vee-validate/tests/Field.spec.ts
+++ b/packages/vee-validate/tests/Field.spec.ts
@@ -892,7 +892,7 @@ describe('<Field />', () => {
     const input = wrapper.$el.querySelector('input');
     const meta = wrapper.$el.querySelector('#meta');
 
-    expect(meta?.textContent).toBe('valid');
+    expect(meta?.textContent).toBe('invalid');
     setValue(input, '');
     await flushPromises();
     expect(meta?.textContent).toBe('invalid');
@@ -917,8 +917,11 @@ describe('<Field />', () => {
 
     await flushPromises();
     const meta = wrapper.$el.querySelector('#meta');
-
-    expect(meta?.textContent).toBe('valid');
+    expect(meta?.textContent).toBe('invalid');
+    const input = wrapper.$el.querySelector('input');
+    setValue(input, '');
+    await flushPromises();
+    expect(meta?.textContent).toBe('invalid');
 
     wrapper.$el.querySelector('button').click();
     await flushPromises();

--- a/packages/vee-validate/tests/Form.spec.ts
+++ b/packages/vee-validate/tests/Form.spec.ts
@@ -993,10 +993,10 @@ describe('<Form />', () => {
     const submitBtn = wrapper.$el.querySelector('#submit');
     const input = wrapper.$el.querySelector('input');
     await flushPromises();
-    expect(submitBtn.disabled).toBe(false);
-    setValue(input, '');
-    await flushPromises();
     expect(submitBtn.disabled).toBe(true);
+    setValue(input, '12');
+    await flushPromises();
+    expect(submitBtn.disabled).toBe(false);
   });
 
   test('nested object fields', async () => {
@@ -1595,7 +1595,7 @@ describe('<Form />', () => {
     await flushPromises();
     const span = wrapper.$el.querySelector('#meta');
     const input = wrapper.$el.querySelector('input');
-    expect(span.textContent).toBe('valid');
+    expect(span.textContent).toBe('invalid');
     setValue(input, '');
     await flushPromises();
 
@@ -1608,7 +1608,7 @@ describe('<Form />', () => {
   test('resetForm should reset the meta flag based on the errors length', async () => {
     const wrapper = mountWithHoc({
       template: `
-      <VForm  v-slot="{ meta, resetForm }">
+      <VForm :initial-values="{ email: '2', password: '3' }"  v-slot="{ meta, resetForm }">
         <Field id="email" name="email" as="input" rules="required" />
         <Field id="password" name="password" as="input" rules="required" />
 
@@ -1624,5 +1624,39 @@ describe('<Form />', () => {
     wrapper.$el.querySelector('button').click();
     await flushPromises();
     expect(span.textContent).toBe('invalid');
+  });
+
+  test('valid flag should reflect the accurate form validity', async () => {
+    const wrapper = mountWithHoc({
+      template: `
+      <VForm  v-slot="{ meta, resetForm }">
+        <Field id="email" name="email" as="input" rules="required" />
+        <Field id="password" name="password" as="input" rules="required" />
+
+        <span id="meta">{{ meta.valid ? 'valid' : 'invalid' }}</span>
+      </VForm>
+    `,
+    });
+
+    await flushPromises();
+    const span = wrapper.$el.querySelector('#meta');
+    expect(span.textContent).toBe('invalid');
+
+    const email = wrapper.$el.querySelector('#email');
+    setValue(email, '');
+    await flushPromises();
+    // the email field is invalid
+    expect(span.textContent).toBe('invalid');
+
+    // should be valid now
+    setValue(email, 'example@test.com');
+    await flushPromises();
+    // still invalid because the password is invalid
+    expect(span.textContent).toBe('invalid');
+
+    const password = wrapper.$el.querySelector('#password');
+    setValue(password, '12');
+    await flushPromises();
+    expect(span.textContent).toBe('valid');
   });
 });

--- a/packages/vee-validate/tests/useField.spec.ts
+++ b/packages/vee-validate/tests/useField.spec.ts
@@ -50,8 +50,7 @@ describe('useField()', () => {
     const meta = document.querySelector('#meta');
 
     await flushPromises();
-    // by default it should be `valid`
-    expect(meta?.textContent).toBe('valid');
+    expect(meta?.textContent).toBe('invalid');
 
     setValue(input, '');
     await flushPromises();
@@ -83,7 +82,12 @@ describe('useField()', () => {
 
     await flushPromises();
     const meta = document.querySelector('#meta');
-    // by default it should be `valid`
+    const input = document.querySelector('input') as HTMLInputElement;
+
+    expect(meta?.textContent).toBe('invalid');
+
+    setValue(input, '12');
+    await flushPromises();
     expect(meta?.textContent).toBe('valid');
 
     // trigger reset

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -258,7 +258,7 @@ describe('useForm()', () => {
     await flushPromises();
     const span = document.querySelector('#meta');
     const input = document.querySelector('input') as HTMLInputElement;
-    expect(span?.textContent).toBe('valid');
+    expect(span?.textContent).toBe('invalid');
     setValue(input, '');
     await flushPromises();
     expect(span?.textContent).toBe('invalid');
@@ -273,7 +273,6 @@ describe('useForm()', () => {
       setup() {
         const { meta: formMeta, resetForm } = useForm();
         const { value } = useField('field', val => (val ? true : REQUIRED_MESSAGE));
-        useField('password', val => (val ? true : REQUIRED_MESSAGE));
 
         return {
           value,
@@ -290,6 +289,11 @@ describe('useForm()', () => {
 
     await flushPromises();
     const span = document.querySelector('#meta');
+    expect(span?.textContent).toBe('invalid');
+
+    const input = document.querySelector('input') as HTMLInputElement;
+    setValue(input, '12');
+    await flushPromises();
     expect(span?.textContent).toBe('valid');
 
     document.querySelector('button')?.click();


### PR DESCRIPTION
🔎 __Overview__

The changes in 4.2 introduced by #3176 made a couple of common cases impossible to verify as reported by @cexbrayat in #3189 


This PR eliminates the "undetermined" issue caused by the `meta.valid` flag. Now vee-validate will always run a silent validation in various cases:

- When the form/field is mounted
- When the value changes

These silent validations do not populate the `errors` in fields or forms, instead they just update the `meta.valid` flag.

That means that for a very tiny amount of time, the `meta.valid` will be undetermined (true) until the silent validation has been executed then it would have an accurate representation.

This makes combining `valid` with `dirty` or `touched` more reliable.

✔ __Issues affected__

closes #3189
