### PR TITLE
grammar fix: it's -> its

### DIFF
--- a/docs/concepts/injections.md
+++ b/docs/concepts/injections.md
@@ -22,7 +22,7 @@ export default {
 };
 ```
 
-This will make the component inherit it's parent's validator scope, thus sharing all errors and validation state. Meaning it has access to the same `errors` and `fields` computed properties as well.
+This will make the component inherit its parent's validator scope, thus sharing all errors and validation state. Meaning it has access to the same `errors` and `fields` computed properties as well.
 
 ::: tip
   If the direct parent isn't able to provide a validator scope, the API will traverse the tree upwards looking for a parent that can.

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -5,7 +5,7 @@ The [English messages file](https://github.com/logaretm/vee-validate/blob/v2/loc
 
 ## Aliases
 
-Not only can you create and overwrite messages but you can also provide an alias for a field that to be used in the message instead of it's original name. Seeing 'first_name' in your error messages can't be very good for your users experience. There is a couple of solutions.
+Not only can you create and overwrite messages but you can also provide an alias for a field that to be used in the message instead of its original name. Seeing 'first_name' in your error messages can't be very good for your users experience. There is a couple of solutions.
 
 ### Using data-vv-as
 

--- a/docs/guide/messages.md
+++ b/docs/guide/messages.md
@@ -16,7 +16,7 @@ It receives the field name or an alias for it as the first parameter, as well as
 
 ## Overwriting Messages
 
-The Validator class and it's instances provide a `localize` method, which will merge the provided messages with the internal dictionary, overwriting any duplicates.
+The Validator class and its instances provide a `localize` method, which will merge the provided messages with the internal dictionary, overwriting any duplicates.
 
 ::: tip
   Any merges will have an effect on all validator instances as the messages dictionary is shared.


### PR DESCRIPTION
🔎 __Overview__

This PR provides a minor grammar fix for V2, changing three instances of possessive "its" from "it's" to "its".  
That's all.  Small potatoes.  My mom was a teacher, what can I say.

🤓 __Code snippets/examples (if applicable)__

N/A

✔ __Issues affected__

No issues affected.
 
