### PR TITLE
fix(provider): changed flag computation

### DIFF
--- a/src/components/Provider.ts
+++ b/src/components/Provider.ts
@@ -256,7 +256,7 @@ export const ValidationProvider = (Vue as withProviderPrivates).extend({
     syncValue(v: any) {
       const value = normalizeEventValue(v);
       this.value = value;
-      this.flags.changed = this.initialValue !== value;
+      this.flags.changed = !isEqual(this.initialValue, value);
     },
     reset() {
       this.errors = [];
@@ -319,7 +319,7 @@ export const ValidationProvider = (Vue as withProviderPrivates).extend({
         invalid: !!errors.length,
         failed: !!errors.length,
         validated: true,
-        changed: this.value !== this.initialValue
+        changed: !isEqual(this.value, this.initialValue)
       });
     },
     registerField() {


### PR DESCRIPTION
🔎 __Overview__

This PR fixes the bug with provider changed flag.

It now works with object and array values.
I use the pre-existing `isEqual` function instead of a simple equality operator.
(and add tests :wink: )

✔ __Issues affected__

closes #3300
