### PR TITLE
feat: expose controlled values on useForm

### DIFF
--- a/docs/src/pages/api/use-form.mdx
+++ b/docs/src/pages/api/use-form.mdx
@@ -171,6 +171,15 @@ interface FormMeta<TValues extends Record<string, any>> {
   initialValues?: TValues;
 }
 
+type InvalidSubmissionHandler<TValues extends GenericFormValues = GenericFormValues> = (
+  ctx: InvalidSubmissionContext<TValues>
+) => void;
+
+type HandleSubmitFactory<TValues extends GenericFormValues> = <TReturn = unknown>(
+  cb: SubmissionHandler<TValues, TReturn>,
+  onSubmitValidationErrorCb?: InvalidSubmissionHandler<TValues>
+) => (e?: Event) => Promise<TReturn | undefined>;
+
 type useForm = (opts?: FormOptions) => {
   values: TValues; // current form values
   submitCount: Ref<number>; // the number of submission attempts
@@ -190,10 +199,7 @@ type useForm = (opts?: FormOptions) => {
   validateField(field: keyof TValues): Promise<ValidationResult>;
   useFieldModel<TPath extends keyof TValues>(path: MaybeRef<TPath>): Ref<TValues[TPath]>;
   useFieldModel<TPath extends keyof TValues>(paths: [...MaybeRef<TPath>[]]): MapValues<typeof paths, TValues>;
-  handleSubmit<TReturn = unknown>(
-    cb: SubmissionHandler<TValues, TReturn>,
-    onSubmitValidationErrorCb?: InvalidSubmissionHandler<TValues>
-  ): (e?: Event) => Promise<TReturn | undefined>;
+  handleSubmit: HandleSubmitFactory<TValues> & { withControlled: HandleSubmitFactory<TValues> };
 };
 ```
 
@@ -535,6 +541,26 @@ const onSubmit = handleSubmit((values, actions) => {
   // reset the form
   actions.resetForm();
 });
+```
+
+`handleSubmit` contains a `withControlled` function that you can use to only submit fields controlled by `useField` or `useFieldModel`. Read the [guide](/guide/composition-api/handling-forms) for more information.
+
+```vue
+<template>
+  <form @submit="onSubmit"></form>
+</template>
+
+<script setup>
+import { useForm } from 'vee-validate';
+
+const { handleSubmit } = useForm();
+
+const onSubmit = handleSubmit.withControlled(values => {
+  // Send only controlled values to the API
+  // Only fields declared with `useField` or `useFieldModel` will be printed
+  alert(JSON.stringify(values, null, 2));
+});
+</script>
 ```
 
 <DocTip title="Virtual Forms">

--- a/docs/src/pages/guide/composition-api/handling-forms.mdx
+++ b/docs/src/pages/guide/composition-api/handling-forms.mdx
@@ -391,7 +391,7 @@ const { handleSubmit, setFieldError, setErrors } = useForm();
 
 const onSubmit = handleSubmit(async values => {
   // Send data to the API
-  const response = await client.post('/users/');
+  const response = await client.post('/users/', values);
 
   // all good
   if (!response.errors) {
@@ -415,7 +415,7 @@ Alternatively you can use the `FormActions` passed as the second argument to the
 ```js
 const onSubmit = handleSubmit(async (values, actions) => {
   // Send data to the API
-  const response = await client.post('/users/');
+  const response = await client.post('/users/', values);
   // ...
 
   // set single field error
@@ -427,4 +427,57 @@ const onSubmit = handleSubmit(async (values, actions) => {
   // and the values is the error message
   actions.setErrors(response.errors);
 });
+```
+
+## Controlled Values
+
+The form values can be categorized into two categories:
+
+- Controlled values: values that have a form input controlling them via `useField` or `<Field />` or via `useFieldModel` model binding.
+- Uncontrolled values: values that are inserted dynamically with `setFieldValue` or inserted initially with initial values.
+
+Sometimes you maybe only interested in controlled values. For example, your initial data contains noisy extra properties from your API and you wish to ignore them when submitting them back to your API.
+
+When accessing `values` from `useForm` result or the submission handler you get all the values, both controlled and uncontrolled values. To get access to only the controlled values you can use `controlledValues` from the `useForm` result:
+
+```vue
+<template>
+  <form @submit="onSubmit">
+    <!-- some fields -->
+  </form>
+</template>
+
+<script setup>
+import { useForm } from 'vee-validate';
+
+const { handleSubmit, controlledValues } = useForm();
+
+const onSubmit = handleSubmit(async () => {
+  // Send only controlled values to the API
+  // Only fields declared with `useField` or `useFieldModel` will be sent
+  const response = await client.post('/users/', controlledValues.value);
+});
+</script>
+```
+
+Alternatively you can create handlers with only the controlled values with `handleSubmit.controlled` which has the same API as `handleSubmit`:
+
+```vue
+<template>
+  <form @submit="onSubmit">
+    <!-- some fields -->
+  </form>
+</template>
+
+<script setup>
+import { useForm } from 'vee-validate';
+
+const { handleSubmit } = useForm();
+
+const onSubmit = handleSubmit.controlled(async values => {
+  // Send only controlled values to the API
+  // Only fields declared with `useField` or `useFieldModel` will be sent
+  const response = await client.post('/users/', values);
+});
+</script>
 ```

--- a/docs/src/pages/guide/composition-api/handling-forms.mdx
+++ b/docs/src/pages/guide/composition-api/handling-forms.mdx
@@ -460,7 +460,7 @@ const onSubmit = handleSubmit(async () => {
 </script>
 ```
 
-Alternatively you can create handlers with only the controlled values with `handleSubmit.controlled` which has the same API as `handleSubmit`:
+Alternatively for less verbosity, you can create handlers with only the controlled values with `handleSubmit.withControlled` which has the same API as `handleSubmit`:
 
 ```vue
 <template>
@@ -474,7 +474,7 @@ import { useForm } from 'vee-validate';
 
 const { handleSubmit } = useForm();
 
-const onSubmit = handleSubmit.controlled(async values => {
+const onSubmit = handleSubmit.withControlled(async values => {
   // Send only controlled values to the API
   // Only fields declared with `useField` or `useFieldModel` will be sent
   const response = await client.post('/users/', values);

--- a/packages/vee-validate/src/Form.ts
+++ b/packages/vee-validate/src/Form.ts
@@ -22,6 +22,7 @@ type FormSlotProps = UnwrapRef<
     | 'setFieldTouched'
     | 'setTouched'
     | 'resetForm'
+    | 'controlledValues'
   >
 > & {
   handleSubmit: (evt: Event | SubmissionHandler, onSubmit?: SubmissionHandler) => Promise<unknown>;
@@ -80,6 +81,7 @@ const FormImpl = defineComponent({
       meta,
       isSubmitting,
       submitCount,
+      controlledValues,
       validate,
       validateField,
       handleReset,
@@ -132,6 +134,7 @@ const FormImpl = defineComponent({
         values: values,
         isSubmitting: isSubmitting.value,
         submitCount: submitCount.value,
+        controlledValues: controlledValues.value,
         validate,
         validateField,
         handleSubmit: handleScopedSlotSubmit,

--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -178,6 +178,11 @@ export type MapValues<T, TValues extends Record<string, any>> = {
     : Ref<unknown>;
 };
 
+type HandleSubmitFactory<TValues extends GenericFormValues> = <TReturn = unknown>(
+  cb: SubmissionHandler<TValues, TReturn>,
+  onSubmitValidationErrorCb?: InvalidSubmissionHandler<TValues>
+) => (e?: Event) => Promise<TReturn | undefined>;
+
 export interface PrivateFormContext<TValues extends Record<string, any> = Record<string, any>>
   extends FormActions<TValues> {
   formId: number;
@@ -200,10 +205,7 @@ export interface PrivateFormContext<TValues extends Record<string, any> = Record
   unsetInitialValue(path: string): void;
   register(field: PrivateFieldContext): void;
   unregister(field: PrivateFieldContext): void;
-  handleSubmit<TReturn = unknown>(
-    cb: SubmissionHandler<TValues, TReturn>,
-    onSubmitValidationErrorCb?: InvalidSubmissionHandler<TValues>
-  ): (e?: Event) => Promise<TReturn | undefined>;
+  handleSubmit: HandleSubmitFactory<TValues> & { withControlled: HandleSubmitFactory<TValues> };
   setFieldInitialValue(path: string, value: unknown): void;
   useFieldModel<TPath extends keyof TValues>(path: MaybeRef<TPath>): Ref<TValues[TPath]>;
   useFieldModel<TPath extends keyof TValues>(paths: [...MaybeRef<TPath>[]]): MapValues<typeof paths, TValues>;

--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -145,6 +145,7 @@ export interface FormValidationResult<TValues> {
 
 export interface SubmissionContext<TValues extends GenericFormValues = GenericFormValues> extends FormActions<TValues> {
   evt?: Event;
+  controlledValues: Partial<TValues>;
 }
 
 export type SubmissionHandler<TValues extends GenericFormValues = GenericFormValues, TReturn = unknown> = (

--- a/packages/vee-validate/src/types.ts
+++ b/packages/vee-validate/src/types.ts
@@ -181,6 +181,7 @@ export interface PrivateFormContext<TValues extends Record<string, any> = Record
   extends FormActions<TValues> {
   formId: number;
   values: TValues;
+  controlledValues: Ref<TValues>;
   fieldsByPath: Ref<FieldPathLookup>;
   fieldArrays: PrivateFieldArrayContext[];
   submitCount: Ref<number>;

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -71,6 +71,8 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
 ): FormContext<TValues> {
   const formId = FORM_COUNTER++;
 
+  const controlledModelPaths: Set<string> = new Set();
+
   // Prevents fields from double resetting their values, which causes checkboxes to toggle their initial value
   // TODO: This won't be needed if we centralize all the state inside the `form` for form inputs
   let RESET_LOCK = false;
@@ -157,11 +159,9 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
   const meta = useFormMeta(fieldsByPath, formValues, originalInitialValues, errors);
 
   const controlledValues = computed(() => {
-    return keysOf(fieldsByPath.value).reduce((acc, path) => {
-      const field = getFirstFieldAtPath(path as string);
-      if (field) {
-        setInPath(acc, path as string, field?.value.value);
-      }
+    return [...controlledModelPaths, ...keysOf(fieldsByPath.value)].reduce((acc, path) => {
+      const value = getFromPath(formValues, path as string);
+      setInPath(acc, path as string, value);
 
       return acc;
     }, {} as TValues);
@@ -450,6 +450,8 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
         deep: true,
       }
     );
+
+    controlledModelPaths.add(unref(path) as string);
 
     return value;
   }

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -156,6 +156,17 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
   // form meta aggregations
   const meta = useFormMeta(fieldsByPath, formValues, originalInitialValues, errors);
 
+  const controlledValues = computed(() => {
+    return keysOf(fieldsByPath.value).reduce((acc, path) => {
+      const field = getFirstFieldAtPath(path as string);
+      if (field) {
+        setInPath(acc, path as string, field?.value.value);
+      }
+
+      return acc;
+    }, {} as TValues);
+  });
+
   const schema = opts?.validationSchema;
 
   /**
@@ -225,6 +236,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
     formId,
     fieldsByPath,
     values: formValues,
+    controlledValues,
     errorBag,
     errors,
     schema,

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -668,6 +668,7 @@ export function useForm<TValues extends Record<string, any> = Record<string, any
           if (result.valid && typeof fn === 'function') {
             return fn(deepCopy(formValues), {
               evt: e as Event,
+              controlledValues: deepCopy(controlledValues.value),
               setErrors,
               setFieldError,
               setTouched,

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -541,8 +541,45 @@ describe('useForm()', () => {
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        values: expect.objectContaining(initial),
-        controlled: expect.objectContaining({ field: initial.field }),
+        values: initial,
+        controlled: { field: initial.field },
+      })
+    );
+  });
+
+  // #3862
+  test('exposes controlled only via submission handler withControlled', async () => {
+    const spy = jest.fn();
+    const initial = {
+      field: '111',
+      createdAt: Date.now(),
+    };
+    mountWithHoc({
+      setup() {
+        const { handleSubmit } = useForm({
+          initialValues: initial,
+        });
+
+        const onSubmit = handleSubmit.withControlled(values => {
+          spy({ values });
+        });
+
+        useField('field');
+
+        onMounted(onSubmit);
+
+        return {};
+      },
+      template: `
+        <div></div>
+      `,
+    });
+
+    await flushPromises();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        values: { field: initial.field },
       })
     );
   });

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -583,4 +583,41 @@ describe('useForm()', () => {
       })
     );
   });
+
+  test('useFieldModel marks the field as controlled', async () => {
+    const spy = jest.fn();
+    const initial = {
+      field: '111',
+      field2: '222',
+      createdAt: Date.now(),
+    };
+    mountWithHoc({
+      setup() {
+        const { handleSubmit, useFieldModel } = useForm({
+          initialValues: initial,
+        });
+
+        const onSubmit = handleSubmit.withControlled(values => {
+          spy({ values });
+        });
+
+        const fields = useFieldModel(['field', 'field2']);
+
+        onMounted(onSubmit);
+
+        return {};
+      },
+      template: `
+        <div></div>
+      `,
+    });
+
+    await flushPromises();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        values: { field: initial.field, field2: initial.field2 },
+      })
+    );
+  });
 });


### PR DESCRIPTION
# What

There is a need where you are only interested in the "controlled" field values, which are fields that have corresponding `useField` calls. This is a "nice to have" since it improves the form ergonomics, especially for highly generic forms.

This PR introduces `controlledValues` computed property of the `useForm` return object, which can be used to only get the controlled values.

```ts
const { controlledValues, handleSubmit } = useForm({
  initialValues: {
      name: 'abc',
      createdAt: Date.now(),
    };,
});

// `name` is now controlled
useField('name');

const onSubmit = handleSubmit(values => {
  // won't have `createdAt` because it is not controlled
  console.log(controlledValues.value);
});
```

Ideally, I would like this exposed in various points in the `Form` component as a slot prop and also in submission handlers in the submission context. This way it won't affect the current API in any way.

closes #3862