### PR TITLE
feat: support consideration for surrogate pairs

### DIFF
--- a/packages/rules/src/max.ts
+++ b/packages/rules/src/max.ts
@@ -10,11 +10,6 @@ const maxLengthValidator = (value: unknown, params: [string | number] | { length
     return value.every(val => maxLengthValidator(val, { length }));
   }
 
-  /**
-   * 𩸽
-   * But String(value).length => 2
-   * Success [...String(value)].length => 1
-   */
   return [...String(value)].length <= Number(length);
 };
 

--- a/packages/rules/src/max.ts
+++ b/packages/rules/src/max.ts
@@ -10,7 +10,12 @@ const maxLengthValidator = (value: unknown, params: [string | number] | { length
     return value.every(val => maxLengthValidator(val, { length }));
   }
 
-  return String(value).length <= Number(length);
+  /**
+   * 𩸽
+   * But String(value).length => 2
+   * Success [...String(value)].length => 1
+   */
+  return [...String(value)].length <= Number(length);
 };
 
 export default maxLengthValidator;

--- a/packages/rules/src/min.ts
+++ b/packages/rules/src/min.ts
@@ -10,7 +10,7 @@ const minValidator = (value: unknown, params: [string | number] | { length: stri
     return value.every(val => minValidator(val, { length }));
   }
 
-  return String(value).length >= Number(length);
+  return [...String(value)].length >= Number(length);
 };
 
 export default minValidator;

--- a/packages/rules/tests/max.spec.ts
+++ b/packages/rules/tests/max.spec.ts
@@ -11,10 +11,12 @@ test('validates maximum number of characters in a string', () => {
   expect(validate(null, params)).toBe(true);
   expect(validate('', params)).toBe(true);
   expect(validate([1, 2], params)).toBe(true);
+  expect(validate('𩸽寿司', params)).toBe(true);
 
   // invalid
   expect(validate('abcde', params)).toBe(false);
   expect(validate('null', params)).toBe(false);
   expect(validate('undefined', params)).toBe(false);
   expect(validate(['1234'], params)).toBe(false);
+  expect(validate('𩸽寿司の', params)).toBe(false);
 });

--- a/packages/rules/tests/min.spec.ts
+++ b/packages/rules/tests/min.spec.ts
@@ -13,9 +13,11 @@ test('validates minimum number of characters in a string', () => {
   expect(validate(null, params)).toBe(true);
   expect(validate('', params)).toBe(true);
   expect(validate([], params)).toBe(true);
+  expect(validate('𩸽寿司', params)).toBe(true);
 
   // invalid
   expect(validate(1, params)).toBe(false);
   expect(validate(12, params)).toBe(false);
   expect(validate([1], params)).toBe(false);
+  expect(validate('𩸽', params)).toBe(false);
 });


### PR DESCRIPTION
🔎 __Overview__

<!-- Explain the why behind adding this PR, here is a couple of examples -->
<!--
  This PR {adds/fixes/improves} the {feature/bug/something}.
  This PR changes the {locale} messages style because {reason}
-->

🤓 __Code snippets/examples (if applicable)__

 It appears that the current implementation of the String.length method may not accurately reflect the number of characters in a string containing surrogate pairs.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length

Specifically, this is the case
https://codepen.io/nao62165/pen/OJBgwjB?editors=1111

With this change, users of surrogate pairs will also receive the expected results.

We hope you will consider this!

The method of using [Intl.Segmenter](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/Segmenter) is also mentioned. Segmenter](), but it is not available in FireFox at this time. Spread syntax has been adopted so that more users can use it.

```js
// some code
[...String(value)].length <= Number(length);
```

✔ __Issues affected__

<!-- list of issues formatted like this
closes #{issue id}
 -->
 
