### PR TITLE
fix: handle nested value change validation #3926

### DIFF
--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -219,16 +219,18 @@ function _useField<TValue = unknown>(
   }
 
   let unwatchValue: WatchStopHandle;
+  let lastWatchedValue = deepCopy(value.value);
   function watchValue() {
     unwatchValue = watch(
       value,
       (val, oldVal) => {
-        if (isEqual(val, oldVal)) {
+        if (isEqual(val, oldVal) && isEqual(val, lastWatchedValue)) {
           return;
         }
 
         const validateFn = validateOnValueUpdate ? validateWithStateMutation : validateValidStateOnly;
         validateFn();
+        lastWatchedValue = deepCopy(val);
       },
       {
         deep: true,

--- a/packages/vee-validate/tests/useField.spec.ts
+++ b/packages/vee-validate/tests/useField.spec.ts
@@ -29,6 +29,44 @@ describe('useField()', () => {
     expect(error?.textContent).toBe(REQUIRED_MESSAGE);
   });
 
+  // #3926
+  test('validates when nested value changes', async () => {
+    mountWithHoc({
+      setup() {
+        const { value, errorMessage } = useField<any>(
+          'field',
+          val => {
+            if (!val?.name) {
+              return REQUIRED_MESSAGE;
+            }
+
+            return true;
+          },
+          {
+            initialValue: { name: 'test' },
+          }
+        );
+
+        onMounted(() => {
+          value.value.name = '';
+        });
+
+        return {
+          value,
+          errorMessage,
+        };
+      },
+      template: `
+      <span>{{ errorMessage }}</span>
+    `,
+    });
+
+    const error = document.querySelector('span');
+
+    await flushPromises();
+    expect(error?.textContent).toBe(REQUIRED_MESSAGE);
+  });
+
   test('valid flag is correct after reset', async () => {
     mountWithHoc({
       setup() {


### PR DESCRIPTION
By saving a copy of the last value that was watched, we can detect when the `watch` was triggered due to a nested mutation.

Comparing the old value may seem redundant now, but didn't have time to check that.

closes #3926 