### PR TITLE
fix: correctly mutate deep field array item and trigger validation

### DIFF
--- a/packages/vee-validate/src/useFieldArray.ts
+++ b/packages/vee-validate/src/useFieldArray.ts
@@ -1,8 +1,8 @@
-import { Ref, unref, ref, computed, onBeforeUnmount } from 'vue';
+import { Ref, unref, ref, onBeforeUnmount } from 'vue';
 import { isNullOrUndefined } from '../../shared';
 import { FormContextKey } from './symbols';
 import { FieldArrayContext, FieldEntry, MaybeRef, PrivateFieldArrayContext } from './types';
-import { getFromPath, injectWithSelf, warn } from './utils';
+import { computedDeep, getFromPath, injectWithSelf, warn } from './utils';
 
 export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): FieldArrayContext<TValue> {
   const form = injectWithSelf(FormContextKey, undefined);
@@ -64,7 +64,7 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): Fi
 
     const entry: FieldEntry<TValue> = {
       key,
-      value: computed<TValue>({
+      value: computedDeep<TValue>({
         get() {
           const currentValues = getFromPath<TValue[]>(form?.values, unref(arrayPath), []) || [];
           const idx = fields.value.findIndex(e => e.key === key);
@@ -172,7 +172,9 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): Fi
     if (!Array.isArray(pathValue) || pathValue.length - 1 < idx) {
       return;
     }
+
     form?.setFieldValue(`${pathName}[${idx}]`, value);
+    form?.validate({ mode: 'validated-only' });
   }
 
   function prepend(value: TValue) {

--- a/packages/vee-validate/tests/useFieldArray.spec.ts
+++ b/packages/vee-validate/tests/useFieldArray.spec.ts
@@ -1,5 +1,6 @@
-import { useForm, useFieldArray } from '@/vee-validate';
-import { onMounted } from 'vue';
+import { useForm, useFieldArray, FieldEntry } from '@/vee-validate';
+import { onMounted, Ref } from 'vue';
+import * as yup from 'yup';
 import { mountWithHoc, flushPromises } from './helpers';
 
 test('can update a field entry model directly', async () => {
@@ -28,6 +29,49 @@ test('can update a field entry model directly', async () => {
 
   await flushPromises();
   expect(document.querySelector('p')?.innerHTML).toBe('test');
+});
+
+test('can update a field entry deep model directly and validate it', async () => {
+  let fields!: Ref<FieldEntry<{ name: string }>[]>;
+  mountWithHoc({
+    setup() {
+      const { errors } = useForm({
+        validateOnMount: true,
+        validationSchema: yup.object({
+          users: yup.array().of(
+            yup.object({
+              name: yup.string().required(),
+            })
+          ),
+        }),
+        initialValues: {
+          users: [{ name: '' }],
+        },
+      });
+
+      fields = useFieldArray<{ name: string }>('users').fields;
+
+      return {
+        fields,
+        errors,
+      };
+    },
+    template: `
+      <p>{{ fields[0].value.name }}</p>
+      <span>{{ errors }}</span>
+    `,
+  });
+
+  await flushPromises();
+  expect(document.querySelector('p')?.innerHTML).toBe('');
+  expect(document.querySelector('span')?.innerHTML).toBeTruthy();
+
+  const item = fields.value[0];
+  item.value.name = 'test';
+
+  await flushPromises();
+  expect(document.querySelector('p')?.innerHTML).toBe('test');
+  expect(document.querySelector('span')?.innerHTML).toBe('{}');
 });
 
 test('warns when updating a no-longer existing item', async () => {


### PR DESCRIPTION
# What

Since `computed` didn't offer deep setter triggers it made mutating a reference type field entry item mutable and didn't trigger validation.

This PR fixes that by introducing a proxy between the form and the field array item that can be deep-watched, so it can trigger validation while disallowing direct mutations over the computed property result.

closes #3968 