### PR TITLE
chore: rename the value prop to checkedValue

### DIFF
--- a/docs/content/api/use-field.md
+++ b/docs/content/api/use-field.md
@@ -88,7 +88,8 @@ interface FieldOptions {
   bails?: boolean; // if the field validation should run all validations
   label?: string; // A friendly name to be used in `generateMessage` config instead of the field name
   type?: string; // The input type, can be any string. Toggles specific toggle mode for `checkbox`
-  valueProp?: string; // Used the input type is `checkbox` or `radio` otherwise ignored
+  checkedValue?: string; // Used the input type is `checkbox` or `radio` otherwise ignored
+  uncheckedValue?: string; // Used the input type is `checkbox` otherwise ignored
 }
 
 interface ValidationResult {

--- a/docs/content/examples/custom-checkboxes.md
+++ b/docs/content/examples/custom-checkboxes.md
@@ -20,7 +20,7 @@ This is because of the nature of checkboxes behaving as **"multi-value"** form i
 
 With all of that in mind, vee-validate offers simple abstractions for checkboxes. You can build your own checkboxes with vee-validate's `useField` function which gives you the full capabilities of validation in a composable fashion.
 
-Because `useField` isn't aware of what kind of input will be composed with it, you will need to specify that the input is of type `checkbox` and pass a `valueProp` as well which represents that single field's value. By doing so, you gain access to `checked` prop which tells you if the checkbox should be selected.
+Because `useField` isn't aware of what kind of input will be composed with it, you will need to specify that the input is of type `checkbox` and pass a `checkedValue` as well which represents that single field's value. By doing so, you gain access to `checked` prop which tells you if the checkbox should be selected.
 
 ```js
 import { useField } from 'vee-validate';
@@ -47,7 +47,7 @@ export default {
     const { checked, handleChange } = useField(props.name, props.rules, {
       // 👇 These are important
       type: 'checkbox',
-      valueProp: props.value,
+      checkedValue: props.value,
     });
 
     // select/unselect the input
@@ -66,3 +66,18 @@ vee-validate handles some of the complexities of the checkbox inputs nature, by 
 Here is a live example of a custom checkbox input:
 
 <code-sandbox id="vee-validate-custom-checkboxes-v0rnv" title="vee-validate custom checkboxes"></code-sandbox>
+
+<doc-tip>
+
+You can also specify a custom `uncheckedValue` which sets the input value to when it is unchecked.
+
+```js
+const { checked, handleChange } = useField('toa', undefined, {
+  // Will make the checkbox set its value to true/false if it was checked or not
+  type: 'checkbox',
+  checkedValue: true,
+  uncheckedValue: false,
+});
+```
+
+</doc-tip>

--- a/packages/vee-validate/src/Field.ts
+++ b/packages/vee-validate/src/Field.ts
@@ -97,7 +97,7 @@ export const Field = defineComponent({
       type: ctx.attrs.type as string,
       initialValue: resolveInitialValue(props, ctx),
       // Only for checkboxes and radio buttons
-      valueProp: ctx.attrs.value,
+      checkedValue: ctx.attrs.value,
       uncheckedValue,
       label,
       validateOnValueUpdate: false,

--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -47,7 +47,7 @@ export interface PrivateFieldComposite<TValue = unknown> {
   errors: Ref<string[]>;
   errorMessage: ComputedRef<string | undefined>;
   type?: string;
-  valueProp?: MaybeRef<TValue>;
+  checkedValue?: MaybeRef<TValue>;
   uncheckedValue?: MaybeRef<TValue>;
   checked?: ComputedRef<boolean>;
   resetField(state?: FieldState<TValue>): void;

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -46,6 +46,7 @@ interface FieldOptions<TValue = unknown> {
   bails?: boolean;
   type?: string;
   valueProp?: MaybeRef<TValue>;
+  checkedValue?: MaybeRef<TValue>;
   uncheckedValue?: MaybeRef<TValue>;
   label?: MaybeRef<string>;
 }
@@ -74,7 +75,7 @@ export function useField<TValue = unknown>(
     validateOnMount,
     bails,
     type,
-    valueProp,
+    checkedValue,
     label,
     validateOnValueUpdate,
     uncheckedValue,
@@ -97,7 +98,7 @@ export function useField<TValue = unknown>(
     initValue: initialValue,
     form,
     type,
-    valueProp,
+    checkedValue,
   });
 
   const normalizedRules = computed(() => {
@@ -157,7 +158,7 @@ export function useField<TValue = unknown>(
     let newValue = normalizeEventValue(e) as TValue;
     // Single checkbox field without a form to toggle it's value
     if (checked && type === 'checkbox' && !form) {
-      newValue = resolveNextCheckboxValue(value.value, unref(valueProp), unref(uncheckedValue)) as TValue;
+      newValue = resolveNextCheckboxValue(value.value, unref(checkedValue), unref(uncheckedValue)) as TValue;
     }
 
     value.value = newValue;
@@ -207,7 +208,7 @@ export function useField<TValue = unknown>(
     errors,
     errorMessage,
     type,
-    valueProp,
+    checkedValue,
     uncheckedValue,
     checked,
     resetField,
@@ -311,9 +312,13 @@ function normalizeOptions<TValue>(name: string, opts: Partial<FieldOptions<TValu
     return defaults();
   }
 
+  // TODO: Deprecate this in next major release
+  const checkedValue = 'valueProp' in opts ? opts.valueProp : opts.checkedValue;
+
   return {
     ...defaults(),
     ...(opts || {}),
+    checkedValue,
   };
 }
 
@@ -325,10 +330,10 @@ function useValidationState<TValue>({
   initValue,
   form,
   type,
-  valueProp,
+  checkedValue,
 }: {
   name: MaybeRef<string>;
-  valueProp?: MaybeRef<TValue>;
+  checkedValue?: MaybeRef<TValue>;
   initValue?: MaybeRef<TValue>;
   form?: FormContext;
   type?: string;
@@ -348,10 +353,10 @@ function useValidationState<TValue>({
   const checked = hasCheckedAttr(type)
     ? computed(() => {
         if (Array.isArray(value.value)) {
-          return value.value.includes(unref(valueProp));
+          return value.value.includes(unref(checkedValue));
         }
 
-        return unref(valueProp) === value.value;
+        return unref(checkedValue) === value.value;
       })
     : undefined;
 

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -267,7 +267,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
 
     // otherwise find the actual value in the current array of values and remove it
     const valueIdx: number | undefined = getFromPath<unknown[] | undefined>(formValues, fieldName)?.indexOf?.(
-      unref(field.valueProp)
+      unref(field.checkedValue)
     );
 
     if (valueIdx === undefined) {


### PR DESCRIPTION
## What

This PR renames the `valueProp` option used by `useField` to `checkedValue` since this is its only valid use.

This can be a breaking change but at the moment it accounts for both `valueProp` and `checkedValue`, so it's backward compatible.
