### PR TITLE
Update Double rules to accept integer values

### DIFF
--- a/src/rules/double.ts
+++ b/src/rules/double.ts
@@ -12,7 +12,21 @@ const validate = (value: StringOrNumber | StringOrNumber[], params: Record<strin
   const regexPart = +decimals === 0 ? '+' : `{${decimals}}`;
   const regex = new RegExp(`^-?\\d+\\${separators[separator as Separator] || '.'}\\d${regexPart}$`);
 
-  return Array.isArray(value) ? value.every(val => regex.test(String(val))) : regex.test(String(value));
+  let valueTemp = value;
+  if (params.separator == "comma") {
+    valueTemp = value.toString().replace(",", ".");
+  }
+  if (!isNaN(value) || !isNaN(valueTemp)) {
+    let valueParsed = parseFloat(valueTemp);
+    if (!Number.isNaN(valueParsed)) {
+      if (!Number.isInteger(valueParsed)) {
+        return Array.isArray(value) ? value.every(val => regex.test(String(val))) : regex.test(String(value));
+      } else {
+        return true;
+      }
+    }
+  }
+  return false;
 };
 
 const params: RuleParamSchema[] = [


### PR DESCRIPTION
🔎 __Overview__
Change Double Rule

I added an condition to determine if the value is an integer or not. Because when you use the double rule in V3, you must put .0 after an integer. (in my case the value can be an integer or a double). For my case SQL server doesn't register float like 0.0 and just save 0 instead . But when I edit the value in my website, i need to put .0 (because sql retrieve an integer) on each double value where it's an integer in DB.

🤓 __Code snippets/examples (if applicable)__

No code to test, use it as it should, it now validate if the value is an integer.

✔ __Issues affected__

closes #3207 
 
