### PR TITLE
feat: export type `FieldState`

### DIFF
--- a/packages/vee-validate/src/index.ts
+++ b/packages/vee-validate/src/index.ts
@@ -14,6 +14,7 @@ export {
   FormState,
   FormValidationResult,
   FormContext,
+  FieldState,
   FieldContext,
   FieldEntry,
   FieldArrayContext,


### PR DESCRIPTION
When I want to expose the remaining FieldContext methods, The ts error appears `Default export of the module has or is using private name 'FieldState'.ts(4082)`

<img width="829" alt="image" src="https://user-images.githubusercontent.com/29533304/220820708-06dfc27a-d9b7-43f9-a04e-b24d74e173fd.png">