### PR TITLE
feat: support `v-model.number`

### DIFF
--- a/packages/shared/utils.ts
+++ b/packages/shared/utils.ts
@@ -33,3 +33,9 @@ export function merge(target: any, source: any) {
 export function isIndex(value: unknown): value is number {
   return Number(value) >= 0;
 }
+
+export function toNumber(value: string): number | string {
+  const n = parseFloat(value);
+
+  return isNaN(n) ? value : n;
+}

--- a/packages/vee-validate/src/Field.ts
+++ b/packages/vee-validate/src/Field.ts
@@ -2,6 +2,7 @@ import { h, defineComponent, toRef, SetupContext, resolveDynamicComponent, compu
 import { getConfig } from './config';
 import { useField } from './useField';
 import { normalizeChildren, hasCheckedAttr, shouldHaveValueBinding } from './utils';
+import { toNumber } from '../../shared';
 
 interface ValidationTriggersProps {
   validateOnMount: boolean;
@@ -61,6 +62,10 @@ export const Field = defineComponent({
     },
     modelValue: {
       type: null,
+    },
+    modelModifiers: {
+      type: null,
+      default: () => ({}),
     },
   },
   emits: ['update:modelValue'],
@@ -177,7 +182,7 @@ export const Field = defineComponent({
     if ('modelValue' in props) {
       const modelValue = toRef(props, 'modelValue');
       watch(modelValue, newModelValue => {
-        if (newModelValue !== value.value) {
+        if (newModelValue !== applyModifiers(value.value, props.modelModifiers)) {
           value.value = newModelValue;
           validateField();
         }
@@ -224,4 +229,12 @@ function resolveValidationTriggers(props: ValidationTriggersProps) {
     validateOnBlur: props.validateOnBlur ?? validateOnBlur,
     validateOnModelUpdate: props.validateOnModelUpdate ?? validateOnModelUpdate,
   };
+}
+
+function applyModifiers(value: unknown, modifiers: Record<string, boolean>) {
+  if (modifiers.number) {
+    return toNumber(value as string);
+  }
+
+  return value;
 }


### PR DESCRIPTION
🔎 __Overview__

As we've discussed [here](https://github.com/logaretm/vee-validate/issues/3230). The `v-model.number` modifier triggers the validation on every type regardless of the validation triggers settings. It only affects `number` modifier, `trim` modifier works just fine.

This PR adds the support for `v-model.number` modifier.

✔ __Issues affected__

Closes #3230
 
