### PR TITLE
fix(docs): typo in use-form.mdx

### DIFF
--- a/docs/src/pages/api/use-form.mdx
+++ b/docs/src/pages/api/use-form.mdx
@@ -299,7 +299,7 @@ Here is an example of its shape:
 }
 ```
 
-Any fields without error messages will not be included in the object. So you can safety iterate over it with `Object.keys()` knowing all the included fields are invalid.
+Any fields without error messages will not be included in the object. So you can safely iterate over it with `Object.keys()` knowing all the included fields are invalid.
 
 <CodeTitle level="4">
 


### PR DESCRIPTION
changed `safety` to `safely`.
