### PR TITLE
docs: use the latest zod

### DIFF
--- a/docs/src/pages/integrations/zod-schema-validation.mdx
+++ b/docs/src/pages/integrations/zod-schema-validation.mdx
@@ -28,11 +28,11 @@ With `@vee-validate/zod` you can use `Zod` typed schemas as drop-in replacements
 To use this plugin, make sure to install these packages `vee-validate`, `zod`, and `@vee-validate/zod`.
 
 ```sh
-yarn add vee-validate zod@beta @vee-validate/zod
+yarn add vee-validate zod @vee-validate/zod
 
 # or with NPM
 
-npm install vee-validate zod@beta @vee-validate/zod
+npm install vee-validate zod @vee-validate/zod
 ```
 
 ## Validating with Zod


### PR DESCRIPTION
The latest version of `zod` is `3.20.6`, but the `zod@beta` is [3.20.4-beta.0](https://www.npmjs.com/package/zod/v/3.20.4-beta.0), so we should remove the `beta` flag.