### PR TITLE
feat: added support for reactive schemas

### DIFF
--- a/docs/content/guide/components/validation.md
+++ b/docs/content/guide/components/validation.md
@@ -232,6 +232,40 @@ export default {
 };
 ```
 
+```vue
+<template>
+  <Form @submit="submit" :validation-schema="schema">
+    <Field name="password" type="password" />
+    <ErrorMessage name="password" />
+
+    <button>Submit</button>
+  </Form>
+</template>
+
+<script>
+import { Form, Field, ErrorMessage } from 'vee-validate';
+import * as yup from 'yup';
+
+export default {
+  components: {
+    Form,
+    Field,
+    ErrorMessage,
+  },
+  data: () => ({
+    min: 6,
+  }),
+  computed: {
+    schema() {
+      return yup.object({
+        password: yup.string().min(this.min),
+      });
+    },
+  },
+};
+</script>
+```
+
 When the validation schema changes, only the fields that were validated at least once will be re-validated, the other fields won't be validated to avoid aggressive validation behavior.
 
 ## Validation Behavior

--- a/docs/content/guide/components/validation.md
+++ b/docs/content/guide/components/validation.md
@@ -211,6 +211,29 @@ There is an official integration available for [Zod validation](https://github.c
 
 </doc-tip>
 
+### Reactive Form Schema
+
+You can have reactive form schemas using `computed` if you are looking to create dynamic schemas using either `yup` or a validation object.
+
+```js
+import * as yup from 'yup';
+
+export default {
+  data: () => ({
+    min: 6,
+  }),
+  computed: {
+    schema() {
+      return yup.object({
+        password: yup.string().min(this.min),
+      });
+    },
+  },
+};
+```
+
+When the validation schema changes, only the fields that were validated at least once will be re-validated, the other fields won't be validated to avoid aggressive validation behavior.
+
 ## Validation Behavior
 
 By default vee-validate runs validation in these scenarios:

--- a/docs/content/guide/composition-api/validation.md
+++ b/docs/content/guide/composition-api/validation.md
@@ -212,6 +212,29 @@ There is an official integration available for [Zod validation](https://github.c
 
 </doc-tip>
 
+### Reactive Form Schema
+
+You can have reactive form schemas using `computed` if you are looking to create dynamic schemas using either `yup` or a validation object.
+
+```js
+import { computed, ref } from 'vue';
+import * as yup from 'yup';
+import { useForm } from 'vee-validate';
+
+const min = ref(0);
+const schema = computed(() => {
+  return yup.object({
+    password: yup.string().min(min.value)
+  });
+});
+
+const { ... } = useForm({
+  validationSchema: schema
+});
+```
+
+When the validation schema changes, only the fields that were validated at least once will be re-validated, the other fields won't be validated to avoid aggressive validation behavior.
+
 ## Validation Behavior
 
 <doc-tip>

--- a/docs/content/guide/composition-api/validation.md
+++ b/docs/content/guide/composition-api/validation.md
@@ -216,21 +216,40 @@ There is an official integration available for [Zod validation](https://github.c
 
 You can have reactive form schemas using `computed` if you are looking to create dynamic schemas using either `yup` or a validation object.
 
-```js
+```vue
+<template>
+  <input name="password" v-model="password" type="password" />
+  <span>{{ passwordError }}</span>
+</template>
+
+<script>
 import { computed, ref } from 'vue';
+import { useForm, useField } from 'vee-validate';
 import * as yup from 'yup';
-import { useForm } from 'vee-validate';
 
-const min = ref(0);
-const schema = computed(() => {
-  return yup.object({
-    password: yup.string().min(min.value)
-  });
-});
+export default {
+  setup() {
+    const min = ref(0);
+    const schema = computed(() => {
+      return yup.object({
+        password: yup.string().min(min.value),
+      });
+    });
 
-const { ... } = useForm({
-  validationSchema: schema
-});
+    // Create a form context with the validation schema
+    useForm({
+      validationSchema: schema,
+    });
+
+    const { value: password, errorMessage: passwordError } = useField('password');
+
+    return {
+      password,
+      passwordError,
+    };
+  },
+};
+</script>
 ```
 
 When the validation schema changes, only the fields that were validated at least once will be re-validated, the other fields won't be validated to avoid aggressive validation behavior.

--- a/packages/vee-validate/src/Form.ts
+++ b/packages/vee-validate/src/Form.ts
@@ -38,6 +38,8 @@ export const Form = defineComponent({
   },
   setup(props, ctx) {
     const initialValues = toRef(props, 'initialValues');
+    const validationSchema = toRef(props, 'validationSchema');
+
     const {
       errors,
       values,
@@ -57,7 +59,7 @@ export const Form = defineComponent({
       setFieldTouched,
       setTouched,
     } = useForm({
-      validationSchema: props.validationSchema,
+      validationSchema: validationSchema.value ? validationSchema : undefined,
       initialValues,
       initialErrors: props.initialErrors,
       initialTouched: props.initialTouched,

--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -25,6 +25,7 @@ export interface FieldMeta<TValue> {
   touched: boolean;
   dirty: boolean;
   valid: boolean;
+  validated: boolean;
   pending: boolean;
   initialValue?: TValue;
 }
@@ -107,6 +108,12 @@ export type SubmissionHandler<TValues extends Record<string, unknown> = Record<s
   ctx: SubmissionContext<TValues>
 ) => unknown;
 
+/**
+ * validated-only: only mutate the previously validated fields
+ * silent: do not mutate any field
+ * force: validate all fields and mutate their state
+ */
+export type SchemaValidationMode = 'validated-only' | 'silent' | 'force';
 export interface FormContext<TValues extends Record<string, any> = Record<string, any>> extends FormActions<TValues> {
   register(field: PrivateFieldComposite): void;
   unregister(field: PrivateFieldComposite): void;
@@ -114,7 +121,7 @@ export interface FormContext<TValues extends Record<string, any> = Record<string
   fieldsById: ComputedRef<Record<keyof TValues, PrivateFieldComposite | PrivateFieldComposite[]>>;
   submitCount: Ref<number>;
   schema?: MaybeRef<Record<keyof TValues, GenericValidateFunction | string | Record<string, any>> | SchemaOf<TValues>>;
-  validateSchema?: (shouldMutate?: boolean) => Promise<Record<keyof TValues, ValidationResult>>;
+  validateSchema?: (mode: SchemaValidationMode) => Promise<Record<keyof TValues, ValidationResult>>;
   validate(): Promise<FormValidationResult<TValues>>;
   validateField(field: keyof TValues): Promise<ValidationResult>;
   errorBag: Ref<FormErrorBag<TValues>>;

--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -113,7 +113,7 @@ export interface FormContext<TValues extends Record<string, any> = Record<string
   values: TValues;
   fieldsById: ComputedRef<Record<keyof TValues, PrivateFieldComposite | PrivateFieldComposite[]>>;
   submitCount: Ref<number>;
-  schema?: Record<keyof TValues, GenericValidateFunction | string | Record<string, any>> | SchemaOf<TValues>;
+  schema?: MaybeRef<Record<keyof TValues, GenericValidateFunction | string | Record<string, any>> | SchemaOf<TValues>>;
   validateSchema?: (shouldMutate?: boolean) => Promise<Record<keyof TValues, ValidationResult>>;
   validate(): Promise<FormValidationResult<TValues>>;
   validateField(field: keyof TValues): Promise<ValidationResult>;

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -117,6 +117,7 @@ export function useField<TValue = unknown>(
   async function validateWithStateMutation(): Promise<ValidationResult> {
     meta.pending = true;
     let result: ValidationResult;
+    meta.validated = true;
     if (!form || !form.validateSchema) {
       result = await validateValue(value.value, normalizedRules.value, {
         name: unref(label) || unref(name),
@@ -124,7 +125,7 @@ export function useField<TValue = unknown>(
         bails,
       });
     } else {
-      result = (await form.validateSchema())[unref(name)] ?? { valid: true, errors: [] };
+      result = (await form.validateSchema('validated-only'))[unref(name)] ?? { valid: true, errors: [] };
     }
 
     meta.pending = false;
@@ -141,7 +142,7 @@ export function useField<TValue = unknown>(
         bails,
       });
     } else {
-      result = (await form.validateSchema(false))?.[unref(name)] ?? { valid: true, errors: [] };
+      result = (await form.validateSchema('silent'))?.[unref(name)] ?? { valid: true, errors: [] };
     }
 
     meta.valid = result.valid;
@@ -392,6 +393,7 @@ function useValidationState<TValue>({
     setErrors(state?.errors || []);
     meta.touched = state?.touched ?? false;
     meta.pending = false;
+    meta.validated = false;
   }
 
   return {
@@ -416,6 +418,7 @@ function useMeta<TValue>(initialValue: MaybeRef<TValue>, currentValue: Ref<TValu
     touched: false,
     pending: false,
     valid: true,
+    validated: false,
     initialValue: computed(() => unref(initialValue) as TValue | undefined),
     dirty: computed(() => {
       return !isEqual(currentValue.value, unref(initialValue));

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -102,7 +102,7 @@ export function useField<TValue = unknown>(
 
   const normalizedRules = computed(() => {
     let rulesValue = unref(rules);
-    const schema = form?.schema;
+    const schema = unref(form?.schema);
     if (schema && !isYupValidator(schema)) {
       rulesValue = extractRuleFromSchema<TValue>(schema, unref(name)) || rulesValue;
     }


### PR DESCRIPTION
🔎 __Overview__

<!-- Explain the why behind adding this PR, here is a couple of examples -->

Adds support for reactive form schemas for the `<Form />` and `useForm`

<!--
  This PR {adds/fixes/improves} the {feature/bug/something}.
  This PR changes the {locale} messages style because {reason}
-->

It allows using `computed` to create reactive schema objects

```js
import * as yup from 'yup';
import { computed, ref } from 'vue';
import { useForm } from 'vee-validate';

const accepted = ref(['1', '2', '3']);
const schema = computed(() => {
  return yup.object({
    field: yup.string().oneOf(accepted.value);
  })
});

useForm({
  validationSchema: schema
});
```

✔ __Issues affected__

<!-- list of issues formatted like this
closes #{issue id}
 -->

closes #3235 
 
