### PR TITLE
Fix broken links for available rules

### DIFF
--- a/docs/src/pages/guide/global-validators.mdx
+++ b/docs/src/pages/guide/global-validators.mdx
@@ -280,85 +280,85 @@ Object.keys(AllRules).forEach(rule => {
 
 <ul class="grid grid-cols-2 col-gap-4 lg:grid-cols-3 lg:col-gap-8 text-accent-800">
   <li>
-    <a href="/guide/global-validators#alpha">alpha</a>
+    <a href="/v4/guide/global-validators#alpha">alpha</a>
   </li>
   <li>
-    <a href="/guide/global-validators#alpha_dash">alpha_dash</a>
+    <a href="/v4/guide/global-validators#alpha_dash">alpha_dash</a>
   </li>
   <li>
-    <a href="/guide/global-validators#alpha_num">alpha_num</a>
+    <a href="/v4/guide/global-validators#alpha_num">alpha_num</a>
   </li>
   <li>
-    <a href="/guide/global-validators#alpha_spaces">alpha_spaces</a>
+    <a href="/v4/guide/global-validators#alpha_spaces">alpha_spaces</a>
   </li>
   <li>
-    <a href="/guide/global-validators#between">between</a>
+    <a href="/v4/guide/global-validators#between">between</a>
   </li>
   <li>
-    <a href="/guide/global-validators#confirmed">confirmed</a>
+    <a href="/v4/guide/global-validators#confirmed">confirmed</a>
   </li>
   <li>
-    <a href="/guide/global-validators#digits">digits</a>
+    <a href="/v4/guide/global-validators#digits">digits</a>
   </li>
   <li>
-    <a href="/guide/global-validators#dimensions">dimensions</a>
+    <a href="/v4/guide/global-validators#dimensions">dimensions</a>
   </li>
   <li>
-    <a href="/guide/global-validators#email">email</a>
+    <a href="/v4/guide/global-validators#email">email</a>
   </li>
   <li>
-    <a href="/guide/global-validators#excluded">excluded</a>
+    <a href="/v4/guide/global-validators#excluded">excluded</a>
   </li>
   <li>
-    <a href="/guide/global-validators#ext">ext</a>
+    <a href="/v4/guide/global-validators#ext">ext</a>
   </li>
   <li>
-    <a href="/guide/global-validators#image">image</a>
+    <a href="/v4/guide/global-validators#image">image</a>
   </li>
   <li>
-    <a href="/guide/global-validators#one_of">one_of</a>
+    <a href="/v4/guide/global-validators#one_of">one_of</a>
   </li>
   <li>
-    <a href="/guide/global-validators#integer">integer</a>
+    <a href="/v4/guide/global-validators#integer">integer</a>
   </li>
   <li>
-    <a href="/guide/global-validators#is">is</a>
+    <a href="/v4/guide/global-validators#is">is</a>
   </li>
   <li>
-    <a href="/guide/global-validators#is_not">is_not</a>
+    <a href="/v4/guide/global-validators#is_not">is_not</a>
   </li>
   <li>
-    <a href="/guide/global-validators#length">length</a>
+    <a href="/v4/guide/global-validators#length">length</a>
   </li>
   <li>
-    <a href="/guide/global-validators#max">max</a>
+    <a href="/v4/guide/global-validators#max">max</a>
   </li>
   <li>
-    <a href="/guide/global-validators#max_value">max_value</a>
+    <a href="/v4/guide/global-validators#max_value">max_value</a>
   </li>
   <li>
-    <a href="/guide/global-validators#mimes">mimes</a>
+    <a href="/v4/guide/global-validators#mimes">mimes</a>
   </li>
   <li>
-    <a href="/guide/global-validators#min">min</a>
+    <a href="/v4/guide/global-validators#min">min</a>
   </li>
   <li>
-    <a href="/guide/global-validators#min_value">min_value</a>
+    <a href="/v4/guide/global-validators#min_value">min_value</a>
   </li>
   <li>
-    <a href="/guide/global-validators#numeric">numeric</a>
+    <a href="/v4/guide/global-validators#numeric">numeric</a>
   </li>
   <li>
-    <a href="/guide/global-validators#regex">regex</a>
+    <a href="/v4/guide/global-validators#regex">regex</a>
   </li>
   <li>
-    <a href="/guide/global-validators#required">required</a>
+    <a href="/v4/guide/global-validators#required">required</a>
   </li>
   <li>
-    <a href="/guide/global-validators#size">size</a>
+    <a href="/v4/guide/global-validators#size">size</a>
   </li>
   <li>
-    <a href="/guide/global-validators#url">url</a>
+    <a href="/v4/guide/global-validators#url">url</a>
   </li>
 </ul>
 


### PR DESCRIPTION
A prefix `v4/` was missing in available rules links

🔎 __Overview__

This PR fixes the broken inline links in the available rules section of global validators.

<!-- Explain the why behind adding this PR, here is a couple of examples -->
<!--
  This PR {adds/fixes/improves} the {feature/bug/something}.
  This PR changes the {locale} messages style because {reason}
-->
 
