### PR TITLE
docs: added example for headless ui closes #3406

### DIFF
--- a/docs/content/examples/ui-libraries.md
+++ b/docs/content/examples/ui-libraries.md
@@ -20,25 +20,19 @@ In the next few examples you will find examples on how to do that in various way
 
 > Effortlessly build high-performance & high-quality Vue 3 user interfaces in record time
 
-<iframe src="https://codesandbox.io/embed/vee-validate-v4-with-quasar-framework-1lx81?fontsize=14&hidenavigation=1&module=%2Fsrc%2FApp.vue&theme=dark"
-  style="width:100%; height:700px; border:0; border-radius: 4px; overflow:hidden;"
-  title="vee-validate v4 with Quasar framework"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-  loading="lazy"
-></iframe>
+<code-sandbox id="vee-validate-v4-with-quasar-framework-1lx81" title="vee-validate quasar framework example"></code-sandbox>
 
 ## Element Plus
 
 > [Element Plus](https://element-plus.org/#/en-US), a Vue 3.0 based component library for developers, designers and product managers
 
-<iframe src="https://codesandbox.io/embed/stupefied-goldberg-8l0zi?fontsize=14&hidenavigation=1&module=%2Fsrc%2FApp.vue&theme=dark"
-  style="width:100%; height:700px; border:0; border-radius: 4px; overflow:hidden;"
-  title="vee-validate v4 with element plus framework"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
-  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
-  loading="lazy"
-></iframe>
+<code-sandbox id="stupefied-goldberg-8l0zi" title="vee-validate element plus example"></code-sandbox>
+
+## Headless UI
+
+> [Headless UI](https://headlessui.dev/): Completely unstyled, fully accessible UI components, designed to integrate beautifully with Tailwind CSS.
+
+<code-sandbox id="vee-validate-headless-ui-example-9jz9h" title="vee-validate headless ui example"></code-sandbox>
 
 ## Request a UI library
 


### PR DESCRIPTION
🔎 __Overview__

Adds headless UI example to the docs, only covering the select input for now
