### PR TITLE
Export PublicFormContext interface

### DIFF
--- a/packages/vee-validate/src/index.ts
+++ b/packages/vee-validate/src/index.ts
@@ -12,6 +12,7 @@ export {
   FormState,
   FormValidationResult,
   FormContext,
+  PublicFormContext,
   SubmissionContext,
   SubmissionHandler,
 } from './types';


### PR DESCRIPTION
🔎 __Overview__

If i need to pass `form` variable to the nested component, i want to define prop type, and for that i we need to export `PublicFormContext`

i've checked it's working.

**App.vue**:
```vue
<template>
  <TestForm :form="form" />
</template>

<script lang="ts">
export default defineComponent({
  setup() {
    const form = useForm<SomeInterface>(); // form: PublicFormContext<SomeInterface>

    return {
      form,
    };
  },
});
</script>
```

**TestForm.vue**:
```vue
<script lang="ts">
import '...';

// I need this
import { PublicFormContext } from 'vee-validate';

export default defineComponent({
  props: {
    form: {
      type: Object as PropType<PublicFormContext<SomeInterface>>, // to use here
    },
  },
});
</script>
```
