### PR TITLE
fix: added a symbol to detect non passed props with Vue 3.1.x

### DIFF
--- a/packages/vee-validate/src/symbols.ts
+++ b/packages/vee-validate/src/symbols.ts
@@ -12,3 +12,5 @@ export const FormInitialValuesSymbol: InjectionKey<ComputedRef<Record<string, un
 );
 
 export const FieldContextSymbol: InjectionKey<PrivateFieldComposite<unknown>> = Symbol('vee-validate-field-instance');
+
+export const EMPTY_VALUE = Symbol('Default empty value');

--- a/packages/vee-validate/src/utils/assertions.ts
+++ b/packages/vee-validate/src/utils/assertions.ts
@@ -1,5 +1,6 @@
 import { Locator, YupValidator } from '../types';
 import { isCallable, isObject } from '../../../shared';
+import { EMPTY_VALUE } from '../symbols';
 
 export function isLocator(value: unknown): value is Locator {
   return isCallable(value) && !!(value as Locator).__locatorRef;
@@ -98,4 +99,8 @@ export function isEvent(evt: unknown): evt is Event {
   }
 
   return false;
+}
+
+export function isPropPresent(obj: Record<string, unknown>, prop: string) {
+  return prop in obj && obj[prop] !== EMPTY_VALUE;
 }


### PR DESCRIPTION
As reported in #3294 the new behavior of prop keys always present causes issues with checkboxes and initial value detection, this is caused by the reliance on detecting if a user didn't pass a `model-value` prop.

This PR mitigates this by introducing a unique symbol value as a default to deter when the user didn't pass a model value.