### PR TITLE
feat: added unsetValueOnUnmount config

### DIFF
--- a/packages/vee-validate/src/Field.ts
+++ b/packages/vee-validate/src/Field.ts
@@ -112,9 +112,9 @@ const FieldImpl = defineComponent({
       type: Boolean,
       default: false,
     },
-    unsetValueOnUnmount: {
+    keepValue: {
       type: Boolean,
-      default: true,
+      default: undefined,
     },
   },
   setup(props, ctx) {
@@ -148,7 +148,7 @@ const FieldImpl = defineComponent({
       uncheckedValue,
       label,
       validateOnValueUpdate: false,
-      unsetValueOnUnmount: props.unsetValueOnUnmount,
+      keepValueOnUnmount: props.keepValue,
     });
 
     // If there is a v-model applied on the component we need to emit the `update:modelValue` whenever the value binding changes

--- a/packages/vee-validate/src/Field.ts
+++ b/packages/vee-validate/src/Field.ts
@@ -112,6 +112,10 @@ const FieldImpl = defineComponent({
       type: Boolean,
       default: false,
     },
+    unsetValueOnUnmount: {
+      type: Boolean,
+      default: true,
+    },
   },
   setup(props, ctx) {
     const rules = toRef(props, 'rules');
@@ -144,6 +148,7 @@ const FieldImpl = defineComponent({
       uncheckedValue,
       label,
       validateOnValueUpdate: false,
+      unsetValueOnUnmount: props.unsetValueOnUnmount,
     });
 
     // If there is a v-model applied on the component we need to emit the `update:modelValue` whenever the value binding changes

--- a/packages/vee-validate/src/Form.ts
+++ b/packages/vee-validate/src/Form.ts
@@ -64,6 +64,10 @@ const FormImpl = defineComponent({
       type: Function as PropType<InvalidSubmissionHandler>,
       default: undefined,
     },
+    unsetValuesOnUnmount: {
+      type: Boolean,
+      default: true,
+    },
   },
   setup(props, ctx) {
     const initialValues = toRef(props, 'initialValues');
@@ -93,6 +97,7 @@ const FormImpl = defineComponent({
       initialErrors: props.initialErrors,
       initialTouched: props.initialTouched,
       validateOnMount: props.validateOnMount,
+      unsetValuesOnUnmount: props.unsetValuesOnUnmount,
     });
 
     const onSubmit = props.onSubmit ? handleSubmit(props.onSubmit, props.onInvalidSubmit) : submitForm;

--- a/packages/vee-validate/src/Form.ts
+++ b/packages/vee-validate/src/Form.ts
@@ -64,9 +64,9 @@ const FormImpl = defineComponent({
       type: Function as PropType<InvalidSubmissionHandler>,
       default: undefined,
     },
-    unsetValuesOnUnmount: {
+    keepValues: {
       type: Boolean,
-      default: true,
+      default: false,
     },
   },
   setup(props, ctx) {
@@ -97,7 +97,7 @@ const FormImpl = defineComponent({
       initialErrors: props.initialErrors,
       initialTouched: props.initialTouched,
       validateOnMount: props.validateOnMount,
-      unsetValuesOnUnmount: props.unsetValuesOnUnmount,
+      keepValuesOnUnmount: props.keepValues,
     });
 
     const onSubmit = props.onSubmit ? handleSubmit(props.onSubmit, props.onInvalidSubmit) : submitForm;

--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -85,7 +85,7 @@ export interface PrivateFieldContext<TValue = unknown> {
   label?: MaybeRef<string | undefined>;
   type?: string;
   bails?: boolean;
-  unsetValueOnUnmount?: boolean;
+  keepValueOnUnmount?: boolean;
   checkedValue?: MaybeRef<TValue>;
   uncheckedValue?: MaybeRef<TValue>;
   checked?: Ref<boolean>;
@@ -182,7 +182,7 @@ export interface PrivateFormContext<TValues extends Record<string, any> = Record
   errors: ComputedRef<FormErrors<TValues>>;
   meta: ComputedRef<FormMeta<TValues>>;
   isSubmitting: Ref<boolean>;
-  unsetValuesOnUnmount: boolean;
+  keepValuesOnUnmount: boolean;
   validateSchema?: (mode: SchemaValidationMode) => Promise<FormValidationResult<TValues>>;
   validate(opts?: Partial<ValidationOptions>): Promise<FormValidationResult<TValues>>;
   validateField(field: keyof TValues): Promise<ValidationResult>;
@@ -215,7 +215,7 @@ export interface FormContext<TValues extends Record<string, any> = Record<string
     | 'setFieldInitialValue'
     | 'unsetInitialValue'
     | 'fieldArraysLookup'
-    | 'unsetValuesOnUnmount'
+    | 'keepValuesOnUnmount'
   > {
   handleReset: () => void;
   submitForm: (e?: unknown) => Promise<void>;

--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -85,6 +85,7 @@ export interface PrivateFieldContext<TValue = unknown> {
   label?: MaybeRef<string | undefined>;
   type?: string;
   bails?: boolean;
+  unsetValueOnUnmount?: boolean;
   checkedValue?: MaybeRef<TValue>;
   uncheckedValue?: MaybeRef<TValue>;
   checked?: Ref<boolean>;
@@ -181,6 +182,7 @@ export interface PrivateFormContext<TValues extends Record<string, any> = Record
   errors: ComputedRef<FormErrors<TValues>>;
   meta: ComputedRef<FormMeta<TValues>>;
   isSubmitting: Ref<boolean>;
+  unsetValuesOnUnmount: boolean;
   validateSchema?: (mode: SchemaValidationMode) => Promise<FormValidationResult<TValues>>;
   validate(opts?: Partial<ValidationOptions>): Promise<FormValidationResult<TValues>>;
   validateField(field: keyof TValues): Promise<ValidationResult>;
@@ -213,6 +215,7 @@ export interface FormContext<TValues extends Record<string, any> = Record<string
     | 'setFieldInitialValue'
     | 'unsetInitialValue'
     | 'fieldArraysLookup'
+    | 'unsetValuesOnUnmount'
   > {
   handleReset: () => void;
   submitForm: (e?: unknown) => Promise<void>;

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -51,7 +51,7 @@ interface FieldOptions<TValue = unknown> {
   uncheckedValue?: MaybeRef<TValue>;
   label?: MaybeRef<string | undefined>;
   standalone?: boolean;
-  unsetValueOnUnmount?: boolean;
+  keepValueOnUnmount?: boolean;
 }
 
 export type RuleExpression<TValue> =
@@ -93,7 +93,7 @@ function _useField<TValue = unknown>(
     validateOnValueUpdate,
     uncheckedValue,
     standalone,
-    unsetValueOnUnmount,
+    keepValueOnUnmount,
   } = normalizeOptions(unref(name), opts);
 
   const form = !standalone ? injectWithSelf(FormContextKey) : undefined;
@@ -265,7 +265,7 @@ function _useField<TValue = unknown>(
     checkedValue,
     uncheckedValue,
     bails,
-    unsetValueOnUnmount,
+    keepValueOnUnmount,
     resetField,
     handleReset: () => resetField(),
     validate,
@@ -374,7 +374,7 @@ function normalizeOptions<TValue>(name: string, opts: Partial<FieldOptions<TValu
     label: name,
     validateOnValueUpdate: true,
     standalone: false,
-    unsetValueOnUnmount: true,
+    keepValueOnUnmount: undefined,
   });
 
   if (!opts) {
@@ -443,8 +443,9 @@ function useCheckboxField<TValue = unknown>(
     }
 
     onBeforeUnmount(() => {
+      const shouldKeepValue = field.keepValueOnUnmount ?? form?.keepValuesOnUnmount ?? false;
       // toggles the checkbox value if it was checked and the unset behavior is set
-      if (checked.value && field.unsetValueOnUnmount && form?.unsetValuesOnUnmount) {
+      if (checked.value && !shouldKeepValue) {
         handleCheckboxChange(unref(checkedValue), false);
       }
     });

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -51,6 +51,7 @@ interface FieldOptions<TValue = unknown> {
   uncheckedValue?: MaybeRef<TValue>;
   label?: MaybeRef<string | undefined>;
   standalone?: boolean;
+  unsetValueOnUnmount?: boolean;
 }
 
 export type RuleExpression<TValue> =
@@ -92,6 +93,7 @@ function _useField<TValue = unknown>(
     validateOnValueUpdate,
     uncheckedValue,
     standalone,
+    unsetValueOnUnmount,
   } = normalizeOptions(unref(name), opts);
 
   const form = !standalone ? injectWithSelf(FormContextKey) : undefined;
@@ -263,6 +265,7 @@ function _useField<TValue = unknown>(
     checkedValue,
     uncheckedValue,
     bails,
+    unsetValueOnUnmount,
     resetField,
     handleReset: () => resetField(),
     validate,
@@ -371,6 +374,7 @@ function normalizeOptions<TValue>(name: string, opts: Partial<FieldOptions<TValu
     label: name,
     validateOnValueUpdate: true,
     standalone: false,
+    unsetValueOnUnmount: true,
   });
 
   if (!opts) {
@@ -439,8 +443,8 @@ function useCheckboxField<TValue = unknown>(
     }
 
     onBeforeUnmount(() => {
-      // toggles the checkbox value if it was checked
-      if (checked.value) {
+      // toggles the checkbox value if it was checked and the unset behavior is set
+      if (checked.value && field.unsetValueOnUnmount && form?.unsetValuesOnUnmount) {
         handleCheckboxChange(unref(checkedValue), false);
       }
     });

--- a/packages/vee-validate/tests/Form.spec.ts
+++ b/packages/vee-validate/tests/Form.spec.ts
@@ -711,7 +711,6 @@ describe('<Form />', () => {
     expect(value.textContent).toBe('undefined');
   });
 
-  // broken as of 3.0.0-rc.12 for some reason
   test('unmounted fields gets unregistered and their values cleaned up', async () => {
     const showFields = ref(true);
     const wrapper = mountWithHoc({
@@ -833,6 +832,264 @@ describe('<Form />', () => {
     button.click();
     await flushPromises();
     expect(spy).toHaveBeenLastCalledWith({ drink: ['Coke'] });
+  });
+
+  test('unmounted fields gets unregistered and their values are kept if configured on the form level', async () => {
+    const showFields = ref(true);
+    const wrapper = mountWithHoc({
+      setup() {
+        const schema = computed(() => ({
+          field: showFields.value ? 'required' : '',
+          drink: 'required',
+        }));
+
+        return {
+          schema,
+          showFields,
+        };
+      },
+      template: `
+      <VForm as="form" :validationSchema="schema" v-slot="{ errors, values }" :unsetValuesOnUnmount="false">
+        <template v-if="showFields">
+          <Field name="field" as="input" />
+          <Field name="nested.field" />
+          <Field name="[non-nested.field]" />
+          <Field name="drink" as="input" type="checkbox" value="" /> Coffee
+          <Field name="drink" as="input" type="checkbox" value="Tea" /> Tea
+        </template>
+        <Field name="drink" as="input" type="checkbox" value="Coke" /> Coke
+
+        <span id="errors">{{ errors }}</span>
+        <span id="values">{{ values }}</span>
+
+        <button>Validate</button>
+      </VForm>
+    `,
+    });
+
+    await flushPromises();
+    const errors = wrapper.$el.querySelector('#errors');
+    const values = wrapper.$el.querySelector('#values');
+    const inputs = wrapper.$el.querySelectorAll('input');
+
+    wrapper.$el.querySelector('button').click();
+    await flushPromises();
+    expect(errors.textContent).toBeTruthy();
+    setChecked(inputs[4]);
+    setChecked(inputs[5]);
+    setValue(inputs[0], 'test');
+    setValue(inputs[1], '12');
+    setValue(inputs[2], '12');
+    await flushPromises();
+    const expected = {
+      drink: ['Tea', 'Coke'],
+      field: 'test',
+      'non-nested.field': '12',
+      nested: { field: '12' },
+    };
+    expect(JSON.parse(values.textContent)).toEqual(expected);
+
+    showFields.value = false;
+    await flushPromises();
+    // errors were cleared
+    expect(errors.textContent).toBe('{}');
+    expect(JSON.parse(values.textContent)).toEqual(expected);
+  });
+
+  test('unmounted fields gets unregistered and their submitted values are kept if configured on the form level', async () => {
+    let showFields!: Ref<boolean>;
+    const spy = jest.fn();
+    const wrapper = mountWithHoc({
+      setup() {
+        showFields = ref(true);
+
+        return {
+          showFields,
+          onSubmit(values: any) {
+            spy(values);
+          },
+        };
+      },
+      template: `
+      <VForm @submit="onSubmit" as="form" v-slot="{ errors }" :unsetValuesOnUnmount="false">
+        <template v-if="showFields">
+          <Field name="field" as="input" rules="required" />
+          <Field name="nested.field" rules="required" />
+          <Field name="[non-nested.field]" rules="required" />
+          <Field name="drink" as="input" type="checkbox" value="" rules="required" /> Coffee
+          <Field name="drink" as="input" type="checkbox" value="Tea" rules="required" /> Tea
+        </template>
+        <Field name="drink" as="input" type="checkbox" value="Coke" rules="required" /> Coke
+
+        <span id="errors">{{ errors }}</span>
+
+        <button>Submit</button>
+      </VForm>
+    `,
+    });
+
+    await flushPromises();
+    const errors = wrapper.$el.querySelector('#errors');
+    const button = wrapper.$el.querySelector('button');
+    const inputs = wrapper.$el.querySelectorAll('input');
+
+    wrapper.$el.querySelector('button').click();
+    await flushPromises();
+    expect(errors.textContent).toBeTruthy();
+    setChecked(inputs[4]);
+    setChecked(inputs[5]);
+    setValue(inputs[0], 'test');
+    setValue(inputs[1], '12');
+    setValue(inputs[2], '12');
+    await flushPromises();
+    button.click();
+    await flushPromises();
+    const expected = {
+      drink: ['Tea', 'Coke'],
+      field: 'test',
+      'non-nested.field': '12',
+      nested: { field: '12' },
+    };
+    expect(spy).toHaveBeenLastCalledWith(expected);
+
+    showFields.value = false;
+    await flushPromises();
+    expect(errors.textContent).toBe('{}');
+    button.click();
+    await flushPromises();
+    expect(spy).toHaveBeenLastCalledWith(expected);
+  });
+
+  test('unmounted fields gets unregistered and their values are kept if configured on the field level', async () => {
+    const showFields = ref(true);
+    const wrapper = mountWithHoc({
+      setup() {
+        const schema = computed(() => ({
+          field: showFields.value ? 'required' : '',
+          drink: 'required',
+        }));
+
+        return {
+          schema,
+          showFields,
+        };
+      },
+      template: `
+      <VForm as="form" :validationSchema="schema" v-slot="{ errors, values }">
+        <template v-if="showFields">
+          <Field name="field" as="input" />
+          <Field name="nested.field" :unsetValueOnUnmount="false" />
+          <Field name="[non-nested.field]" :unsetValueOnUnmount="false" />
+          <Field name="drink" as="input" type="checkbox" value="" /> Coffee
+          <Field name="drink" as="input" type="checkbox" value="Tea" :unsetValueOnUnmount="false" /> Tea
+        </template>
+        <Field name="drink" as="input" type="checkbox" value="Coke" /> Coke
+
+        <span id="errors">{{ errors }}</span>
+        <span id="values">{{ values }}</span>
+
+        <button>Validate</button>
+      </VForm>
+    `,
+    });
+
+    await flushPromises();
+    const errors = wrapper.$el.querySelector('#errors');
+    const values = wrapper.$el.querySelector('#values');
+    const inputs = wrapper.$el.querySelectorAll('input');
+
+    wrapper.$el.querySelector('button').click();
+    await flushPromises();
+    expect(errors.textContent).toBeTruthy();
+    setChecked(inputs[4]);
+    setChecked(inputs[5]);
+    setValue(inputs[0], 'test');
+    setValue(inputs[1], '12');
+    setValue(inputs[2], '12');
+    await flushPromises();
+    expect(JSON.parse(values.textContent)).toEqual({
+      drink: ['Tea', 'Coke'],
+      field: 'test',
+      'non-nested.field': '12',
+      nested: { field: '12' },
+    });
+
+    showFields.value = false;
+    await flushPromises();
+    // errors were cleared
+    expect(errors.textContent).toBe('{}');
+    expect(JSON.parse(values.textContent)).toEqual({
+      drink: ['Tea', 'Coke'],
+      'non-nested.field': '12',
+      nested: { field: '12' },
+    });
+  });
+
+  test('unmounted fields gets unregistered and their submitted values are kept if configured on the field level', async () => {
+    let showFields!: Ref<boolean>;
+    const spy = jest.fn();
+    const wrapper = mountWithHoc({
+      setup() {
+        showFields = ref(true);
+
+        return {
+          showFields,
+          onSubmit(values: any) {
+            spy(values);
+          },
+        };
+      },
+      template: `
+      <VForm @submit="onSubmit" as="form" v-slot="{ errors }">
+        <template v-if="showFields">
+          <Field name="field" as="input" rules="required" />
+          <Field name="nested.field" rules="required" :unsetValueOnUnmount="false" />
+          <Field name="[non-nested.field]" rules="required" :unsetValueOnUnmount="false" />
+          <Field name="drink" as="input" type="checkbox" value="" rules="required" /> Coffee
+          <Field name="drink" as="input" type="checkbox" value="Tea" rules="required" :unsetValueOnUnmount="false" /> Tea
+        </template>
+        <Field name="drink" as="input" type="checkbox" value="Coke" rules="required" /> Coke
+
+        <span id="errors">{{ errors }}</span>
+
+        <button>Submit</button>
+      </VForm>
+    `,
+    });
+
+    await flushPromises();
+    const errors = wrapper.$el.querySelector('#errors');
+    const button = wrapper.$el.querySelector('button');
+    const inputs = wrapper.$el.querySelectorAll('input');
+
+    wrapper.$el.querySelector('button').click();
+    await flushPromises();
+    expect(errors.textContent).toBeTruthy();
+    setChecked(inputs[4]);
+    setChecked(inputs[5]);
+    setValue(inputs[0], 'test');
+    setValue(inputs[1], '12');
+    setValue(inputs[2], '12');
+    await flushPromises();
+    button.click();
+    await flushPromises();
+    expect(spy).toHaveBeenLastCalledWith({
+      drink: ['Tea', 'Coke'],
+      field: 'test',
+      'non-nested.field': '12',
+      nested: { field: '12' },
+    });
+
+    showFields.value = false;
+    await flushPromises();
+    expect(errors.textContent).toBe('{}');
+    button.click();
+    await flushPromises();
+    expect(spy).toHaveBeenLastCalledWith({
+      drink: ['Tea', 'Coke'],
+      'non-nested.field': '12',
+      nested: { field: '12' },
+    });
   });
 
   test('checkboxes with yup schema', async () => {


### PR DESCRIPTION
🔎 __Overview__

This PR adds a configuration to change the automatic behavior of unsetting field values when the components are unmounted.

The configuration is available on both the form level and the field level.

```js
useField('name', undefined, { keepValueOnUnmount: true });

useForm({ keepValuesOnUnmount: true });
```

```vue
<Field name="fieldName" keep-value />

<Form keep-values>
....
</Form>
```

✔ __Issues affected__

closes #3795
closes #3607
 
