### PR TITLE
feat: Sync useField with component v-model

### DIFF
--- a/packages/vee-validate/src/Field.ts
+++ b/packages/vee-validate/src/Field.ts
@@ -11,7 +11,14 @@ import {
 } from 'vue';
 import { getConfig } from './config';
 import { RuleExpression, useField } from './useField';
-import { normalizeChildren, hasCheckedAttr, shouldHaveValueBinding, isPropPresent, normalizeEventValue } from './utils';
+import {
+  normalizeChildren,
+  hasCheckedAttr,
+  shouldHaveValueBinding,
+  isPropPresent,
+  normalizeEventValue,
+  applyModelModifiers,
+} from './utils';
 import { toNumber } from '../../shared';
 import { IS_ABSENT } from './symbols';
 import { FieldMeta } from './types';
@@ -212,7 +219,7 @@ const FieldImpl = defineComponent({
         return;
       }
 
-      if (newModelValue !== applyModifiers(value.value, props.modelModifiers)) {
+      if (newModelValue !== applyModelModifiers(value.value, props.modelModifiers)) {
         value.value = (newModelValue as any) === IS_ABSENT ? undefined : newModelValue;
         validateField();
       }
@@ -283,14 +290,6 @@ function resolveValidationTriggers(props: Partial<ValidationTriggersProps>) {
     validateOnBlur: props.validateOnBlur ?? validateOnBlur,
     validateOnModelUpdate: props.validateOnModelUpdate ?? validateOnModelUpdate,
   };
-}
-
-function applyModifiers(value: unknown, modifiers: Record<string, boolean>) {
-  if (modifiers.number) {
-    return toNumber(value as string);
-  }
-
-  return value;
 }
 
 function resolveInitialValue(props: Record<string, unknown>, ctx: SetupContext<any>) {

--- a/packages/vee-validate/src/Field.ts
+++ b/packages/vee-validate/src/Field.ts
@@ -129,7 +129,6 @@ const FieldImpl = defineComponent({
     const name = toRef(props, 'name');
     const label = toRef(props, 'label');
     const uncheckedValue = toRef(props, 'uncheckedValue');
-    const hasModelEvents = isPropPresent(props, 'onUpdate:modelValue');
 
     const {
       errors,
@@ -160,12 +159,10 @@ const FieldImpl = defineComponent({
     });
 
     // If there is a v-model applied on the component we need to emit the `update:modelValue` whenever the value binding changes
-    const onChangeHandler = hasModelEvents
-      ? function handleChangeWithModel(e: unknown, shouldValidate = true) {
-          handleChange(e, shouldValidate);
-          ctx.emit('update:modelValue', value.value);
-        }
-      : handleChange;
+    const onChangeHandler = function handleChangeWithModel(e: unknown, shouldValidate = true) {
+      handleChange(e, shouldValidate);
+      ctx.emit('update:modelValue', value.value);
+    };
 
     const handleInput = (e: any) => {
       if (!hasCheckedAttr(ctx.attrs.type)) {
@@ -173,12 +170,10 @@ const FieldImpl = defineComponent({
       }
     };
 
-    const onInputHandler = hasModelEvents
-      ? function handleInputWithModel(e: any) {
-          handleInput(e);
-          ctx.emit('update:modelValue', value.value);
-        }
-      : handleInput;
+    const onInputHandler = function handleInputWithModel(e: any) {
+      handleInput(e);
+      ctx.emit('update:modelValue', value.value);
+    };
 
     const fieldProps = computed(() => {
       const { validateOnInput, validateOnChange, validateOnBlur, validateOnModelUpdate } =

--- a/packages/vee-validate/src/Field.ts
+++ b/packages/vee-validate/src/Field.ts
@@ -1,25 +1,7 @@
-import {
-  h,
-  defineComponent,
-  toRef,
-  SetupContext,
-  resolveDynamicComponent,
-  computed,
-  watch,
-  PropType,
-  VNode,
-} from 'vue';
+import { h, defineComponent, toRef, SetupContext, resolveDynamicComponent, computed, PropType, VNode } from 'vue';
 import { getConfig } from './config';
 import { RuleExpression, useField } from './useField';
-import {
-  normalizeChildren,
-  hasCheckedAttr,
-  shouldHaveValueBinding,
-  isPropPresent,
-  normalizeEventValue,
-  applyModelModifiers,
-} from './utils';
-import { toNumber } from '../../shared';
+import { normalizeChildren, hasCheckedAttr, shouldHaveValueBinding, isPropPresent, normalizeEventValue } from './utils';
 import { IS_ABSENT } from './symbols';
 import { FieldMeta } from './types';
 import { FieldContext } from '.';
@@ -155,7 +137,6 @@ const FieldImpl = defineComponent({
       label,
       validateOnValueUpdate: false,
       keepValueOnUnmount: props.keepValue,
-      syncVModel: false,
     });
 
     // If there is a v-model applied on the component we need to emit the `update:modelValue` whenever the value binding changes
@@ -205,19 +186,6 @@ const FieldImpl = defineComponent({
       }
 
       return attrs;
-    });
-
-    const modelValue = toRef(props, 'modelValue');
-    watch(modelValue, newModelValue => {
-      // Don't attempt to sync absent values
-      if ((newModelValue as any) === IS_ABSENT && value.value === undefined) {
-        return;
-      }
-
-      if (newModelValue !== applyModelModifiers(value.value, props.modelModifiers)) {
-        value.value = (newModelValue as any) === IS_ABSENT ? undefined : newModelValue;
-        validateField();
-      }
     });
 
     function slotProps(): FieldSlotProps {

--- a/packages/vee-validate/src/Field.ts
+++ b/packages/vee-validate/src/Field.ts
@@ -149,6 +149,7 @@ const FieldImpl = defineComponent({
       label,
       validateOnValueUpdate: false,
       keepValueOnUnmount: props.keepValue,
+      syncVModel: false,
     });
 
     // If there is a v-model applied on the component we need to emit the `update:modelValue` whenever the value binding changes

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -496,6 +496,11 @@ function useVModel<TValue = unknown>({ prop, value, handleChange }: ModelOpts<TV
   const propName = prop || 'modelValue';
   const emitName = `update:${propName}`;
 
+  // Component doesn't have a model prop setup (must be defined on the props)
+  if (!(propName in vm.props)) {
+    return;
+  }
+
   watch(value, newValue => {
     if (isEqual(newValue, getCurrentModelValue(vm, propName))) {
       return;

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -481,6 +481,7 @@ interface ModelOpts {
 
 function useVModel<TValue = unknown>(value: Ref<TValue>, opts?: ModelOpts) {
   const vm = getCurrentInstance();
+  /* istanbul ignore next */
   if (!vm) {
     if (__DEV__) {
       console.warn('Failed to setup model events because `useField` was not called in setup.');

--- a/packages/vee-validate/src/utils/common.ts
+++ b/packages/vee-validate/src/utils/common.ts
@@ -1,4 +1,4 @@
-import { isIndex, isNullOrUndefined, isObject } from '../../../shared';
+import { isIndex, isNullOrUndefined, isObject, toNumber } from '../../../shared';
 import { getCurrentInstance, inject, InjectionKey, warn as vueWarning } from 'vue';
 import { isContainerValue, isEmptyContainer, isNotNestedPath } from './assertions';
 import { PrivateFieldContext } from '../types';
@@ -229,4 +229,16 @@ export function debounceAsync<TFunction extends (...args: any) => Promise<any>, 
 
     return new Promise<TResult>(resolve => resolves.push(resolve));
   };
+}
+
+export function applyModelModifiers(value: unknown, modifiers: unknown) {
+  if (!isObject(modifiers)) {
+    return;
+  }
+
+  if (modifiers.number) {
+    return toNumber(value as string);
+  }
+
+  return value;
 }

--- a/packages/vee-validate/tests/FieldArray.spec.ts
+++ b/packages/vee-validate/tests/FieldArray.spec.ts
@@ -831,7 +831,7 @@ test('clean up form registration on unmount', async () => {
       };
     },
     template: `
-      <VForm @submit="onSubmit" :initial-values="initialValues">
+      <VForm :initial-values="initialValues">
         <FieldArray v-if="shown" name="users" v-slot="{ remove, fields }">
           <fieldset v-for="(field, idx) in fields" :key="field.key">
             <legend>User #{{ idx }}</legend>


### PR DESCRIPTION
## What

This PR adds a new capability to `useField` to allow it to automatically sync the `v-model` directive when it is used on the component that has called it.

This was a common question and issue where multiple people found syncing the `modelValue` prop themselves annoying.

I think this is a nice addition that is relatively safe to introduce into `useField` at this stage.


## How

`useField` will now automatically make the component emit `update:modelValue` and listen to `props.modelValue` changes and sync it with the `value` property. It will also take into account the model modifiers like `v-model.number`.

For custom models names, you can control what the prop/event names are called with `modelPropName` option:

```js
// component will now emit `update:custom` and sync `custom` prop value with the `value` returned from `useField`.
const { value } = useField('field', undefined, {
  modelPropName: 'custom'
});
```

You can disable this behavior if you prefer to do that yourself or if you have specific needs with `syncVModel` option:


```js
// Now it won't emit anything and won't sync anything.
const { value } = useField('field', undefined, {
  syncVModel: false
});
```

## TODO

- [x] Make `Field` component use this behavior instead of implementing its own
- [x] Write Tests
- [x] Write docs

## Caveats

For those who have been using `useField` multiple times in the same component it usually won't cause any issues unless you have a `v-model` being used on the component. this makes me think that this behavior could be disabled by default to avoid that rare case, but again `useField` was never encouraged to be used like that. 

This is why `useFieldModel` was introduced to replace that use case.
