### PR TITLE
[v4]Minor documentation error: it should be vee-validate@next for v4.x (Vue 3)

### DIFF
--- a/docs/content/tutorials/basics.md
+++ b/docs/content/tutorials/basics.md
@@ -46,11 +46,11 @@ vue create vee-validate-tutorial
 2. Add `vee-validate` to your project
 
 ```sh
-yarn add vee-validate
+yarn add vee-validate@next
 
 # or
 
-npm install vee-validate
+npm install vee-validate@next --save
 ```
 
 3. Cleanup the contents of `App.vue`, it should look like the following:


### PR DESCRIPTION
This [documentation page](https://vee-validate.logaretm.com/v4/tutorials/basics) is for v4.x (Vue3), it should be using `vee-validate@next` instead of `vee-validate`.

🔎 __Overview__

Updated `docs/content/tutorials/basics.md`

🤓 __Code snippets/examples (if applicable)__

Original:
```sh
yarn add vee-validate
# or
npm install vee-validate
```
To:
```sh
yarn add vee-validate@next
# or
npm install vee-validate@next --save
```


 
