### PR TITLE
chore(docs): fix mismatch function name

### DIFF
--- a/docs/src/pages/guide/components/validation.mdx
+++ b/docs/src/pages/guide/components/validation.mdx
@@ -58,7 +58,7 @@ You can define validation rules for your fields using the `Field` component, you
 <script setup>
 import { Field, Form, ErrorMessage } from 'vee-validate';
 
-function required(value) {
+function isRequired(value) {
   if (value && value.trim()) {
     return true;
   }


### PR DESCRIPTION
This PR fix mismatch function name in components validation page.

Page: https://vee-validate.logaretm.com/v4/guide/components/validation/
Heading: Field-level Validation
changed "required" to "isRequired"

🔎 __Overview__

🤓 __Code snippets/examples (if applicable)__

```js
<template>
  <Form>
    <Field name="field" :rules="isRequired" />
    <ErrorMessage name="field" />
  </Form>
</template>
<script setup>
import { Field, Form, ErrorMessage } from 'vee-validate';
function required(value) {
  if (value && value.trim()) {
    return true;
  }
  return 'This is required';
}
</script>
```
changed to 
```js
<template>
  <Form>
    <Field name="field" :rules="isRequired" />
    <ErrorMessage name="field" />
  </Form>
</template>
<script setup>
import { Field, Form, ErrorMessage } from 'vee-validate';
function isRequired(value) {
  if (value && value.trim()) {
    return true;
  }
  return 'This is required';
}
</script>
```

✔ __Issues affected__

<!-- list of issues formatted like this
closes #{issue id}
 -->
 
