### PR TITLE
fix: extend is equal with file comparison logic #3911

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-standard": "^5.0.0",
-    "fast-deep-equal": "^3.1.3",
     "filesize": "^8.0.7",
     "flush-promises": "^1.0.2",
     "fs-extra": "^10.1.0",

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -13,10 +13,8 @@ import {
   ComponentInternalInstance,
 } from 'vue';
 import { klona as deepCopy } from 'klona/full';
-import isEqual from 'fast-deep-equal/es6';
 import { validate as validateValue } from './validate';
 import {
-  ValidationResult,
   MaybeRef,
   GenericValidateFunction,
   YupValidator,
@@ -37,6 +35,7 @@ import {
   isYupValidator,
   applyModelModifiers,
   withLatest,
+  isEqual,
 } from './utils';
 import { isCallable } from '../../shared';
 import { FieldContextKey, FormContextKey, IS_ABSENT } from './symbols';

--- a/packages/vee-validate/src/useFieldState.ts
+++ b/packages/vee-validate/src/useFieldState.ts
@@ -1,8 +1,7 @@
 import { computed, reactive, ref, Ref, unref, watch } from 'vue';
-import isEqual from 'fast-deep-equal/es6';
 import { FormContextKey } from './symbols';
 import { FieldMeta, FieldState, MaybeRef } from './types';
-import { getFromPath, injectWithSelf } from './utils';
+import { getFromPath, injectWithSelf, isEqual } from './utils';
 
 export interface StateSetterInit<TValue = unknown> extends FieldState<TValue> {
   initialValue: TValue;

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -13,7 +13,6 @@ import {
   markRaw,
   watchEffect,
 } from 'vue';
-import isEqual from 'fast-deep-equal/es6';
 import { klona as deepCopy } from 'klona/full';
 import {
   FieldMeta,
@@ -47,6 +46,7 @@ import {
   debounceAsync,
   isEmptyContainer,
   withLatest,
+  isEqual,
 } from './utils';
 import { FormContextKey } from './symbols';
 import { validateYupSchema, validateObjectSchema } from './validate';

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -50,7 +50,7 @@ function createConfig(pkg, format) {
         }),
         tsPlugin,
         resolve({
-          dedupe: ['fast-deep-equal/es6', 'fast-deep-equal', 'klona', 'klona/full'],
+          dedupe: ['klona', 'klona/full'],
         }),
         commonjs(),
       ],


### PR DESCRIPTION
# What

It Fixes file equality comparison which affects model updates, and dirty meta state. By extending `fast-deep-equal` and adding our custom file matching logic.