### PR TITLE
fix: typo in useFieldArray argument

### DIFF
--- a/docs/src/pages/api/use-field-array.mdx
+++ b/docs/src/pages/api/use-field-array.mdx
@@ -100,7 +100,7 @@ interface FieldEntry<TValue = unknown> {
 
 ```js
 // call composable in component setup to get readable version of links array
-const { fields } = useFieldArray('links);
+const { fields } = useFieldArray('links');
 ```
 
 <CodeTitle level="4">


### PR DESCRIPTION
🔎 __Overview__

fix typo in useFieldArray argument

https://vee-validate.logaretm.com/v4/api/use-field-array#composable-api
