### PR TITLE
fix text alignment

### DIFF
--- a/docs/content/tutorials/dynamic-form-generator.md
+++ b/docs/content/tutorials/dynamic-form-generator.md
@@ -18,7 +18,7 @@ Let's quickly recap what you will be building, the component we will be building
 
 - Accept a form schema specifying the fields
 - Render the given schema
-- Use [yup](https://github.com/jquense/yup) to validate our form
+- <div>Use <a href="https://github.com/jquense/yup">yup</a> to validate our form</div>
 - Show error messages
 
 </div>


### PR DESCRIPTION
The texts "Use [yup](https://github.com/jquense/yup) to validate our form" are squished on this page https://vee-validate.logaretm.com/v4/tutorials/dynamic-form-generator

![image](https://user-images.githubusercontent.com/51456572/180917532-9461e5ce-28cf-4080-bba5-600dce7e4f46.png)

It is because of the structure rendered in the DOM.
![image](https://user-images.githubusercontent.com/51456572/180917828-b42b8de5-5843-41d3-a7c9-4e861746df23.png)


