### PR TITLE
Make content padding important

### DIFF
--- a/docs/.vuepress/theme/layouts/Layout.vue
+++ b/docs/.vuepress/theme/layouts/Layout.vue
@@ -136,7 +136,7 @@ export default {
   margin-top: 50px
 
 .theme-default-content.content__default
-  padding-top: calc(2rem + 50px)
+  padding-top: calc(2rem + 50px) !important
 
 .sidebar
   padding-top: 50px


### PR DESCRIPTION
🔎 __Overview__

There was a simple css bug in [v2 docs](https://vee-validate.logaretm.com/v2/guide/). Padding wasn't working. We at the company were using the v2 and it was getting more of a issue by time. Heading was hidden behind top navs.

![vee](https://user-images.githubusercontent.com/1842459/149522754-4d953915-f410-4254-8d3a-3348ff75a7c4.PNG)
![vee2](https://user-images.githubusercontent.com/1842459/149522762-861d74bf-85d1-4d8c-9913-f74bef875898.PNG)



<!-- Explain the why behind adding this PR, here is a couple of examples -->
<!--
  This PR {adds/fixes/improves} the {feature/bug/something}.
  This PR changes the {locale} messages style because {reason}
-->

🤓 __Just added important to one of the css rule__

```js
.theme-default-content.content__default
  padding-top: calc(2rem + 50px) !important
```


