### PR TITLE
docs: update useField() signature to match implementation

### DIFF
--- a/docs/src/pages/api/use-field.mdx
+++ b/docs/src/pages/api/use-field.mdx
@@ -149,7 +149,7 @@ export interface ValidationOptions {
 
 function useField<TValue = unknown>(
   fieldName: MaybeRef<string>,
-  rules: RuleExpression,
+  rules?: MaybeRef<RuleExpression>,
   opts?: FieldOptions
 ): {
   name: MaybeRef<string>;  // The field name


### PR DESCRIPTION
Currently, `useField()` accepts an optional `MaybeRef<RuleExpression>`. This updates the docs to match.
