### PR TITLE
fix: deprecate handleInput and use handleChange for both events

### DIFF
--- a/docs/content/api/field.md
+++ b/docs/content/api/field.md
@@ -156,7 +156,7 @@ Contains useful information/flags about the field status.
 ```typescript
 interface FieldMeta {
   touched: boolean; // if the field has been blurred (via handleBlur)
-  dirty: boolean; // if the field has been manipulated (via handleInput or handleChange)
+  dirty: boolean; // if the field has been manipulated (via handleChange)
   valid: boolean; // if the field doesn't have any errors
   pending: boolean; // if validation is in progress
   initialValue?: any; // the field's initial value
@@ -244,19 +244,13 @@ await validate();
 
 <code-title level="4">
 
-`handleChange: (evt: Event | any) => void`
+`handleChange: (evt: Event | any, shouldValidate?: boolean) => void`
 
 </code-title>
 
-Updates the field value, and validates the field. Can be used as an event handler to bind on the field. If the passed argument isn't an event object it will be used as the new value for that field.
+Updates the field value, and validates the field vt default. Can be used as an event handler to bind on the field. If the passed argument isn't an event object it will be used as the new value for that field.
 
-<code-title level="4">
-
-`handleInput: (evt: Event | any) => void`
-
-</code-title>
-
-Updates the field value, **but does not validate the field**. Can be used as an event handler to bind on the field. If the passed argument isn't an event object it will be used as the new value for that field.
+You can update the field value without validation by passing `false` as a second argument.
 
 <code-title level="4">
 

--- a/docs/content/api/use-field.md
+++ b/docs/content/api/use-field.md
@@ -115,8 +115,7 @@ type useField = (
   errorMessage: Ref<string | undefined>; // the first error message
   resetField: (state?: Partial<FieldState>) => void; // resets errors and field meta, updates the current value to its initial value
   validate: () => Promise<ValidationResult>; // validates and updates the errors and field meta
-  handleChange: (e: Event) => void; // updates the value
-  handleInput: (e: Event) => void; // updates the field meta associated with input event and syncs the field value
+  handleChange: (e: Event, shouldValidate?: boolean) => void; // updates the value and triggers validation
   handleBlur: (e: Event) => void; // updates the field meta associated with blur event
   setValidationState: (v: ValidationResult) => ValidationResult; // updates the field state
   checked: ComputedRef<boolean> | undefined; // Present if input type is checkbox
@@ -188,7 +187,7 @@ Contains useful information/flags about the field status, should be treated as *
 ```typescript
 interface FieldMeta {
   touched: boolean; // if the field has been blurred (via handleBlur)
-  dirty: boolean; // if the field has been manipulated (via handleInput or handleChange)
+  dirty: boolean; // if the field has been manipulated (via handleChange)
   valid: boolean; // if the field doesn't have any errors
   pending: boolean; // if validation is in progress
   initialValue?: any; // the field's initial value
@@ -321,39 +320,10 @@ export default {
     const { handleChange } = useField('field');
 
     handleChange('new value'); // update field value and validate it
+    handleChange('new value 2', false); // update field value without validating it (you have to turn off validateOnValueUpdate)
 
     return {
       handleChange,
-    };
-  },
-};
-</script>
-```
-
-<code-title level="4">
-
-`handleInput: (evt: Event | any) => void`
-
-</code-title>
-
-Updates the field value, **but does not validate the field**. Can be used as an event handler to bind on the field. If the passed argument isn't an event object it will be used as the new value for that field.
-
-It sets the `dirty` meta flag to `true`
-
-```vue
-<template>
-  <input @input="handleInput" type="text" />
-</template>
-
-<script>
-export default {
-  setup() {
-    const { handleInput } = useField('field');
-
-    handleInput('new value'); // update field value
-
-    return {
-      handleInput,
     };
   },
 };

--- a/docs/content/guide/components/validation.md
+++ b/docs/content/guide/components/validation.md
@@ -295,8 +295,8 @@ Note that `input` event is not considered to be a trigger because it would make 
 
 By default vee-validate adds multiple event listeners to your fields:
 
-- **input:** Adds a `handleInput` handler that updates the field value (may update `meta.dirty` flag if the value changed).
-- **change:** Adds a `handleInput` handler that updates the field value and validates the field (may update `meta.dirty` flag if the value changed).
+- **input:** Adds a `handleChange` handler that updates the field value, and it may validate if configured to do so (may update `meta.dirty` flag if the value changed).
+- **change:** Adds a `handleChange` handler that updates the field value and validates the field (may update `meta.dirty` flag if the value changed).
 - **blur:** Adds a `handleBlur` handler that updates the `meta.touched` flag.
 - **update:modelValue** Adds a `handleChange` handler to components emitting the `update:modelValue` event
 
@@ -348,6 +348,15 @@ In addition to those events, you can also validate when the `<Field />` or `<For
   <Field name="email" />
   <Field name="password" />
 </Form>
+```
+
+You can also specify if a `handleChange` call should trigger validation or not by providing the second argument:
+
+```vue
+<!-- Only update field value without validating it -->
+<Field v-slot="{ field, handleChange }">
+  <input @change="$event => handleChange($event, false)" :value="field.value" />
+</Field>
 ```
 
 ## Displaying Error Messages

--- a/docs/content/guide/composition-api/validation.md
+++ b/docs/content/guide/composition-api/validation.md
@@ -288,12 +288,11 @@ value.value = 'something';
 
 The `useField` function exposes some handler functions, each handles a specific aspect of the validation experience:
 
-- `handleChange`: Updates the field value, triggers validation in all cases.
-- `handleInput`: Updates the field value, triggers validation if `validateOnValueUpdate` option is enabled.
+- `handleChange`: Updates the field value, can be configured to trigger validation or silently update the value
 - `handleBlur`: Updates the `meta.touched` flag, doesn't trigger validation.
 
 ```js
-const { handleChange, handleBlur, handleInput } = useField('someField');
+const { handleChange, handleBlur } = useField('someField');
 ```
 
 In this example we are validating on `input` event (when the user types), which would make the validation aggressive:
@@ -373,7 +372,7 @@ export default {
       // ...
     }
 
-    const { errorMessage, value, handleChange, handleInput } = useField('fieldName', isRequired, {
+    const { errorMessage, value, handleChange } = useField('fieldName', isRequired, {
       validateOnValueUpdate: false,
     });
 
@@ -384,7 +383,8 @@ export default {
         return {
           blur: handleChange,
           change: handleChange,
-          input: handleInput,
+          // disable `shouldValidate` to avoid validating on input
+          input: e => handleChange(e, false),
         };
       }
 

--- a/packages/vee-validate/src/Field.ts
+++ b/packages/vee-validate/src/Field.ts
@@ -105,8 +105,8 @@ export const Field = defineComponent({
 
     // If there is a v-model applied on the component we need to emit the `update:modelValue` whenever the value binding changes
     const onChangeHandler = isPropPresent(props, 'modelValue')
-      ? function handleChangeWithModel(e: any) {
-          handleChange(e);
+      ? function handleChangeWithModel(e: unknown, shouldValidate = true) {
+          handleChange(e, shouldValidate);
           ctx.emit('update:modelValue', value.value);
         }
       : handleChange;
@@ -123,12 +123,8 @@ export const Field = defineComponent({
         props
       );
       const baseOnBlur = [handleBlur, ctx.attrs.onBlur, validateOnBlur ? validateField : undefined].filter(Boolean);
-      const baseOnInput = [onInputHandler, validateOnInput ? onChangeHandler : undefined, ctx.attrs.onInput].filter(
-        Boolean
-      );
-      const baseOnChange = [onInputHandler, validateOnChange ? onChangeHandler : undefined, ctx.attrs.onChange].filter(
-        Boolean
-      );
+      const baseOnInput = [(e: unknown) => onChangeHandler(e, validateOnInput), ctx.attrs.onInput].filter(Boolean);
+      const baseOnChange = [(e: unknown) => onChangeHandler(e, validateOnChange), ctx.attrs.onChange].filter(Boolean);
 
       const attrs: Record<string, any> = {
         name: props.name,

--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -53,7 +53,7 @@ export interface PrivateFieldComposite<TValue = unknown> {
   resetField(state?: FieldState<TValue>): void;
   handleReset(state?: FieldState<TValue>): void;
   validate(): Promise<ValidationResult>;
-  handleChange(e: Event | unknown): void;
+  handleChange(e: Event | unknown, shouldValidate?: boolean): void;
   handleBlur(e?: Event): void;
   handleInput(e?: Event | unknown): void;
   setValidationState(state: ValidationResult): void;

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -149,7 +149,7 @@ export function useField<TValue = unknown>(
   }
 
   // Common input/change event handler
-  const handleChange = (e: unknown) => {
+  const handleChange = (e: unknown, shouldValidate = true) => {
     if (checked && checked.value === ((e as Event)?.target as HTMLInputElement)?.checked) {
       return;
     }
@@ -161,7 +161,7 @@ export function useField<TValue = unknown>(
     }
 
     value.value = newValue;
-    if (!validateOnValueUpdate) {
+    if (!validateOnValueUpdate && shouldValidate) {
       return validateWithStateMutation();
     }
   };
@@ -364,6 +364,7 @@ function useValidationState<TValue>({
 
   /**
    * Handles common on blur events
+   * @deprecated You should use `handleChange` instead
    */
   const handleInput = (e: unknown) => {
     // Checkboxes/Radio will emit a `change` event anyway, custom components will use `update:modelValue`


### PR DESCRIPTION
## What

This fixes the cases where the input has disabled the `validateOnChange` while relying on it to update the value, like `checkbox` components/inputs 

## How

This deprecates the `handleInput` and instead introduces an optional argument called `shouldValidate` on the `handleChange` function.

```js
const { handleChange } = useField('field');

handleChange('new value');
handleChange('new value 2', false); 
```

closes #3298 
 
