### PR TITLE
Feat: duplicate calls to useFieldArray with the same path will yield the same API instance

### DIFF
--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -71,8 +71,9 @@ export interface FieldArrayContext<TValue = unknown> {
   move(oldIdx: number, newIdx: number): void;
 }
 
-export interface PrivateFieldArrayContext {
+export interface PrivateFieldArrayContext<TValue = unknown> extends FieldArrayContext<TValue> {
   reset(): void;
+  path: MaybeRef<string>;
 }
 
 export interface PrivateFieldContext<TValue = unknown> {
@@ -175,7 +176,7 @@ export interface PrivateFormContext<TValues extends Record<string, any> = Record
   formId: number;
   values: TValues;
   fieldsByPath: Ref<FieldPathLookup>;
-  fieldArraysLookup: Record<string, PrivateFieldArrayContext>;
+  fieldArrays: PrivateFieldArrayContext[];
   submitCount: Ref<number>;
   schema?: MaybeRef<RawFormSchema<TValues> | SchemaOf<TValues> | undefined>;
   errorBag: Ref<FormErrorBag<TValues>>;
@@ -214,7 +215,7 @@ export interface FormContext<TValues extends Record<string, any> = Record<string
     | 'stageInitialValue'
     | 'setFieldInitialValue'
     | 'unsetInitialValue'
-    | 'fieldArraysLookup'
+    | 'fieldArrays'
     | 'keepValuesOnUnmount'
   > {
   handleReset: () => void;

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -84,8 +84,8 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
   // The number of times the user tried to submit the form
   const submitCount = ref(0);
 
-  // dictionary for field arrays to receive various signals like reset
-  const fieldArraysLookup: Record<string, PrivateFieldArrayContext> = {};
+  // field arrays managed by this form
+  const fieldArrays: PrivateFieldArrayContext[] = [];
 
   // a private ref for all form values
   const formValues = reactive(deepCopy(unref(opts?.initialValues) || {})) as TValues;
@@ -167,7 +167,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     submitCount,
     meta,
     isSubmitting,
-    fieldArraysLookup,
+    fieldArrays,
     keepValuesOnUnmount,
     validateSchema: unref(schema) ? validateSchema : undefined,
     validate,
@@ -287,7 +287,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     });
 
     // regenerate the arrays when the form values change
-    Object.values(fieldArraysLookup).forEach(f => f && f.reset());
+    fieldArrays.forEach(f => f && f.reset());
   }
 
   function createModel<TPath extends keyof TValues>(path: MaybeRef<TPath>) {

--- a/packages/vee-validate/tests/FieldArray.spec.ts
+++ b/packages/vee-validate/tests/FieldArray.spec.ts
@@ -1,6 +1,6 @@
 import { defineRule, useField } from '@/vee-validate';
 import { defineComponent } from '@vue/runtime-core';
-import { toRef } from 'vue';
+import { toRef, ref } from 'vue';
 import * as yup from 'yup';
 import { mountWithHoc, setValue, getValue, dispatchEvent, flushPromises } from './helpers';
 
@@ -815,4 +815,37 @@ test('removing an item marks the form as dirty', async () => {
   await flushPromises();
 
   await expect(getDirtyPre().textContent).toBe('true');
+});
+
+test('clean up form registration on unmount', async () => {
+  const shown = ref(true);
+  mountWithHoc({
+    setup() {
+      const initialValues = {
+        users: [{ name: '1' }, { name: '2' }, { name: '3' }],
+      };
+
+      return {
+        initialValues,
+        shown,
+      };
+    },
+    template: `
+      <VForm @submit="onSubmit" :initial-values="initialValues">
+        <FieldArray v-if="shown" name="users" v-slot="{ remove, fields }">
+          <fieldset v-for="(field, idx) in fields" :key="field.key">
+            <legend>User #{{ idx }}</legend>
+            <label :for="'name_' + idx">Name</label>
+            <Field :id="'name_' + idx" :name="'users[' + idx + '].name'" />
+
+          </fieldset>  
+        </FieldArray>
+      </VForm>
+    `,
+  });
+
+  await flushPromises();
+  shown.value = false;
+  await flushPromises();
+  expect(1).toBe(1);
 });


### PR DESCRIPTION
🔎 __Overview__

This PR changes how field arrays are registered within forms to allow their instances to be re-used. If the same array path is used for multiple calls of `useFieldArray` or `FieldArray` component then these calls will return the same instance.

This makes the field array state can be used and manipulated from multiple places at once.

✔ __Issues affected__

closes #3809
