### PR TITLE
fix: ensure validation if we skip checkbox value setting #3927

### DIFF
--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -449,6 +449,9 @@ function useCheckboxField<TValue = unknown>(
 
     function handleCheckboxChange(e: unknown, shouldValidate = true) {
       if (checked.value === ((e as Event)?.target as HTMLInputElement)?.checked) {
+        if (shouldValidate) {
+          field.validate();
+        }
         return;
       }
 


### PR DESCRIPTION
# What

Fixes #3927 by triggering validation if it should before we skip the value setting aspect of checkboxes.

This issue was caused by the `input` event being triggered before `change` event as we try not to toggle the value twice. By mistake, we also avoided validating the value when the `change` event occurred.

This happens in default settings where `change` event triggers validation while the `input` event does not.