### PR TITLE
fix: ext rule regex has wildcard when it should be literal period

### DIFF
--- a/packages/rules/src/ext.ts
+++ b/packages/rules/src/ext.ts
@@ -9,7 +9,7 @@ const extValidator = (files: unknown, extensions: string[]) => {
     extensions = [];
   }
 
-  const regex = new RegExp(`.(${extensions.join('|')})$`, 'i');
+  const regex = new RegExp(`\\.(${extensions.join('|')})$`, 'i');
   if (Array.isArray(files)) {
     return files.every(file => regex.test((file as File).name));
   }

--- a/packages/rules/tests/ext.spec.ts
+++ b/packages/rules/tests/ext.spec.ts
@@ -10,4 +10,6 @@ test('validates files extensions', () => {
 
   expect(validate(validFiles, params)).toBe(true);
   expect(validate(helpers.file('file.pdf', 'application/pdf'), params)).toBe(false);
+  expect(validate(helpers.file('filetxt', 'text/plain'), params)).toBe(false);
+  expect(validate(helpers.file('file.jpgg', 'image/jpeg'), params)).toBe(false);
 });


### PR DESCRIPTION
🔎 __Overview__

This PR fixes a bug with the ext rule

With the current regex:
```js
// using extensions = ['txt', 'jpg', 'svg']
new RegExp(`.(${extensions.join('|')})$`, 'i');
```
This passes validation on filenames like,
```
filename.etxt
filenamejpg
```

This PR also adds some additional invalid cases to the ext tests.

I discovered this when someone was able to submit a form with a `.epub` which was not in our accept list, however `.pub` was.