### PR TITLE
chore: add repository for all packages.json

### DIFF
--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -17,7 +17,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/logaretm/vee-validate.git"
+    "url": "https://github.com/logaretm/vee-validate.git",
+    "directory": "packages/i18n"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1"

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -9,7 +9,11 @@
   "main": "dist/vee-validate-rules.js",
   "types": "dist/vee-validate-rules.d.ts",
   "homepage": "https://vee-validate.logaretm.com/v4/guide/global-validators",
-  "repository": "https://github.com/logaretm/vee-validate",
+  "repository": {
+    "url": "https://github.com/logaretm/vee-validate.git",
+    "type": "git",
+    "directory": "packages/rules"
+  },
   "sideEffects": false,
   "keywords": [
     "VueJS",

--- a/packages/vee-validate/package.json
+++ b/packages/vee-validate/package.json
@@ -9,7 +9,11 @@
   "main": "dist/vee-validate.js",
   "types": "dist/vee-validate.d.ts",
   "homepage": "https://vee-validate.logaretm.com/",
-  "repository": "https://github.com/logaretm/vee-validate",
+  "repository": {
+    "url": "https://github.com/logaretm/vee-validate.git",
+    "type": "git",
+    "directory": "packages/vee-validate"
+  },
   "sideEffects": false,
   "keywords": [
     "VueJS",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -9,7 +9,11 @@
   "main": "dist/vee-validate-zod.js",
   "types": "dist/vee-validate-zod.d.ts",
   "homepage": "https://vee-validate.logaretm.com/v4/guide/global-validators",
-  "repository": "https://github.com/logaretm/vee-validate",
+  "repository": {
+    "url": "https://github.com/logaretm/vee-validate.git",
+    "type": "git",
+    "directory": "packages/zod"
+  },
   "sideEffects": false,
   "keywords": [
     "VueJS",


### PR DESCRIPTION
> If the package.json for your package is not in the root directory (for
example if it is part of a monorepo), you can specify the directory in
which it lives:
> ```json
> "repository": {
>   "type" : "git",
>   "url" : "https://github.com/facebook/react.git",
>   "directory": "packages/react-dom"
> }
> ```
> — https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

I use a lot https://njt.vercel.app/ to jump to different packages information,
and with this PR we can know exactly what package in what folder lives

Made the changes with a script to make it easier 🙂

https://gist.github.com/iamandrewluca/5cc85b56a595056f0099d04ed6dd8a79
