### PR TITLE
feat: added field model writable slot prop

### DIFF
--- a/packages/vee-validate/src/Field.ts
+++ b/packages/vee-validate/src/Field.ts
@@ -1,10 +1,9 @@
-import { h, defineComponent, toRef, SetupContext, resolveDynamicComponent, computed, PropType, VNode } from 'vue';
+import { h, defineComponent, toRef, SetupContext, resolveDynamicComponent, computed, PropType, VNode, Ref } from 'vue';
 import { getConfig } from './config';
 import { RuleExpression, useField } from './useField';
 import { normalizeChildren, hasCheckedAttr, shouldHaveValueBinding, isPropPresent, normalizeEventValue } from './utils';
 import { IS_ABSENT } from './symbols';
-import { FieldMeta } from './types';
-import { FieldContext } from '.';
+import { FieldMeta, FieldContext } from './types';
 
 interface ValidationTriggersProps {
   validateOnMount: boolean;
@@ -32,6 +31,7 @@ interface FieldSlotProps<TValue = unknown>
   field: FieldBindingObject<TValue>;
   value: TValue;
   meta: FieldMeta<TValue>;
+  model: Ref<TValue>;
   errors: string[];
   errorMessage: string | undefined;
   handleInput: FieldContext['handleChange'];
@@ -189,6 +189,11 @@ const FieldImpl = defineComponent({
       return attrs;
     });
 
+    const model = computed({
+      get: () => value.value,
+      set: value => handleChange(value),
+    });
+
     function slotProps(): FieldSlotProps {
       return {
         field: fieldProps.value,
@@ -196,6 +201,7 @@ const FieldImpl = defineComponent({
         meta,
         errors: errors.value,
         errorMessage: errorMessage.value,
+        model,
         validate: validateField,
         resetField,
         handleChange: onChangeHandler,
@@ -213,6 +219,7 @@ const FieldImpl = defineComponent({
       reset: resetField,
       validate: validateField,
       handleChange,
+      setValue: handleChange,
     });
 
     return () => {
@@ -273,6 +280,7 @@ export const Field = FieldImpl as typeof FieldImpl & {
     reset: FieldContext['resetField'];
     validate: FieldContext['validate'];
     handleChange: FieldContext['handleChange'];
+    setValue: FieldContext['handleChange'];
     $slots: {
       default: (arg: FieldSlotProps<unknown>) => VNode[];
     };


### PR DESCRIPTION
🔎 __Overview__

This PR introduces a new way to hook `<Field />` component into custom slot elements with more compatibility using the `v-model` API against a writable model ref.

The motivation for this is because:

- 3rd party components having inconsistent events behavior
- Custom components may emit HTML events by mistake to `v-bind="field"` as to has no way to choose which events to listen to since it doesn't have access to the virtual DOM node.
- `v-model` is easier to understand than `v-bind="field"` and its implications.


```vue
<Field v-slot="{ model, errorMessage }" name="test">
  <input type="text" v-model="model.value" />
  <pre>{{ errorMessage }}</pre>
</Field>
```

This would make it significantly easier to integrate with 3rd party components since all of them use `v-model` to sync values, at the cost of losing event-based validation.

Still unsure if this is a direction I want to go in or not but let's see how it goes.