### PR TITLE
fix da.json (local): Missing comma

### DIFF
--- a/packages/i18n/src/locale/da.json
+++ b/packages/i18n/src/locale/da.json
@@ -26,7 +26,7 @@
     "regex": "{field} skal have et gyldigt format",
     "required_if": "{field} skal udfyldes",
     "required": "{field} skal udfyldes",
-    "size": "{field} må maksimalt have en størrelse på 0:{size}KB"
+    "size": "{field} må maksimalt have en størrelse på 0:{size}KB",
     "url": "{field} er ikke en gyldig URL"
   }
 }


### PR DESCRIPTION
makes files valid json again

🔎 __Overview__

This PR fixes i18n because da.json (local) was not a valid json

✔ __Issues affected__

`import da from '@vee-validate/i18n/dist/locale/da.json';` don't work anymore