### PR TITLE
feat(4.6): Allow mutating field array iterable's value property

### DIFF
--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -1,4 +1,4 @@
-import { ComputedRef, DeepReadonly, Ref } from 'vue';
+import { ComputedRef, Ref } from 'vue';
 import { SchemaOf, AnySchema, AnyObjectSchema } from 'yup';
 import { FieldValidationMetaInfo } from '../../shared';
 
@@ -58,7 +58,7 @@ export interface FieldEntry<TValue = unknown> {
 }
 
 export interface FieldArrayContext<TValue = unknown> {
-  fields: DeepReadonly<Ref<FieldEntry<TValue>[]>>;
+  fields: Ref<FieldEntry<TValue>[]>;
   remove(idx: number): void;
   replace(newArray: TValue[]): void;
   update(idx: number, value: TValue): void;

--- a/packages/vee-validate/tests/FieldArray.spec.ts
+++ b/packages/vee-validate/tests/FieldArray.spec.ts
@@ -467,6 +467,58 @@ test('can update an item value at a given array index', async () => {
   expect(getValue(inputAt(1))).toBe('updated');
 });
 
+test('can update an item value directly with .value setter', async () => {
+  const onSubmit = jest.fn();
+  mountWithHoc({
+    setup() {
+      const initial = {
+        users: [
+          {
+            name: 'first',
+          },
+        ],
+      };
+
+      return {
+        initial,
+        onSubmit,
+      };
+    },
+    template: `
+    <VForm :initial-values="initial" @submit="onSubmit">
+      <FieldArray name="users" v-slot="{ fields }">
+          <div v-for="(field, idx) in fields" :key="field.key">
+            <input v-model="fields[idx].value.name" />
+          </div>
+      </FieldArray>
+
+      <button>Submit</button>
+    </VForm>
+    `,
+  });
+
+  await flushPromises();
+  const inputAt = (idx: number) => (document.querySelectorAll('input') || [])[idx] as HTMLInputElement;
+
+  expect(getValue(inputAt(0))).toBe('first');
+  setValue(inputAt(0), 'updated');
+  await flushPromises();
+  expect(getValue(inputAt(0))).toBe('updated');
+  document.querySelector('button')?.click();
+  await flushPromises();
+
+  expect(onSubmit).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      users: [
+        {
+          name: 'updated',
+        },
+      ],
+    }),
+    expect.anything()
+  );
+});
+
 test('adds items to the start of the array with prepend()', async () => {
   const onSubmit = jest.fn();
   mountWithHoc({

--- a/packages/vee-validate/tests/useFieldArray.spec.ts
+++ b/packages/vee-validate/tests/useFieldArray.spec.ts
@@ -1,0 +1,31 @@
+import { useForm, useFieldArray } from '@/vee-validate';
+import { onMounted } from 'vue';
+import { mountWithHoc, flushPromises } from './helpers';
+
+test('warns when updating a no-longer existing item', async () => {
+  const spy = jest.spyOn(console, 'warn').mockImplementation();
+  mountWithHoc({
+    setup() {
+      useForm({
+        initialValues: {
+          users: ['1'],
+        },
+      });
+
+      const { remove, fields } = useFieldArray('users');
+      onMounted(() => {
+        const item = fields.value[0];
+        remove(0);
+        item.value = 'test';
+      });
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+
+  expect(spy).toHaveBeenCalled();
+  spy.mockRestore();
+});

--- a/packages/vee-validate/tests/useFieldArray.spec.ts
+++ b/packages/vee-validate/tests/useFieldArray.spec.ts
@@ -2,6 +2,34 @@ import { useForm, useFieldArray } from '@/vee-validate';
 import { onMounted } from 'vue';
 import { mountWithHoc, flushPromises } from './helpers';
 
+test('can update a field entry model directly', async () => {
+  mountWithHoc({
+    setup() {
+      useForm({
+        initialValues: {
+          users: ['1'],
+        },
+      });
+
+      const { fields } = useFieldArray('users');
+      onMounted(() => {
+        const item = fields.value[0];
+        item.value = 'test';
+      });
+
+      return {
+        fields,
+      };
+    },
+    template: `
+      <p>{{ fields[0].value }}</p>
+    `,
+  });
+
+  await flushPromises();
+  expect(document.querySelector('p')?.innerHTML).toBe('test');
+});
+
 test('warns when updating a no-longer existing item', async () => {
   const spy = jest.spyOn(console, 'warn').mockImplementation();
   mountWithHoc({


### PR DESCRIPTION
## What

This PR implements an enhancement for the `FieldArray` or `useFieldArray` where it wasn't possible to use `v-model` with it to mutate the iterable value directly.

The motivation for that design is to force the lib user to go through the API, however, it doesn't seem necessary to have this restriction as `v-model` is an initiative way to mutate such values.

This was mentioned in #3617 discussion