### PR TITLE
fix: handle validation races for async validations

### DIFF
--- a/packages/vee-validate/src/utils/common.ts
+++ b/packages/vee-validate/src/utils/common.ts
@@ -244,3 +244,24 @@ export function applyModelModifiers(value: unknown, modifiers: unknown) {
 
   return value;
 }
+
+export function withLatest<TFunction extends (...args: any[]) => Promise<any>, TResult = ReturnType<TFunction>>(
+  fn: TFunction,
+  onDone: (result: Awaited<TResult>, args: Parameters<TFunction>) => void
+) {
+  let latestRun: Promise<TResult> | undefined;
+
+  return async function runLatest(...args: Parameters<TFunction>) {
+    const pending = fn(...args);
+    latestRun = pending;
+    const result = await pending;
+    if (pending !== latestRun) {
+      return result;
+    }
+
+    latestRun = undefined;
+    onDone(result, args);
+
+    return result;
+  };
+}

--- a/packages/vee-validate/tests/useField.spec.ts
+++ b/packages/vee-validate/tests/useField.spec.ts
@@ -659,7 +659,6 @@ describe('useField()', () => {
 
   // #3906
   test('only latest validation run messages are used', async () => {
-    jest.useFakeTimers();
     function validator(value: string | undefined) {
       if (!value) {
         return true;
@@ -706,6 +705,5 @@ describe('useField()', () => {
     jest.advanceTimersByTime(200);
     await flushPromises();
     expect(error?.textContent).toBe('not b');
-    jest.useRealTimers();
   });
 });

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -452,27 +452,8 @@ describe('useForm()', () => {
     });
   });
 
-  test('Validates the field model immediately and when it changes', async () => {
-    await runInSetup(async () => {
-      const { errors, useFieldModel } = useForm();
-      const model = useFieldModel('test');
-
-      await flushPromises();
-      expect(errors.value.test).toBe(REQUIRED_MESSAGE);
-
-      model.value = 'hello';
-      await flushPromises();
-      expect(errors.value.test).toBe('');
-
-      model.value = '';
-      await flushPromises();
-      expect(errors.value.test).toBe(REQUIRED_MESSAGE);
-    });
-  });
-
   // #3906
   test('only latest schema validation run messages are used', async () => {
-    jest.useFakeTimers();
     function validator(value: string | undefined) {
       if (!value) {
         return true;
@@ -509,8 +490,8 @@ describe('useForm()', () => {
         };
       },
       template: `
-        <input name="field" v-model="value" />
-        <span>{{ errorMessage }}</span>
+        <input name="field" v-model="model" />
+        <span>{{ errors.test }}</span>
       `,
     });
 
@@ -526,6 +507,5 @@ describe('useForm()', () => {
     jest.advanceTimersByTime(200);
     await flushPromises();
     expect(error?.textContent).toBe('not b');
-    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
Fixes when an async validation concludes after subsequent validation runs. closes #3906 