### PR TITLE
perf: re-write field tracking and batch schema validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [4.5.0-alpha.2](https://github.com/logaretm/vee-validate/compare/v4.5.0-alpha.1...v4.5.0-alpha.2) (2021-07-08)
 
-
 ### Bug Fixes
 
-* clean error message for singular fields after unmount ([#3385](https://github.com/logaretm/vee-validate/issues/3385)) ([79c82eb](https://github.com/logaretm/vee-validate/commit/79c82eb9009662576f8f23b8491626c20176d92f))
-
-
-
-
+- clean error message for singular fields after unmount ([#3385](https://github.com/logaretm/vee-validate/issues/3385)) ([79c82eb](https://github.com/logaretm/vee-validate/commit/79c82eb9009662576f8f23b8491626c20176d92f))
 
 # [4.5.0-alpha.1](https://github.com/logaretm/vee-validate/compare/v4.4.5...v4.5.0-alpha.1) (2021-07-06)
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
+  setupFilesAfterEnv: ['./jest.setup.js'],
   testEnvironment: 'jsdom',
   rootDir: __dirname,
   testMatch: ['<rootDir>/packages/**/tests/**/*spec.[jt]s?(x)'],

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,6 @@
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+afterEach(() => {
+  jest.useRealTimers();
+});

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "npmClient": "yarn",
   "version": "4.5.0-alpha.2",
   "useWorkspaces": true,

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -7,10 +7,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @vee-validate/i18n
 
-
-
-
-
 # [4.5.0-alpha.1](https://github.com/logaretm/vee-validate/compare/v4.4.5...v4.5.0-alpha.1) (2021-07-06)
 
 **Note:** Version bump only for package @vee-validate/i18n

--- a/packages/i18n/tests/index.spec.ts
+++ b/packages/i18n/tests/index.spec.ts
@@ -1,8 +1,7 @@
-import flushPromises from 'flush-promises';
 import { defineRule, configure } from '@/vee-validate';
 import { required, between } from '@/rules';
 import { localize, setLocale } from '@/i18n';
-import { mountWithHoc, setValue } from '../../vee-validate/tests/helpers';
+import { mountWithHoc, setValue, flushPromises } from '../../vee-validate/tests/helpers';
 
 defineRule('required', required);
 defineRule('between', between);

--- a/packages/rules/CHANGELOG.md
+++ b/packages/rules/CHANGELOG.md
@@ -7,10 +7,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @vee-validate/rules
 
-
-
-
-
 # [4.5.0-alpha.1](https://github.com/logaretm/vee-validate/compare/v4.4.5...v4.5.0-alpha.1) (2021-07-06)
 
 **Note:** Version bump only for package @vee-validate/rules

--- a/packages/vee-validate/CHANGELOG.md
+++ b/packages/vee-validate/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [4.5.0-alpha.2](https://github.com/logaretm/vee-validate/compare/v4.5.0-alpha.1...v4.5.0-alpha.2) (2021-07-08)
 
-
 ### Bug Fixes
 
-* clean error message for singular fields after unmount ([#3385](https://github.com/logaretm/vee-validate/issues/3385)) ([79c82eb](https://github.com/logaretm/vee-validate/commit/79c82eb9009662576f8f23b8491626c20176d92f))
-
-
-
-
+- clean error message for singular fields after unmount ([#3385](https://github.com/logaretm/vee-validate/issues/3385)) ([79c82eb](https://github.com/logaretm/vee-validate/commit/79c82eb9009662576f8f23b8491626c20176d92f))
 
 # [4.5.0-alpha.1](https://github.com/logaretm/vee-validate/compare/v4.4.5...v4.5.0-alpha.1) (2021-07-06)
 

--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -40,7 +40,6 @@ export type WritableRef<TValue> = Ref<TValue> | WritableComputedRef<TValue>;
 
 export interface PrivateFieldContext<TValue = unknown> {
   fid: number;
-  idx: number;
   name: MaybeRef<string>;
   value: WritableRef<TValue>;
   meta: FieldMeta<TValue>;
@@ -123,7 +122,7 @@ export interface PrivateFormContext<TValues extends Record<string, any> = Record
   register(field: PrivateFieldContext): void;
   unregister(field: PrivateFieldContext): void;
   values: TValues;
-  fieldsById: ComputedRef<Record<keyof TValues, PrivateFieldContext | PrivateFieldContext[]>>;
+  fieldsByPath: Ref<Record<keyof TValues, PrivateFieldContext | PrivateFieldContext[]>>;
   submitCount: Ref<number>;
   schema?: MaybeRef<RawFormSchema<TValues> | SchemaOf<TValues> | undefined>;
   validateSchema?: (mode: SchemaValidationMode) => Promise<FormValidationResult<TValues>>;
@@ -149,7 +148,7 @@ export interface FormContext<TValues extends Record<string, any> = Record<string
     PrivateFormContext<TValues>,
     | 'register'
     | 'unregister'
-    | 'fieldsById'
+    | 'fieldsByPath'
     | 'schema'
     | 'validateSchema'
     | 'errorBag'

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -205,7 +205,6 @@ export function useField<TValue = unknown>(
   }
 
   const field: PrivateFieldContext<TValue> = {
-    idx: -1,
     fid,
     name,
     label,

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -351,13 +351,18 @@ function useValidationState<TValue>({
   const { errors, errorMessage, setErrors } = useFieldErrors(name, form);
   const formInitialValues = standalone ? undefined : injectWithSelf(FormInitialValuesKey, undefined);
   // clones the ref value to a mutable version
-  const initialValueRef = ref(unref(initValue)) as Ref<TValue>;
+  const initialValueSourceRef = ref(unref(initValue)) as Ref<TValue>;
 
   const initialValue = computed(() => {
-    return getFromPath<TValue>(unref(formInitialValues), unref(name), unref(initialValueRef)) as TValue;
+    return getFromPath<TValue>(unref(formInitialValues), unref(name), unref(initialValueSourceRef)) as TValue;
   });
 
-  const value = useFieldValue(initialValue, name, form);
+  const value = useFieldValue(
+    initialValueSourceRef.value === undefined ? initialValue : initialValueSourceRef,
+    name,
+    form
+  );
+
   const meta = useFieldMeta(initialValue, value, errors);
 
   const checked = hasCheckedAttr(type)
@@ -409,7 +414,7 @@ function useValidationState<TValue>({
       form.setFieldInitialValue(fieldPath, newValue);
     } else {
       value.value = newValue;
-      initialValueRef.value = newValue;
+      initialValueSourceRef.value = newValue;
     }
 
     setErrors(state?.errors || []);

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -527,6 +527,10 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
    * Sneaky function to set initial field values
    */
   function stageInitialValue(path: string, value: unknown) {
+    if (formValues[path] && value === undefined) {
+      return;
+    }
+
     setInPath(formValues, path, value);
     setFieldInitialValue(path, value);
   }

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -1,4 +1,4 @@
-import { computed, ref, Ref, provide, reactive, onMounted, isRef, watch, unref, nextTick, warn } from 'vue';
+import { computed, ref, Ref, provide, reactive, onMounted, isRef, watch, unref, nextTick, warn, markRaw } from 'vue';
 import isEqual from 'fast-deep-equal/es6';
 import type { SchemaOf } from 'yup';
 import { klona as deepCopy } from 'klona/lite';
@@ -28,6 +28,7 @@ import {
   unsetPath,
   isFormSubmitEvent,
   normalizeField,
+  debounceAsync,
 } from './utils';
 import { FormErrorsKey, FormContextKey, FormInitialValuesKey } from './symbols';
 import { validateYupSchema, validateObjectSchema } from './validate';
@@ -47,37 +48,11 @@ type RegisteredField = PrivateFieldContext | PrivateFieldContext[];
 export function useForm<TValues extends Record<string, any> = Record<string, any>>(
   opts?: FormOptions<TValues>
 ): FormContext<TValues> {
-  // A flat array containing field references
-  const fields: Ref<PrivateFieldContext[]> = ref([]);
+  // A lookup containing fields or field groups
+  const fieldsByPath: Ref<Record<keyof TValues, RegisteredField>> = ref({} as any);
 
   // If the form is currently submitting
   const isSubmitting = ref(false);
-
-  // a field map object useful for faster access of fields
-  const fieldsById = computed<Record<keyof TValues, RegisteredField>>(() => {
-    return fields.value.reduce((acc, field) => {
-      const fieldPath: keyof TValues = unref(field.name);
-      // if the field was not added before
-      if (!acc[fieldPath]) {
-        acc[fieldPath] = field;
-        field.idx = -1;
-
-        return acc;
-      }
-      // if the same name is detected
-      const existingField: RegisteredField = acc[fieldPath];
-      if (!Array.isArray(existingField)) {
-        existingField.idx = 0;
-        acc[fieldPath] = [existingField];
-      }
-
-      const fieldGroup = acc[fieldPath] as PrivateFieldContext[];
-      field.idx = fieldGroup.length;
-      fieldGroup.push(field);
-
-      return acc;
-    }, {} as Record<keyof TValues, RegisteredField>);
-  });
 
   // The number of times the user tried to submit the form
   const submitCount = ref(0);
@@ -107,8 +82,8 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
    * Holds a computed reference to all fields names and labels
    */
   const fieldNames = computed(() => {
-    return keysOf(fieldsById.value).reduce((names, path) => {
-      const field = normalizeField(fieldsById.value[path]);
+    return keysOf(fieldsByPath.value).reduce((names, path) => {
+      const field = normalizeField(fieldsByPath.value[path]);
       if (field) {
         names[path as string] = unref(field.label || field.name) || '';
       }
@@ -118,8 +93,8 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
   });
 
   const fieldBailsMap = computed(() => {
-    return keysOf(fieldsById.value).reduce((map, path) => {
-      const field = normalizeField(fieldsById.value[path]);
+    return keysOf(fieldsByPath.value).reduce((map, path) => {
+      const field = normalizeField(fieldsByPath.value[path]);
       if (field) {
         map[path as string] = field.bails ?? true;
       }
@@ -134,17 +109,17 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
 
   // initial form values
   const { readonlyInitialValues, initialValues, setInitialValues } = useFormInitialValues<TValues>(
-    fieldsById,
+    fieldsByPath,
     formValues,
     opts?.initialValues
   );
 
   // form meta aggregations
-  const meta = useFormMeta(fields, formValues, readonlyInitialValues, errors);
+  const meta = useFormMeta(fieldsByPath, formValues, readonlyInitialValues, errors);
 
   const schema = opts?.validationSchema;
   const formCtx: PrivateFormContext<TValues> = {
-    fieldsById,
+    fieldsByPath,
     values: formValues,
     errorBag,
     schema,
@@ -191,7 +166,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     value: TValues[T] | undefined,
     { force } = { force: false }
   ) {
-    const fieldInstance: RegisteredField | undefined = fieldsById.value[field];
+    const fieldInstance: RegisteredField | undefined = fieldsByPath.value[field];
     // field wasn't found, create a virtual field as a placeholder
     if (!fieldInstance) {
       setInPath(formValues, field as string, value);
@@ -249,7 +224,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
    * Sets the touched meta state on a field
    */
   function setFieldTouched(field: keyof TValues, isTouched: boolean) {
-    const fieldInstance: RegisteredField | undefined = fieldsById.value[field];
+    const fieldInstance: RegisteredField | undefined = fieldsByPath.value[field];
     if (!fieldInstance) {
       return;
     }
@@ -280,7 +255,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     }
 
     // Reset all fields state
-    fields.value.forEach(f => f.resetField());
+    Object.values(fieldsByPath.value).forEach(fieldGroup => applyFieldMutation(fieldGroup, f => f.resetField()));
 
     if (state?.touched) {
       setTouched(state.touched);
@@ -290,26 +265,72 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     submitCount.value = state?.submitCount || 0;
   }
 
+  function insertFieldAtPath(field: PrivateFieldContext, path: string) {
+    const rawField = markRaw(field);
+    const fieldPath: keyof TValues = path;
+    // if the field was not added before
+    if (!fieldsByPath.value[path]) {
+      fieldsByPath.value[fieldPath] = rawField;
+      return;
+    }
+
+    const existingField: RegisteredField = fieldsByPath.value[fieldPath];
+    if (!Array.isArray(existingField)) {
+      fieldsByPath.value[fieldPath] = [existingField];
+    }
+
+    const fieldGroup = fieldsByPath.value[fieldPath] as PrivateFieldContext[];
+    fieldGroup.push(rawField);
+  }
+
+  function removeFieldFromPath(field: PrivateFieldContext, path: string) {
+    const fieldPath: keyof TValues = path;
+    const fieldOrFieldGroup = fieldsByPath.value[fieldPath];
+    if (!fieldOrFieldGroup) {
+      return;
+    }
+
+    if (!Array.isArray(fieldOrFieldGroup)) {
+      // delete the path if its a singular field
+      delete fieldsByPath.value[fieldPath];
+
+      return;
+    }
+
+    // if its a field group remove that specific field
+    const fieldIdx = fieldOrFieldGroup.indexOf(field);
+    if (fieldIdx !== -1) {
+      fieldOrFieldGroup.splice(fieldIdx, 1);
+    }
+
+    // if no field in the group remains, remove the entire group
+    if (fieldOrFieldGroup.length === 0) {
+      delete fieldsByPath.value[fieldPath];
+    }
+  }
+
   function registerField(field: PrivateFieldContext) {
-    fields.value.push(field);
-    // TODO: Do this automatically on registration
-    // eslint-disable-next-line no-unused-expressions
-    fieldsById.value; // force computation of the fields ids to properly set their idx
+    const fieldPath = unref(field.name);
+    insertFieldAtPath(field, fieldPath);
+
     if (isRef(field.name)) {
       valuesByFid[field.fid] = field.value.value;
       // ensures when a field's name was already taken that it preserves its same value
       // necessary for fields generated by loops
+
       watch(
         field.name,
         (newPath, oldPath) => {
+          removeFieldFromPath(field, oldPath);
+          insertFieldAtPath(field, newPath);
           setFieldValue(newPath, valuesByFid[field.fid]);
-          const isSharingName = fields.value.find(f => unref(f.name) === oldPath);
+          // const isSharingName = fields.value.find(f => unref(f.name) === oldPath);
           // clean up the old path if no other field is sharing that name
           // #3325
-          if (!isSharingName) {
-            unsetPath(formValues, oldPath);
-            unsetPath(initialValues.value, oldPath);
-          }
+          // if (!isSharingName) {
+          //   unsetPath(formValues, oldPath);
+          //   unsetPath(initialValues.value, oldPath);
+          // }
         },
         {
           flush: 'post',
@@ -320,23 +341,18 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     // if field already had errors (initial errors) that's not user-set, validate it again to ensure state is correct
     // the difference being that `initialErrors` will contain the error message while other errors (pre-validated schema) won't have them as initial errors
     // #3342
-    const path = unref(field.name);
     const initialErrorMessage = unref(field.errorMessage);
-    if (initialErrorMessage && initialErrors?.[path] !== initialErrorMessage) {
-      validateField(path);
+    if (initialErrorMessage && initialErrors?.[fieldPath] !== initialErrorMessage) {
+      validateField(fieldPath);
     }
 
     // marks the initial error as "consumed" so it won't be matched later with same non-initial error
-    delete initialErrors[path];
+    delete initialErrors[fieldPath];
   }
 
   function unregisterField(field: PrivateFieldContext<unknown>) {
-    const idx = fields.value.indexOf(field);
-    if (idx === -1) {
-      return;
-    }
-
-    fields.value.splice(idx, 1);
+    const fieldName = unref(field.name);
+    removeFieldFromPath(field, fieldName);
     const fid = field.fid;
     // cleans up the field value from fid lookup
     nextTick(() => {
@@ -344,22 +360,22 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
       // clears a field error on unmounted
       // we wait till next tick to make sure if the field is completely removed and doesn't have any siblings like checkboxes
       // #3384
-      if (!fieldsById.value[fieldName]) {
+      if (!fieldsByPath.value[fieldName]) {
         setFieldError(fieldName, undefined);
       }
     });
-    const fieldName = unref(field.name);
+
+    const fieldGroup = fieldsByPath.value[fieldName];
     // in this case, this is a single field not a group (checkbox or radio)
     // so remove the field value key immediately
-
-    if (field.idx === -1) {
+    if (!Array.isArray(fieldGroup)) {
       // avoid un-setting the value if the field was switched with another that shares the same name
       // they will be unset once the new field takes over the new name, look at `#registerField()`
       // #3166
-      const isSharingName = fields.value.find(f => unref(f.name) === fieldName);
-      if (isSharingName) {
-        return;
-      }
+      // const isSharingName = fields.value.find(f => unref(f.name) === fieldName);
+      // if (isSharingName) {
+      //   return;
+      // }
 
       unsetPath(formValues, fieldName);
       unsetPath(initialValues.value, fieldName);
@@ -398,10 +414,15 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
 
     // No schema, each field is responsible to validate itself
     const validations = await Promise.all(
-      fields.value.map(f => {
-        return f.validate().then((result: ValidationResult) => {
+      Object.values(fieldsByPath.value).map(fieldGroup => {
+        const field = normalizeField(fieldGroup);
+        if (!field) {
+          return Promise.resolve({ key: '', valid: true, errors: [] });
+        }
+
+        return field.validate().then((result: ValidationResult) => {
           return {
-            key: unref(f.name),
+            key: unref(field.name),
             valid: result.valid,
             errors: result.errors,
           };
@@ -430,7 +451,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
   }
 
   async function validateField(field: keyof TValues): Promise<ValidationResult> {
-    const fieldInstance: RegisteredField | undefined = fieldsById.value[field];
+    const fieldInstance: RegisteredField | undefined = fieldsByPath.value[field];
     if (!fieldInstance) {
       warn(`field with name ${field} was not found`);
 
@@ -453,7 +474,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
 
       // Touch all fields
       setTouched(
-        keysOf(fieldsById.value).reduce((acc, field) => {
+        keysOf(fieldsByPath.value).reduce((acc, field) => {
           acc[field] = true;
 
           return acc;
@@ -503,7 +524,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     setFieldInitialValue(path, value);
   }
 
-  async function validateSchema(mode: SchemaValidationMode): Promise<FormValidationResult<TValues>> {
+  async function _validateSchema(): Promise<FormValidationResult<TValues>> {
     const schemaValue = unref(schema);
     if (!schemaValue) {
       return { valid: true, results: {}, errors: {} };
@@ -516,8 +537,19 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
           bailsMap: fieldBailsMap.value,
         });
 
+    return formResult;
+  }
+
+  /**
+   * Batches validation runs in 5ms batches
+   */
+  const debouncedSchemaValidation = debounceAsync(_validateSchema, 5);
+
+  async function validateSchema(mode: SchemaValidationMode): Promise<FormValidationResult<TValues>> {
+    const formResult = await debouncedSchemaValidation();
+
     // fields by id lookup
-    const fieldsById = formCtx.fieldsById.value || {};
+    const fieldsById = formCtx.fieldsByPath.value || {};
     // errors fields names, we need it to also check if custom errors are updated
     const currentErrorsPaths = keysOf(formCtx.errorBag.value);
     // collect all the keys from the schema and all fields
@@ -630,7 +662,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
  * Manages form meta aggregation
  */
 function useFormMeta<TValues extends Record<string, unknown>>(
-  fields: Ref<PrivateFieldContext[]>,
+  fieldsByPath: Ref<Record<keyof TValues, RegisteredField>>,
   currentValues: TValues,
   initialValues: MaybeRef<TValues>,
   errors: Ref<FormErrors<TValues>>
@@ -646,9 +678,13 @@ function useFormMeta<TValues extends Record<string, unknown>>(
   });
 
   const flags = computed(() => {
+    const fields = Object.values(fieldsByPath.value)
+      .map(f => normalizeField(f))
+      .filter(Boolean) as PrivateFieldContext[];
+
     return keysOf(MERGE_STRATEGIES).reduce((acc, flag) => {
       const mergeMethod = MERGE_STRATEGIES[flag];
-      acc[flag] = fields.value[mergeMethod](field => field.meta[flag]);
+      acc[flag] = fields[mergeMethod](field => field.meta[flag]);
 
       return acc;
     }, {} as Record<keyof Omit<FieldMeta<unknown>, 'initialValue'>, boolean>);

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -309,6 +309,16 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     }
   }
 
+  function fieldGroupExists(path: string) {
+    const oldGroup = fieldsByPath.value[path];
+
+    if (Array.isArray(oldGroup)) {
+      return oldGroup.length > 0;
+    }
+
+    return !!oldGroup;
+  }
+
   function registerField(field: PrivateFieldContext) {
     const fieldPath = unref(field.name);
     insertFieldAtPath(field, fieldPath);
@@ -327,10 +337,10 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
           // const isSharingName = fields.value.find(f => unref(f.name) === oldPath);
           // clean up the old path if no other field is sharing that name
           // #3325
-          // if (!isSharingName) {
-          //   unsetPath(formValues, oldPath);
-          //   unsetPath(initialValues.value, oldPath);
-          // }
+          if (!fieldGroupExists(oldPath)) {
+            unsetPath(formValues, oldPath);
+            unsetPath(initialValues.value, oldPath);
+          }
         },
         {
           flush: 'post',
@@ -372,13 +382,10 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
       // avoid un-setting the value if the field was switched with another that shares the same name
       // they will be unset once the new field takes over the new name, look at `#registerField()`
       // #3166
-      // const isSharingName = fields.value.find(f => unref(f.name) === fieldName);
-      // if (isSharingName) {
-      //   return;
-      // }
-
-      unsetPath(formValues, fieldName);
-      unsetPath(initialValues.value, fieldName);
+      if (!fieldGroupExists(fieldName)) {
+        unsetPath(formValues, fieldName);
+        unsetPath(initialValues.value, fieldName);
+      }
 
       return;
     }

--- a/packages/vee-validate/src/useIsFieldDirty.ts
+++ b/packages/vee-validate/src/useIsFieldDirty.ts
@@ -12,7 +12,7 @@ export function useIsFieldDirty(path?: MaybeRef<string>) {
 
   return computed(() => {
     if (path) {
-      field = normalizeField(form?.fieldsById.value[unref(path)]);
+      field = normalizeField(form?.fieldsByPath.value[unref(path)]);
     }
 
     if (!field) {

--- a/packages/vee-validate/src/useIsFieldTouched.ts
+++ b/packages/vee-validate/src/useIsFieldTouched.ts
@@ -12,7 +12,7 @@ export function useIsFieldTouched(path?: MaybeRef<string>) {
 
   return computed(() => {
     if (path) {
-      field = normalizeField(form?.fieldsById.value[unref(path)]);
+      field = normalizeField(form?.fieldsByPath.value[unref(path)]);
     }
 
     if (!field) {

--- a/packages/vee-validate/src/useIsFieldValid.ts
+++ b/packages/vee-validate/src/useIsFieldValid.ts
@@ -12,7 +12,7 @@ export function useIsFieldValid(path?: MaybeRef<string>) {
 
   return computed(() => {
     if (path) {
-      field = normalizeField(form?.fieldsById.value[unref(path)]);
+      field = normalizeField(form?.fieldsByPath.value[unref(path)]);
     }
 
     if (!field) {

--- a/packages/vee-validate/src/useValidateField.ts
+++ b/packages/vee-validate/src/useValidateField.ts
@@ -12,7 +12,7 @@ export function useValidateField(path?: MaybeRef<string>) {
 
   return function validateField(): Promise<ValidationResult> {
     if (path) {
-      field = normalizeField(form?.fieldsById.value[unref(path)]);
+      field = normalizeField(form?.fieldsByPath.value[unref(path)]);
     }
 
     if (!field) {

--- a/packages/vee-validate/src/utils/common.ts
+++ b/packages/vee-validate/src/utils/common.ts
@@ -194,3 +194,28 @@ export function resolveNextCheckboxValue<T>(currentValue: T | T[], checkedValue:
 
   return currentValue === checkedValue ? uncheckedValue : checkedValue;
 }
+
+export function debounceAsync<TFunction extends (...args: any) => Promise<any>, TResult = ReturnType<TFunction>>(
+  inner: TFunction,
+  ms = 0
+): (...args: Parameters<TFunction>) => Promise<TResult> {
+  let timer: number | null = null;
+  let resolves: any[] = [];
+
+  return function (...args: Parameters<TFunction>) {
+    // Run the function after a certain amount of time
+    if (timer) {
+      window.clearTimeout(timer);
+    }
+
+    timer = window.setTimeout(() => {
+      // Get the result of the inner function, then apply it to the resolve function of
+      // each promise that has been created since the last time the inner function was run
+      const result = inner(...(args as any));
+      resolves.forEach(r => r(result));
+      resolves = [];
+    }, ms);
+
+    return new Promise<TResult>(resolve => resolves.push(resolve));
+  };
+}

--- a/packages/vee-validate/tests/ErrorMessage.spec.ts
+++ b/packages/vee-validate/tests/ErrorMessage.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { defineRule, ErrorMessage } from '@/vee-validate';
-import { mountWithHoc, setValue } from './helpers';
+import { mountWithHoc, setValue, flushPromises } from './helpers';
 
 describe('<ErrorMessage />', () => {
   const REQUIRED_MESSAGE = `This field is required`;

--- a/packages/vee-validate/tests/Field.spec.ts
+++ b/packages/vee-validate/tests/Field.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { defineRule, configure } from '@/vee-validate';
-import { mountWithHoc, setValue, dispatchEvent, setChecked } from './helpers';
+import { mountWithHoc, setValue, dispatchEvent, setChecked, flushPromises } from './helpers';
 import * as yup from 'yup';
 import { reactive, ref, Ref } from 'vue';
 

--- a/packages/vee-validate/tests/Form.spec.ts
+++ b/packages/vee-validate/tests/Form.spec.ts
@@ -1578,11 +1578,11 @@ describe('<Form />', () => {
     const input = () => document.querySelector('input');
     setModified(data[3]);
     await flushPromises();
-    expect(input()?.value).not.toBe('');
+    expect(input()?.value).toBe(data[3].title);
 
     setModified(data[2]);
     await flushPromises();
-    expect(input()?.value).not.toBe('');
+    expect(input()?.value).toBe(data[2].title);
   });
 
   test('resetForm should reset the meta flag', async () => {

--- a/packages/vee-validate/tests/Form.spec.ts
+++ b/packages/vee-validate/tests/Form.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { defineRule } from '@/vee-validate';
-import { mountWithHoc, setValue, setChecked, dispatchEvent } from './helpers';
+import { mountWithHoc, setValue, setChecked, dispatchEvent, flushPromises } from './helpers';
 import * as yup from 'yup';
 import { computed, onErrorCaptured, reactive, ref, Ref } from 'vue';
 
@@ -382,6 +381,7 @@ describe('<Form />', () => {
     const passwordError = wrapper.$el.querySelector('#passwordErr');
 
     wrapper.$el.querySelector('button').click();
+
     await flushPromises();
 
     expect(emailError.textContent).toBe('email is a required field');
@@ -389,6 +389,7 @@ describe('<Form />', () => {
 
     setValue(email, 'hello@');
     setValue(password, '1234');
+
     await flushPromises();
 
     expect(emailError.textContent).toBe('email must be a valid email');
@@ -396,6 +397,7 @@ describe('<Form />', () => {
 
     setValue(email, 'hello@email.com');
     setValue(password, '12346789');
+
     await flushPromises();
 
     expect(emailError.textContent).toBe('');
@@ -937,8 +939,6 @@ describe('<Form />', () => {
   });
 
   test('isSubmitting state', async () => {
-    jest.useFakeTimers();
-
     let throws = false;
     const wrapper = mountWithHoc({
       setup() {
@@ -983,8 +983,6 @@ describe('<Form />', () => {
     jest.advanceTimersByTime(501);
     await flushPromises();
     expect(submitting.textContent).toBe('false');
-
-    jest.useRealTimers();
   });
 
   test('aggregated meta reactivity', async () => {

--- a/packages/vee-validate/tests/helpers/index.ts
+++ b/packages/vee-validate/tests/helpers/index.ts
@@ -1,4 +1,5 @@
 import { createApp, ComponentPublicInstance } from 'vue';
+import flushP from 'flush-promises';
 import { Field, Form, ErrorMessage } from '@/vee-validate';
 
 export function mount(component: Record<string, any>) {
@@ -49,4 +50,13 @@ export function dispatchEvent(node: ComponentPublicInstance | HTMLInputElement, 
   }
 
   (node as any).$emit(eventName);
+}
+
+/**
+ * Ensures promises and timers are flushed properly including debounce time
+ */
+export async function flushPromises() {
+  await flushP();
+  jest.advanceTimersByTime(5);
+  await flushP();
 }

--- a/packages/vee-validate/tests/useField.spec.ts
+++ b/packages/vee-validate/tests/useField.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField } from '@/vee-validate';
-import { mountWithHoc, setValue } from './helpers';
+import { mountWithHoc, setValue, flushPromises } from './helpers';
 
 describe('useField()', () => {
   const REQUIRED_MESSAGE = 'Field is required';

--- a/packages/vee-validate/tests/useFieldError.spec.ts
+++ b/packages/vee-validate/tests/useFieldError.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useFieldError, useForm } from '@/vee-validate';
-import { mountWithHoc, setValue } from './helpers';
+import { mountWithHoc, setValue, flushPromises } from './helpers';
 import { defineComponent } from 'vue';
 
 describe('useFieldError()', () => {

--- a/packages/vee-validate/tests/useFieldValue.spec.ts
+++ b/packages/vee-validate/tests/useFieldValue.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useFieldValue, useForm } from '@/vee-validate';
-import { mountWithHoc, setValue } from './helpers';
+import { mountWithHoc, setValue, flushPromises } from './helpers';
 import { defineComponent } from 'vue';
 
 describe('useFieldValue()', () => {

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { FormContext, useField, useForm } from '@/vee-validate';
-import { mountWithHoc, setValue } from './helpers';
+import { mountWithHoc, setValue, flushPromises } from './helpers';
 import * as yup from 'yup';
 
 describe('useForm()', () => {
@@ -189,7 +188,7 @@ describe('useForm()', () => {
     });
   });
 
-  test('has a validate() method that returns an aggregate of validation results using validation schema', async () => {
+  test('has a validate method that returns an aggregate of validation results using validation schema', async () => {
     let validate: any;
     mountWithHoc({
       setup() {
@@ -210,7 +209,9 @@ describe('useForm()', () => {
     });
 
     await flushPromises();
-    const result = await validate();
+    const pending = validate();
+    await flushPromises();
+    const result = await pending;
     expect(result).toEqual({
       valid: false,
       errors: {

--- a/packages/vee-validate/tests/useFormErrors.spec.ts
+++ b/packages/vee-validate/tests/useFormErrors.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useForm, useFormErrors } from '@/vee-validate';
-import { mountWithHoc, setValue } from './helpers';
+import { mountWithHoc, setValue, flushPromises } from './helpers';
 
 describe('useFormErrors()', () => {
   const REQUIRED_MESSAGE = 'Field is required';

--- a/packages/vee-validate/tests/useFormValues.spec.ts
+++ b/packages/vee-validate/tests/useFormValues.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useForm, useFormValues } from '@/vee-validate';
-import { mountWithHoc, setValue } from './helpers';
+import { mountWithHoc, setValue, flushPromises } from './helpers';
 
 describe('useFormValues()', () => {
   const REQUIRED_MESSAGE = 'Field is required';

--- a/packages/vee-validate/tests/useIsFieldDirty.spec.ts
+++ b/packages/vee-validate/tests/useIsFieldDirty.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useForm, useIsFieldDirty } from '@/vee-validate';
-import { mountWithHoc, setValue } from './helpers';
+import { mountWithHoc, setValue, flushPromises } from './helpers';
 import { defineComponent } from 'vue';
 
 describe('useIsFieldDirty()', () => {

--- a/packages/vee-validate/tests/useIsFieldTouched.spec.ts
+++ b/packages/vee-validate/tests/useIsFieldTouched.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useForm, useIsFieldTouched } from '@/vee-validate';
-import { dispatchEvent, mountWithHoc } from './helpers';
+import { dispatchEvent, mountWithHoc, flushPromises } from './helpers';
 import { defineComponent } from 'vue';
 
 describe('useIsFieldTouched()', () => {

--- a/packages/vee-validate/tests/useIsFieldValid.spec.ts
+++ b/packages/vee-validate/tests/useIsFieldValid.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useIsFieldValid, useForm } from '@/vee-validate';
-import { mountWithHoc, setValue } from './helpers';
+import { mountWithHoc, setValue, flushPromises } from './helpers';
 import { defineComponent } from 'vue';
 
 describe('useIsFieldValid()', () => {

--- a/packages/vee-validate/tests/useIsFormDirty.spec.ts
+++ b/packages/vee-validate/tests/useIsFormDirty.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useForm, useIsFormDirty } from '@/vee-validate';
-import { mountWithHoc, setValue } from './helpers';
+import { mountWithHoc, setValue, flushPromises } from './helpers';
 
 describe('useIsFormDirty()', () => {
   test('gives access to the forms isDirty status', async () => {

--- a/packages/vee-validate/tests/useIsFormTouched.spec.ts
+++ b/packages/vee-validate/tests/useIsFormTouched.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useForm, useIsFormTouched } from '@/vee-validate';
-import { dispatchEvent, mountWithHoc } from './helpers';
+import { dispatchEvent, mountWithHoc, flushPromises } from './helpers';
 
 describe('useIsFormTouched()', () => {
   test('gives access to the forms isTouched status', async () => {

--- a/packages/vee-validate/tests/useIsFormValid.spec.ts
+++ b/packages/vee-validate/tests/useIsFormValid.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useIsFormValid, useField, useForm } from '@/vee-validate';
-import { mountWithHoc, setValue } from './helpers';
+import { mountWithHoc, setValue, flushPromises } from './helpers';
 
 describe('useIsFormValid()', () => {
   const REQUIRED_MESSAGE = 'Field is required';

--- a/packages/vee-validate/tests/useIsSubmitting.spec.ts
+++ b/packages/vee-validate/tests/useIsSubmitting.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useForm, useIsSubmitting } from '@/vee-validate';
-import { mountWithHoc } from './helpers';
+import { mountWithHoc, flushPromises } from './helpers';
 
 describe('useIsSubmitting()', () => {
   const validate = (): Promise<false> =>
@@ -11,7 +10,6 @@ describe('useIsSubmitting()', () => {
     });
 
   test('indicates if a form is submitting', async () => {
-    jest.useFakeTimers();
     mountWithHoc({
       setup() {
         const { submitForm } = useForm();
@@ -40,8 +38,6 @@ describe('useIsSubmitting()', () => {
     jest.runAllTimers();
     await flushPromises();
     expect(submitText?.textContent).toBe('false');
-
-    jest.useRealTimers();
   });
 
   test('returns false and warns if form is not found', async () => {

--- a/packages/vee-validate/tests/useResetForm.spec.ts
+++ b/packages/vee-validate/tests/useResetForm.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useForm, useResetForm } from '@/vee-validate';
-import { mountWithHoc, setValue } from './helpers';
+import { mountWithHoc, setValue, flushPromises } from './helpers';
 
 describe('useResetForm()', () => {
   const REQUIRED_MESSAGE = 'Field is required';

--- a/packages/vee-validate/tests/useSubmitCount.spec.ts
+++ b/packages/vee-validate/tests/useSubmitCount.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useForm, useSubmitCount } from '@/vee-validate';
-import { mountWithHoc } from './helpers';
+import { mountWithHoc, flushPromises } from './helpers';
 
 describe('useSubmitCount()', () => {
   test('indicates the number of submissions', async () => {

--- a/packages/vee-validate/tests/useSubmitForm.spec.ts
+++ b/packages/vee-validate/tests/useSubmitForm.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useForm, useSubmitForm } from '@/vee-validate';
-import { mountWithHoc, setValue } from './helpers';
+import { mountWithHoc, setValue, flushPromises } from './helpers';
 
 describe('useSubmitForm()', () => {
   const REQUIRED_MESSAGE = 'Field is required';

--- a/packages/vee-validate/tests/useValidateField.spec.ts
+++ b/packages/vee-validate/tests/useValidateField.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useForm, useValidateField } from '@/vee-validate';
-import { mountWithHoc } from './helpers';
+import { mountWithHoc, flushPromises } from './helpers';
 import { defineComponent } from 'vue';
 
 describe('useValidateField()', () => {

--- a/packages/vee-validate/tests/useValidateForm.spec.ts
+++ b/packages/vee-validate/tests/useValidateForm.spec.ts
@@ -1,6 +1,5 @@
-import flushPromises from 'flush-promises';
 import { useField, useForm, useValidateForm } from '@/vee-validate';
-import { mountWithHoc } from './helpers';
+import { mountWithHoc, flushPromises } from './helpers';
 
 describe('useValidateForm()', () => {
   const REQUIRED_MESSAGE = 'Field is required';

--- a/packages/zod/CHANGELOG.md
+++ b/packages/zod/CHANGELOG.md
@@ -7,10 +7,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @vee-validate/zod
 
-
-
-
-
 # [4.5.0-alpha.1](https://github.com/logaretm/vee-validate/compare/v4.4.5...v4.5.0-alpha.1) (2021-07-06)
 
 **Note:** Version bump only for package @vee-validate/zod

--- a/packages/zod/tests/zod.spec.ts
+++ b/packages/zod/tests/zod.spec.ts
@@ -1,6 +1,6 @@
-import { mountWithHoc, setValue, setChecked } from '../../vee-validate/tests/helpers';
+import { mountWithHoc, setValue, setChecked, flushPromises } from '../../vee-validate/tests/helpers';
 import * as zod from 'zod';
-import flushPromises from 'flush-promises';
+
 import { toFieldValidator, toFormValidator } from '../src/index';
 
 const REQUIRED_MSG = 'field is required';


### PR DESCRIPTION
## What

This PR does various things to improve vee-validate performance for larger forms, specifically large nested array forms as noted in #3399 

The bottleneck comes from various factors:

- Using reactive arrays to track registered fields
- Watching value changes and triggering validation
- Schema validation validates all fields

In the example provided in #3399, when removing a field the following happens:

1. Fields change names due to loop index changing
2. Fields swap values with the next field in the loop
3. Each value swap triggers a validation x number of fields

This means for the 20 forms, when a single one is removed around 360 validation runs are triggered. This is of course is undesired

## How

To achieve reasonable performance improvements, we needed to address each of the points mentioned above:

> Using reactive arrays to track registered fields

By using a path-based dictionary for registered fields, makes it cheaper to register/unregister fields, also eliminates having to create a dictionary anyways as a computed prop for doing o(1) optimized operations.

> Watching value changes and triggering validation

We cannot tell the reason for the value change was because of a loop index change, so there is nothing that can be done about this.

> Schema validation validates all fields

This is hard to change because the schema covers cross-field validations, so we cannot avoid validating all fields, but we could reduce the frequency of which to trigger this function using either `throttle/debounce` with a very small timeout like `5ms`. I decided to go with `promise-aware debounce` to effectively batch schema validation calls, this possibly improves performance in other cases where multiple fields are being mounted/unmounted.

This however might introduce some complexities when testing vee-validate, as `flush-promises` may not be good enough, so adding some info to the guide might be necessary to indicate the safest way to wait for validation attempt.