### PR TITLE
feat: allow passing form control to useField closes #3204

### DIFF
--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -355,7 +355,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
   }
 
   function createModel<TPath extends keyof TValues>(path: MaybeRef<TPath>) {
-    const { value } = _useFieldValue<TValues[TPath]>(path as string);
+    const { value } = _useFieldValue<TValues[TPath]>(path as string, undefined, formCtx as PrivateFormContext);
     watch(
       value,
       () => {
@@ -782,24 +782,9 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
   }
 
   return {
-    errors,
-    meta,
-    values: formValues,
-    isSubmitting,
-    submitCount,
-    validate,
-    validateField,
+    ...formCtx,
     handleReset: () => resetForm(),
-    resetForm,
-    handleSubmit,
     submitForm,
-    setFieldError,
-    setErrors,
-    setFieldValue,
-    setValues,
-    setFieldTouched,
-    setTouched,
-    useFieldModel,
   };
 }
 

--- a/packages/vee-validate/tests/useField.spec.ts
+++ b/packages/vee-validate/tests/useField.spec.ts
@@ -1,4 +1,4 @@
-import { useField, useForm } from '@/vee-validate';
+import { FieldContext, FormContext, useField, useForm } from '@/vee-validate';
 import { defineComponent, nextTick, onMounted, ref } from 'vue';
 import { mountWithHoc, setValue, flushPromises } from './helpers';
 
@@ -743,5 +743,37 @@ describe('useField()', () => {
     jest.advanceTimersByTime(200);
     await flushPromises();
     expect(error?.textContent).toBe('not b');
+  });
+
+  test('allows explicit forms to be provided via the form option', async () => {
+    let form1!: FormContext;
+    let form2!: FormContext;
+    let field1!: FieldContext;
+    let field2!: FieldContext;
+    mountWithHoc({
+      setup() {
+        form1 = useForm();
+        form2 = useForm();
+        field1 = useField('field', undefined, {
+          form: form1,
+        });
+        field2 = useField('field', undefined, {
+          form: form2,
+        });
+
+        return {};
+      },
+      template: `
+      <div></div>
+    `,
+    });
+
+    await flushPromises();
+    field1.value.value = '1';
+    field2.value.value = '2';
+    await flushPromises();
+
+    expect(form1.values.field).toBe('1');
+    expect(form2.values.field).toBe('2');
   });
 });


### PR DESCRIPTION
## What

Allows passing `form` object created by `useForm` to `useField` for finer control over field-form registration.

closes #3204