### PR TITLE
Typo in `keepValuesOnUnmount` in useForm()

### DIFF
--- a/docs/content/guide/composition-api/nested-objects-and-arrays.md
+++ b/docs/content/guide/composition-api/nested-objects-and-arrays.md
@@ -251,7 +251,7 @@ import { useForm } from 'vee-validate';
 
 // keep all values when their fields get unmounted
 const { values } = useForm({
-  keepValueOnUnmount: true,
+  keepValuesOnUnmount: true,
 });
 ```
 


### PR DESCRIPTION
🔎 __Overview__

This PR is for fixing typo in document description.

In `useForm` the correct key of the option is `keepValuesOnUnmount` instead of `keepValueOnUnmount`.
 
