### PR TITLE
Changed "keine" to "kein" in credit_card message

### DIFF
--- a/locale/de.js
+++ b/locale/de.js
@@ -10,7 +10,7 @@ const messages = {
   before: (field, [target]) => `${field} muss vor ${target} liegen`,
   between: (field, [min, max]) => `${field} muss zwischen ${min} und ${max} liegen`,
   confirmed: (field) => `Die Bestätigung von ${field} stimmt nicht überein`,
-  credit_card: (field) => `${field} ist keine gültiger Wert für Kreditkarten`,
+  credit_card: (field) => `${field} ist kein gültiger Wert für Kreditkarten`,
   date_between: (field, [min, max]) => `${field} muss zwischen ${min} und ${max} liegen`,
   date_format: (field, [format]) => `${field} muss das Format ${format} haben`,
   decimal: (field, [decimals = '*'] = []) => `${field} muss numerisch sein und darf${!decimals || decimals === '*' ? '' : ' ' + decimals} Dezimalpunkte enthalten`,


### PR DESCRIPTION
🔎 __Overview__

This PR fixes a grammatical error in "credit_card" validation message in German translation file.
 
