### PR TITLE
Fixed mistype in digits translation for LT locale #3209

### DIFF
--- a/packages/i18n/src/locale/lt.json
+++ b/packages/i18n/src/locale/lt.json
@@ -7,7 +7,7 @@
     "alpha_spaces": "Laukelyje {field} leidžiamos tik raidės ir tarpai",
     "between": "Laukelio {field} reikšmė turi būti tarp 0:{min} ir 1:{max}",
     "confirmed": "Laukelio {field} patvirtinimas nesutampa",
-    "digits": "Lauklio {field} reikšmė turi buti 0:{length} ženklų(-o) skaitmuo",
+    "digits": "Laukelio {field} reikšmė turi buti 0:{length} ženklų(-o) skaitmuo",
     "dimensions": "{field} turi būti 0:{width} px x 1:{height} px",
     "email": "Laukelis {field} turi būti teisinga el. pašto adresas",
     "excluded": "{field} reikšmė nėra leidžiama",


### PR DESCRIPTION
🔎 __Overview__

  This PR fixes the lt locale translation.

✔ __Issues affected__

<!-- list of issues formatted like this
closes #{issue id}
 -->
 
