### PR TITLE
chore: fix syntax error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ export default {
   },
   methods: {
     isRequired(value) {
-    return value ? true : 'This field is required';
+      return value ? true : 'This field is required';
+    },
   },
 };
 ```


### PR DESCRIPTION
🔎 __Overview__

This PR fixes syntax error in the example of declarative components.