### PR TITLE
refactor(use-form): remove redundant validateField async keywork

### DIFF
--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -434,7 +434,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     };
   }
 
-  async function validateField(field: keyof TValues): Promise<ValidationResult> {
+  function validateField(field: keyof TValues): Promise<ValidationResult> {
     const fieldInstance: RegisteredField | undefined = fieldsById.value[field];
     if (!fieldInstance) {
       warn(`field with name ${field} was not found`);


### PR DESCRIPTION
`validateField` does not use any `await` keyword inside, it only returns promises.

ps: rewriting hooks of this version of the library for a Vue2 project using `@vue/composition-api`  
and from time to time I may come with some improvements to this library 🙂

