### PR TITLE
Added array 'move' helper function to the documentation

### DIFF
--- a/docs/src/pages/api/use-field-array.mdx
+++ b/docs/src/pages/api/use-field-array.mdx
@@ -202,3 +202,18 @@ const { replace, fields } = useFieldArray('links');
 // replace the entire array with these items
 replace([{ url: 'https://google.com' }, { url: 'https://vuejs.org' }]);
 ```
+
+<CodeTitle level="4">
+
+`move(oldIdx:number, newIdx: number)`
+
+</CodeTitle>
+
+Moves an array item to a different position within the array.
+
+```js
+const { move, fields } = useFieldArray('links');
+
+// move array item to a different position
+move(2, 1);
+```

--- a/docs/src/pages/guide/composition-api/nested-objects-and-arrays.mdx
+++ b/docs/src/pages/guide/composition-api/nested-objects-and-arrays.mdx
@@ -235,6 +235,7 @@ The `<useFieldArray />` function provides the following properties and functions
 - `swap(idxA: number, idxB: number)`: Swaps two array elements by their indexes.
 - `replace(items: any[])`: Replaces the entire array values with the given items.
 - `update(idx: number, value: any)`: Updates an array item value at the specified index.
+- `move(oldIdx: number, newIdx: number)`: Moves an array item to a different position within the array.
 
 [Read the API reference](/api/use-field-array) for more information.
 


### PR DESCRIPTION
🔎 __Overview__

This PR adds the 'move' function to the array documentation which is currently missing.