### PR TITLE
Fix broken Form API v4 doc formatting

### DIFF
--- a/docs/content/api/form.md
+++ b/docs/content/api/form.md
@@ -117,7 +117,7 @@ The default slot gives you access to the following props:
 
 <code-title level="4">
 
-errors: Record<string, string>`
+`errors: Record<string, string>`
 
 </code-title>
 


### PR DESCRIPTION
🔎 __Overview__

There is a missing backtick for the `errors` slot section.

<!-- Explain the why behind adding this PR, here is a couple of examples -->
<!--
  This PR {adds/fixes/improves} the {feature/bug/something}.
  This PR changes the {locale} messages style because {reason}
-->

🤓 __Code snippets/examples (if applicable)__



✔ __Issues affected__

<!-- list of issues formatted like this
closes #{issue id}
 -->
 
