### PR TITLE
Change Double Rule for integer value

### DIFF
--- a/src/rules/double.ts
+++ b/src/rules/double.ts
@@ -11,8 +11,22 @@ const validate = (value: StringOrNumber | StringOrNumber[], params: Record<strin
 
   const regexPart = +decimals === 0 ? '+' : `{${decimals}}`;
   const regex = new RegExp(`^-?\\d+\\${separators[separator as Separator] || '.'}\\d${regexPart}$`);
-
-  return Array.isArray(value) ? value.every(val => regex.test(String(val))) : regex.test(String(value));
+  
+  let valueTemp = value;
+  if (params.separator == "comma") {
+    valueTemp = value.toString().replace(",", ".");
+  }
+  if (!isNaN(value) || !isNaN(valueTemp)) {
+    let valueParsed = parseFloat(valueTemp);
+    if (!Number.isNaN(valueParsed)) {
+      if (!Number.isInteger(valueParsed)) {
+        return Array.isArray(value) ? value.every(val => regex.test(String(val))) : regex.test(String(value));
+      } else {
+        return true;
+      }
+    }
+  }
+  return false;
 };
 
 const params: RuleParamSchema[] = [


### PR DESCRIPTION
Change Double Rule

I added an condition to determine if the value is an integer or not. Because when you use the double rule, you must put .0 after an integer. (in my casethe value can be an integer or a float). For my case SQL server doesn't register float like 0.0, and just put 0 and when i edit my value in my website, i need to put .0 on each double value where i put an integer.