### PR TITLE
fix: update Double rules to accept integer values

### DIFF
--- a/src/rules/double.ts
+++ b/src/rules/double.ts
@@ -9,8 +9,9 @@ const validate = (value: StringOrNumber | StringOrNumber[], params: Record<strin
     comma: ','
   };
 
-  const regexPart = +decimals === 0 ? '+' : `{${decimals}}`;
-  const regex = new RegExp(`^-?\\d+\\${separators[separator as Separator] || '.'}\\d${regexPart}$`);
+  const delimiterRegexPart = separator === 'comma' ? ',?' : '\\.?';
+  const decimalRegexPart = decimals === 0 ? '\\d*' : `(\\d{${decimals}})?`;
+  const regex = new RegExp(`^-?\\d+${delimiterRegexPart}${decimalRegexPart}$`);
 
   return Array.isArray(value) ? value.every(val => regex.test(String(val))) : regex.test(String(value));
 };

--- a/tests/rules/double.js
+++ b/tests/rules/double.js
@@ -1,7 +1,7 @@
 import { validate } from '@/rules/double';
 
-const valid = [2.2, 1.1222, -2.32, '2.3333', '-2.4444'];
-const invalid = ['', undefined, null, true, false, {}, '+32.32', 'a', '323ads232', 1, '1', '2..2'];
+const valid = [2.2, 1.1222, -2.32, '2.3333', 1, '1', '-2.4444'];
+const invalid = ['', undefined, null, true, false, {}, '+32.32', 'a', '323ads232', '2..2'];
 
 test('validates that the value contains a decimal number', () => {
   valid.forEach(value => expect(validate(value)).toBe(true));
@@ -28,7 +28,7 @@ test('validates that the contain a decimal number using a comma as seperator', (
 test('validates that the contain a decimal number with a specific count of decimal places', () => {
   const param = { decimals: '2' };
 
-  const localValid = [1.11, '1.11', '-1.11', -1.11];
+  const localValid = [1.11, '1.11', '-1.11', -1.11, 1, -1, '1', '-1'];
   const localInvalid = [...invalid, 1.1, 1.111, -1.1, '-1.1111', '1.1111'];
 
   localValid.forEach(value => expect(validate(value, param)).toBe(true));


### PR DESCRIPTION
🔎 Overview
Change Double Rule

I added an condition to determine if the value is an integer or not. Because when you use the double rule in V3, you must put .0 after an integer. (in my case the value can be an integer or a double). For my case SQL server doesn't register float like 0.0 and just save 0 instead . But when I edit the value in my website, i need to put .0 (because SQL retrieve an integer) on each double value where it's an integer in DB.

(good for test this time^^)

🤓 Code snippets/examples (if applicable)

No code to test, use it as it should, it now validate if the value is an integer.

✔ Issues affected

closes #3207