### PR TITLE
chore: test failure with vue v3.1.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,11 +60,11 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-config-standard": "^9.0.0",
     "typescript": "4.1.5",
-    "vue": "^3.0.0",
+    "vue": "3.1.0-beta.2",
     "yup": "^0.32.9"
   },
   "peerDependencies": {
-    "vue": "^3.0.0"
+    "vue": "3.1.0-beta.2"
   },
   "lint-staged": {
     "*.ts": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,53 +1773,53 @@
     "@typescript-eslint/types" "4.22.0"
     eslint-visitor-keys "^2.0.0"
 
-"@vue/compiler-core@3.0.11":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.11.tgz#5ef579e46d7b336b8735228758d1c2c505aae69a"
-  integrity sha512-6sFj6TBac1y2cWCvYCA8YzHJEbsVkX7zdRs/3yK/n1ilvRqcn983XvpBbnN3v4mZ1UiQycTvOiajJmOgN9EVgw==
+"@vue/compiler-core@3.1.0-beta.2":
+  version "3.1.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.1.0-beta.2.tgz#fa66626d621801676d11fd28e05ca43f88c67b2f"
+  integrity sha512-HLd5kCiZojcbcu4+PqD22XKkmqvo3XuM7xRAst3y0KXMlmCnkHIK7Z5mmogPjf/xBBZllWl2CIy9+bR7wrdDSA==
   dependencies:
     "@babel/parser" "^7.12.0"
     "@babel/types" "^7.12.0"
-    "@vue/shared" "3.0.11"
+    "@vue/shared" "3.1.0-beta.2"
     estree-walker "^2.0.1"
     source-map "^0.6.1"
 
-"@vue/compiler-dom@3.0.11":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.11.tgz#b15fc1c909371fd671746020ba55b5dab4a730ee"
-  integrity sha512-+3xB50uGeY5Fv9eMKVJs2WSRULfgwaTJsy23OIltKgMrynnIj8hTYY2UL97HCoz78aDw1VDXdrBQ4qepWjnQcw==
+"@vue/compiler-dom@3.1.0-beta.2":
+  version "3.1.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.1.0-beta.2.tgz#4c415102e20b3f54f733dd47d299f396bd0026ca"
+  integrity sha512-FgGCZyaJZ81eCydc6IY0u79DVt09vURYKj95bgQJo07doHW0tHptz9N3zRudfhA0VjoXuRMeDoKHMHuxI1rVHA==
   dependencies:
-    "@vue/compiler-core" "3.0.11"
-    "@vue/shared" "3.0.11"
+    "@vue/compiler-core" "3.1.0-beta.2"
+    "@vue/shared" "3.1.0-beta.2"
 
-"@vue/reactivity@3.0.11":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.11.tgz#07b588349fd05626b17f3500cbef7d4bdb4dbd0b"
-  integrity sha512-SKM3YKxtXHBPMf7yufXeBhCZ4XZDKP9/iXeQSC8bBO3ivBuzAi4aZi0bNoeE2IF2iGfP/AHEt1OU4ARj4ao/Xw==
+"@vue/reactivity@3.1.0-beta.2":
+  version "3.1.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.1.0-beta.2.tgz#fd4acc6b65e7ed1aa28dc85a78a67389c396c616"
+  integrity sha512-vyP7sZZguSSDXdJ+rK/4+JNBHbmoPkmfQAPmIq1IGEfoA0SHuG4Rd8Ehtrm2LDtMSh2a1gPNjRQrmMffFddhsQ==
   dependencies:
-    "@vue/shared" "3.0.11"
+    "@vue/shared" "3.1.0-beta.2"
 
-"@vue/runtime-core@3.0.11":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.11.tgz#c52dfc6acf3215493623552c1c2919080c562e44"
-  integrity sha512-87XPNwHfz9JkmOlayBeCCfMh9PT2NBnv795DSbi//C/RaAnc/bGZgECjmkD7oXJ526BZbgk9QZBPdFT8KMxkAg==
+"@vue/runtime-core@3.1.0-beta.2":
+  version "3.1.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.1.0-beta.2.tgz#abb1c0e606002fc6ac08cc1af8eaf17ebd9caa2b"
+  integrity sha512-adcboyG3NJEMgf3TBKYWAwTkN4UyMHJI1TRbUkh60t9m0QOH7cuNIDKtrEoy4XTCtH0mVfJ0P7Vob+axOMKB/A==
   dependencies:
-    "@vue/reactivity" "3.0.11"
-    "@vue/shared" "3.0.11"
+    "@vue/reactivity" "3.1.0-beta.2"
+    "@vue/shared" "3.1.0-beta.2"
 
-"@vue/runtime-dom@3.0.11":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.11.tgz#7a552df21907942721feb6961c418e222a699337"
-  integrity sha512-jm3FVQESY3y2hKZ2wlkcmFDDyqaPyU3p1IdAX92zTNeCH7I8zZ37PtlE1b9NlCtzV53WjB4TZAYh9yDCMIEumA==
+"@vue/runtime-dom@3.1.0-beta.2":
+  version "3.1.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.1.0-beta.2.tgz#ddace09673677db312b09aa099a876b1d76bd9e9"
+  integrity sha512-LIJEJ/tR5l0bJwyPrbo7c/VFk9lVYkm0X7NowfWHL12aJfdigLNlu1t+jzUvZSt3noQdz8yKYP/zWrjOoLHvqg==
   dependencies:
-    "@vue/runtime-core" "3.0.11"
-    "@vue/shared" "3.0.11"
+    "@vue/runtime-core" "3.1.0-beta.2"
+    "@vue/shared" "3.1.0-beta.2"
     csstype "^2.6.8"
 
-"@vue/shared@3.0.11":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.11.tgz#20d22dd0da7d358bb21c17f9bde8628152642c77"
-  integrity sha512-b+zB8A2so8eCE0JsxjL24J7vdGl8rzPQ09hZNhystm+KqSbKcAej1A+Hbva1rCMmTTqA+hFnUSDc5kouEo0JzA==
+"@vue/shared@3.1.0-beta.2":
+  version "3.1.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.1.0-beta.2.tgz#1189078bbf081c3f19e98709c27cbbafbfcdc6f7"
+  integrity sha512-PZNk03DalUOn3f5Egf/pcaINPLwpcwshjo4PuMXV/76PBfHvKxvkVhCL+aYDfY/9ZeKH+H0hQ00otuAFRLjlKw==
 
 JSONStream@^1.0.4:
   version "1.3.5"
@@ -8240,14 +8240,14 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vue@^3.0.0:
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.11.tgz#c82f9594cbf4dcc869241d4c8dd3e08d9a8f4b5f"
-  integrity sha512-3/eUi4InQz8MPzruHYSTQPxtM3LdZ1/S/BvaU021zBnZi0laRUyH6pfuE4wtUeLvI8wmUNwj5wrZFvbHUXL9dw==
+vue@3.1.0-beta.2:
+  version "3.1.0-beta.2"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.1.0-beta.2.tgz#5d9a67c41e75d45cc1facea096d1a2f8483d024c"
+  integrity sha512-kjvIWSiB4TVujOho/dQEwcOuZNtdw+pk/qF9qGpzJ9EoSq2TlF5FvUCCX8ZGslM1iQperlYftRWmiNrPUJCDYA==
   dependencies:
-    "@vue/compiler-dom" "3.0.11"
-    "@vue/runtime-dom" "3.0.11"
-    "@vue/shared" "3.0.11"
+    "@vue/compiler-dom" "3.1.0-beta.2"
+    "@vue/runtime-dom" "3.1.0-beta.2"
+    "@vue/shared" "3.1.0-beta.2"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
🔎 __Overview__

👋 @logaretm 

Just for the heads up: Vue v3.1.0-beta.2 is out, and our projects have test failures with VeeValidate when we bump to the new beta.
It looks like the same failures are occurring in your unit tests. 
I don't know if it is a regression in vue-next or something that needs fixing with vee-validate...

