### PR TITLE
refactor: Switch to path-based state tracking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ jobs:
           paths:
             - node_modules
       - run:
+          name: Type check
+          command: pnpm typecheck
+      - run:
           name: Build
           command: pnpm build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,11 @@ jobs:
           paths:
             - node_modules
       - run:
-          name: Type check
-          command: pnpm typecheck
-      - run:
           name: Build
           command: pnpm build
+      - run:
+          name: Type check
+          command: pnpm typecheck
       - run:
           name: Generate Coverage
           command: pnpm cover

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "format": "prettier \"./**/*.ts\" --write",
     "build": "node scripts/build.mjs",
     "cover": "vitest run --coverage",
-    "postversion": "npm run build",
-    "docs:dev": "cd ./docs && npm run dev && cd -",
+    "postversion": "pnpm run build",
+    "typecheck": "pnpm run tsc --noEmit --project ./tsconfig.json --skipLibCheck",
+    "docs:dev": "cd ./docs && pnpm run dev && cd -",
     "postinstall": "husky install",
     "release": "./scripts/release.sh"
   },

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "format": "prettier \"./**/*.ts\" --write",
     "build": "node scripts/build.mjs",
     "cover": "vitest run --coverage",
-    "postversion": "pnpm run build",
-    "typecheck": "pnpm run tsc --noEmit --project ./tsconfig.json --skipLibCheck",
-    "docs:dev": "cd ./docs && pnpm run dev && cd -",
+    "postversion": "pnpm build",
+    "typecheck": "pnpm tsc --noEmit --project ./tsconfig.json --skipLibCheck",
+    "docs:dev": "cd ./docs && pnpm dev && cd -",
     "postinstall": "husky install",
     "release": "./scripts/release.sh"
   },

--- a/packages/vee-validate/src/Field.ts
+++ b/packages/vee-validate/src/Field.ts
@@ -3,7 +3,7 @@ import { getConfig } from './config';
 import { RuleExpression, useField } from './useField';
 import { normalizeChildren, hasCheckedAttr, shouldHaveValueBinding, isPropPresent, normalizeEventValue } from './utils';
 import { IS_ABSENT } from './symbols';
-import { FieldMeta } from './types';
+import { FieldMeta, InputType } from './types';
 import { FieldContext } from '.';
 
 interface ValidationTriggersProps {
@@ -132,7 +132,7 @@ const FieldImpl = defineComponent({
       validateOnMount: props.validateOnMount,
       bails: props.bails,
       standalone: props.standalone,
-      type: ctx.attrs.type as string,
+      type: ctx.attrs.type as InputType,
       initialValue: resolveInitialValue(props, ctx),
       // Only for checkboxes and radio buttons
       checkedValue: ctx.attrs.value,

--- a/packages/vee-validate/src/devtools.ts
+++ b/packages/vee-validate/src/devtools.ts
@@ -313,7 +313,7 @@ function getFieldNodeTags(
   const { textColor, bgColor } = getValidityColors(valid);
 
   return [
-    !multiple && fieldsCount === 1
+    multiple
       ? undefined
       : {
           label: 'Field',

--- a/packages/vee-validate/src/devtools.ts
+++ b/packages/vee-validate/src/devtools.ts
@@ -7,8 +7,8 @@ import {
   CustomInspectorState,
   InspectorNodeTag,
 } from '@vue/devtools-api';
-import { PrivateFieldContext, PrivateFormContext } from './types';
-import { keysOf, normalizeField, setInPath, throttle } from './utils';
+import { PathState, PrivateFieldContext, PrivateFormContext } from './types';
+import { keysOf, setInPath, throttle } from './utils';
 import { isObject } from '../../shared';
 
 function installDevtoolsPlugin(app: App) {
@@ -96,8 +96,11 @@ const COLORS = {
   gray: 0xbbbfca,
 };
 
-let SELECTED_NODE: ((PrivateFormContext | PrivateFieldContext) & { _vm?: ComponentInternalInstance | null }) | null =
-  null;
+let SELECTED_NODE:
+  | { type: 'pathState'; form: PrivateFormContext; state: PathState }
+  | { type: 'form'; form: PrivateFormContext & { _vm?: ComponentInternalInstance | null } }
+  | { type: 'field'; field: PrivateFieldContext & { _vm?: ComponentInternalInstance | null } }
+  | null = null;
 
 function setupApiHooks(api: DevtoolsPluginApi<Record<string, any>>) {
   API = api;
@@ -133,7 +136,19 @@ function setupApiHooks(api: DevtoolsPluginApi<Record<string, any>>) {
             return;
           }
 
-          await SELECTED_NODE.validate();
+          if (SELECTED_NODE.type === 'field') {
+            await SELECTED_NODE.field.validate();
+            return;
+          }
+
+          if (SELECTED_NODE.type === 'form') {
+            await SELECTED_NODE.form.validate();
+            return;
+          }
+
+          if (SELECTED_NODE.type === 'pathState') {
+            await SELECTED_NODE.form.validateField(SELECTED_NODE.state.path);
+          }
         },
       },
       {
@@ -145,12 +160,18 @@ function setupApiHooks(api: DevtoolsPluginApi<Record<string, any>>) {
             return;
           }
 
-          if ('id' in SELECTED_NODE) {
-            SELECTED_NODE.resetField();
+          if (SELECTED_NODE.type === 'field') {
+            SELECTED_NODE.field.resetField();
             return;
           }
 
-          SELECTED_NODE.resetForm();
+          if (SELECTED_NODE.type === 'form') {
+            SELECTED_NODE.form.resetForm();
+          }
+
+          if (SELECTED_NODE.type === 'pathState') {
+            SELECTED_NODE.form.resetField(SELECTED_NODE.state.path);
+          }
         },
       },
     ],
@@ -175,18 +196,32 @@ function setupApiHooks(api: DevtoolsPluginApi<Record<string, any>>) {
       return;
     }
 
-    const { form, field, type } = decodeNodeId(payload.nodeId);
+    const { form, field, state, type } = decodeNodeId(payload.nodeId);
 
     if (form && type === 'form') {
       payload.state = buildFormState(form);
-      SELECTED_NODE = form;
+      SELECTED_NODE = { type: 'form', form };
+      highlightSelected();
+      return;
+    }
+
+    if (state && type === 'pathState' && form) {
+      payload.state = buildFieldState(state);
+      SELECTED_NODE = { type: 'pathState', state, form };
       highlightSelected();
       return;
     }
 
     if (field && type === 'field') {
-      payload.state = buildFieldState(field);
-      SELECTED_NODE = field;
+      payload.state = buildFieldState({
+        errors: field.errors.value,
+        dirty: field.meta.dirty,
+        valid: field.meta.valid,
+        touched: field.meta.touched,
+        value: field.value.value,
+        initialValue: field.meta.initialValue,
+      });
+      SELECTED_NODE = { field, type: 'field' };
       highlightSelected();
       return;
     }
@@ -196,16 +231,11 @@ function setupApiHooks(api: DevtoolsPluginApi<Record<string, any>>) {
 }
 
 function mapFormForDevtoolsInspector(form: PrivateFormContext): CustomInspectorNode {
-  const { textColor, bgColor } = getTagTheme(form);
+  const { textColor, bgColor } = getValidityColors(form.meta.value.valid);
 
   const formTreeNodes = {};
-  Object.values(form.fieldsByPath.value).forEach(field => {
-    const fieldInstance: PrivateFieldContext | undefined = Array.isArray(field) ? field[0] : field;
-    if (!fieldInstance) {
-      return;
-    }
-
-    setInPath(formTreeNodes, unref(fieldInstance.name), mapFieldForDevtoolsInspector(fieldInstance, form));
+  Object.values(form.getAllPathStates()).forEach(state => {
+    setInPath(formTreeNodes, unref(state.path), mapPathForDevtoolsInspector(state, form));
   });
 
   function buildFormTree(tree: any[] | Record<string, any>, path: string[] = []): CustomInspectorNode {
@@ -249,7 +279,7 @@ function mapFormForDevtoolsInspector(form: PrivateFormContext): CustomInspectorN
         backgroundColor: bgColor,
       },
       {
-        label: `${Object.keys(form.fieldsByPath.value).length} fields`,
+        label: `${form.getAllPathStates().length} fields`,
         textColor: COLORS.white,
         backgroundColor: COLORS.unknown,
       },
@@ -257,67 +287,74 @@ function mapFormForDevtoolsInspector(form: PrivateFormContext): CustomInspectorN
   };
 }
 
-function mapFieldForDevtoolsInspector(
-  field: PrivateFieldContext | PrivateFieldContext[],
-  form?: PrivateFormContext
-): CustomInspectorNode {
-  const fieldInstance = normalizeField(field) as PrivateFieldContext;
-  const { textColor, bgColor } = getTagTheme(fieldInstance);
-  const isGroup = Array.isArray(field) && field.length > 1;
-
+function mapPathForDevtoolsInspector(state: PathState, form?: PrivateFormContext): CustomInspectorNode {
   return {
-    id: encodeNodeId(form, fieldInstance, !isGroup),
-    label: unref(fieldInstance.name),
-    children: Array.isArray(field) ? field.map(fieldItem => mapFieldForDevtoolsInspector(fieldItem, form)) : undefined,
-    tags: [
-      isGroup
-        ? undefined
-        : {
-            label: 'Field',
-            textColor,
-            backgroundColor: bgColor,
-          },
-      !form
-        ? {
-            label: 'Standalone',
-            textColor: COLORS.black,
-            backgroundColor: COLORS.gray,
-          }
-        : undefined,
-      !isGroup && fieldInstance.type === 'checkbox'
-        ? {
-            label: 'Checkbox',
-            textColor: COLORS.white,
-            backgroundColor: COLORS.blue,
-          }
-        : undefined,
-      !isGroup && fieldInstance.type === 'radio'
-        ? {
-            label: 'Radio',
-            textColor: COLORS.white,
-            backgroundColor: COLORS.purple,
-          }
-        : undefined,
-      isGroup
-        ? {
-            label: 'Group',
-            textColor: COLORS.black,
-            backgroundColor: COLORS.orange,
-          }
-        : undefined,
-    ].filter(Boolean) as InspectorNodeTag[],
+    id: encodeNodeId(form, state),
+    label: unref(state.path),
+    tags: getFieldNodeTags(state.multiple, state.fieldsCount, state.type, state.valid, form),
   };
 }
 
-function encodeNodeId(form?: PrivateFormContext, field?: PrivateFieldContext, encodeIndex = true): string {
-  const fieldPath = form ? unref(field?.name) : field?.id;
-  const fieldGroup = fieldPath ? form?.fieldsByPath.value[fieldPath] : undefined;
-  let idx: number | undefined;
-  if (encodeIndex && field && Array.isArray(fieldGroup)) {
-    idx = fieldGroup.indexOf(field);
-  }
+function mapFieldForDevtoolsInspector(field: PrivateFieldContext, form?: PrivateFormContext): CustomInspectorNode {
+  return {
+    id: encodeNodeId(form, field),
+    label: unref(field.name),
+    tags: getFieldNodeTags(false, 1, field.type, field.meta.valid, form),
+  };
+}
 
-  const idObject = { f: form?.formId, ff: fieldPath, idx, type: field ? 'field' : 'form' };
+function getFieldNodeTags(
+  multiple: boolean,
+  fieldsCount: number,
+  type: string | undefined,
+  valid: boolean,
+  form: PrivateFormContext | undefined
+) {
+  const { textColor, bgColor } = getValidityColors(valid);
+
+  return [
+    !multiple && fieldsCount === 1
+      ? undefined
+      : {
+          label: 'Field',
+          textColor,
+          backgroundColor: bgColor,
+        },
+    !form
+      ? {
+          label: 'Standalone',
+          textColor: COLORS.black,
+          backgroundColor: COLORS.gray,
+        }
+      : undefined,
+    type === 'checkbox'
+      ? {
+          label: 'Checkbox',
+          textColor: COLORS.white,
+          backgroundColor: COLORS.blue,
+        }
+      : undefined,
+    type === 'radio'
+      ? {
+          label: 'Radio',
+          textColor: COLORS.white,
+          backgroundColor: COLORS.purple,
+        }
+      : undefined,
+    multiple
+      ? {
+          label: 'Multiple',
+          textColor: COLORS.black,
+          backgroundColor: COLORS.orange,
+        }
+      : undefined,
+  ].filter(Boolean) as InspectorNodeTag[];
+}
+
+function encodeNodeId(form?: PrivateFormContext, stateOrField?: PathState | PrivateFieldContext): string {
+  const type = stateOrField ? ('path' in stateOrField ? 'field' : 'pathState') : 'form';
+  const fieldPath = stateOrField ? ('path' in stateOrField ? stateOrField?.path : unref(stateOrField?.name)) : '';
+  const idObject = { f: form?.formId, ff: fieldPath, type };
 
   return btoa(JSON.stringify(idObject));
 }
@@ -325,7 +362,8 @@ function encodeNodeId(form?: PrivateFormContext, field?: PrivateFieldContext, en
 function decodeNodeId(nodeId: string): {
   field?: PrivateFieldContext & { _vm?: ComponentInternalInstance | null };
   form?: PrivateFormContext & { _vm?: ComponentInternalInstance | null };
-  type?: 'form' | 'field';
+  state?: PathState;
+  type?: 'form' | 'field' | 'pathState';
 } {
   try {
     const idObject = JSON.parse(atob(nodeId));
@@ -347,12 +385,12 @@ function decodeNodeId(nodeId: string): {
       return {};
     }
 
-    const fieldGroup = form.fieldsByPath.value[idObject.ff];
+    const state = form.getPathState(idObject.ff);
 
     return {
       type: idObject.type,
       form,
-      field: Array.isArray(fieldGroup) ? fieldGroup[idObject.idx || 0] : fieldGroup,
+      state,
     };
   } catch (err) {
     // console.error(`Devtools: [vee-validate] Failed to parse node id ${nodeId}`);
@@ -361,31 +399,31 @@ function decodeNodeId(nodeId: string): {
   return {};
 }
 
-function buildFieldState(field: PrivateFieldContext): CustomInspectorState {
-  const { errors, meta, value } = field;
-
+function buildFieldState(
+  state: Pick<PathState, 'errors' | 'initialValue' | 'touched' | 'dirty' | 'value' | 'valid'>
+): CustomInspectorState {
   return {
     'Field state': [
-      { key: 'errors', value: errors.value },
+      { key: 'errors', value: state.errors },
       {
         key: 'initialValue',
-        value: meta.initialValue,
+        value: state.initialValue,
       },
       {
         key: 'currentValue',
-        value: value.value,
+        value: state.value,
       },
       {
         key: 'touched',
-        value: meta.touched,
+        value: state.touched,
       },
       {
         key: 'dirty',
-        value: meta.dirty,
+        value: state.dirty,
       },
       {
         key: 'valid',
-        value: meta.valid,
+        value: state.valid,
       },
     ],
   };
@@ -442,16 +480,9 @@ function buildFormState(form: PrivateFormContext): CustomInspectorState {
 /**
  * Resolves the tag color based on the form state
  */
-function getTagTheme(fieldOrForm: PrivateFormContext | PrivateFieldContext) {
-  // const fallbackColors = {
-  //   bgColor: COLORS.unknown,
-  //   textColor: COLORS.white,
-  // };
-
-  const isValid = 'id' in fieldOrForm ? fieldOrForm.meta.valid : fieldOrForm.meta.value.valid;
-
+function getValidityColors(valid: boolean) {
   return {
-    bgColor: isValid ? COLORS.success : COLORS.error,
-    textColor: isValid ? COLORS.black : COLORS.white,
+    bgColor: valid ? COLORS.success : COLORS.error,
+    textColor: valid ? COLORS.black : COLORS.white,
   };
 }

--- a/packages/vee-validate/src/devtools.ts
+++ b/packages/vee-validate/src/devtools.ts
@@ -352,7 +352,7 @@ function getFieldNodeTags(
 }
 
 function encodeNodeId(form?: PrivateFormContext, stateOrField?: PathState | PrivateFieldContext): string {
-  const type = stateOrField ? ('path' in stateOrField ? 'field' : 'pathState') : 'form';
+  const type = stateOrField ? ('path' in stateOrField ? 'pathState' : 'field') : 'form';
   const fieldPath = stateOrField ? ('path' in stateOrField ? stateOrField?.path : unref(stateOrField?.name)) : '';
   const idObject = { f: form?.formId, ff: fieldPath, type };
 

--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -50,23 +50,7 @@ export interface FieldState<TValue = unknown> {
   errors: string[];
 }
 
-export interface PathStateConfig {
-  bails: boolean;
-  label: MaybeRef<string>;
-}
-
-export interface PathState<TValue = unknown> {
-  path: string;
-  touched: boolean;
-  dirty: boolean;
-  valid: boolean;
-  validated: boolean;
-  pending: boolean;
-  initialValue: TValue | undefined;
-  errors: string[];
-  bails: boolean;
-  label: string | undefined;
-}
+export type InputType = 'checkbox' | 'radio' | 'default';
 
 /**
  * validated-only: only mutate the previously validated fields
@@ -77,6 +61,34 @@ export type SchemaValidationMode = 'validated-only' | 'silent' | 'force';
 
 export interface ValidationOptions {
   mode: SchemaValidationMode;
+}
+
+export type FieldValidator = (opts?: Partial<ValidationOptions>) => Promise<ValidationResult>;
+
+export interface PathStateConfig {
+  bails: boolean;
+  label: MaybeRef<string | undefined>;
+  type: InputType;
+  validator: FieldValidator;
+}
+
+export interface PathState<TValue = unknown> {
+  id: number | number[];
+  path: string;
+  touched: boolean;
+  dirty: boolean;
+  valid: boolean;
+  validated: boolean;
+  pending: boolean;
+  initialValue: TValue | undefined;
+  value: TValue | undefined;
+  errors: string[];
+  bails: boolean;
+  label: string | undefined;
+  type: InputType;
+  multiple: boolean;
+  fieldsCount: number;
+  validator?: FieldValidator;
 }
 
 export interface FieldEntry<TValue = unknown> {
@@ -119,7 +131,7 @@ export interface PrivateFieldContext<TValue = unknown> {
   checked?: Ref<boolean>;
   resetField(state?: Partial<FieldState<TValue>>): void;
   handleReset(): void;
-  validate(opts?: Partial<ValidationOptions>): Promise<ValidationResult>;
+  validate: FieldValidator;
   handleChange(e: Event | unknown, shouldValidate?: boolean): void;
   handleBlur(e?: Event): void;
   setState(state: Partial<FieldState<TValue>>): void;
@@ -214,6 +226,7 @@ export interface PrivateFormContext<TValues extends GenericObject = GenericObjec
   errors: ComputedRef<FormErrors<TValues>>;
   meta: ComputedRef<FormMeta<TValues>>;
   isSubmitting: Ref<boolean>;
+  isResetting: Ref<boolean>;
   keepValuesOnUnmount: MaybeRef<boolean>;
   validateSchema?: (mode: SchemaValidationMode) => Promise<FormValidationResult<TValues, TOutput>>;
   validate(opts?: Partial<ValidationOptions>): Promise<FormValidationResult<TValues, TOutput>>;
@@ -221,8 +234,6 @@ export interface PrivateFormContext<TValues extends GenericObject = GenericObjec
   setFieldErrorBag(field: Path<TValues>, messages: string | string[]): void;
   stageInitialValue(path: string, value: unknown, updateOriginal?: boolean): void;
   unsetInitialValue(path: string): void;
-  register(field: PrivateFieldContext): void;
-  unregister(field: PrivateFieldContext): void;
   handleSubmit: HandleSubmitFactory<TValues, TOutput> & { withControlled: HandleSubmitFactory<TValues, TOutput> };
   setFieldInitialValue(path: string, value: unknown): void;
   useFieldModel<TPath extends Path<TValues>>(path: TPath): Ref<PathValue<TValues, TPath>>;
@@ -233,17 +244,21 @@ export interface PrivateFormContext<TValues extends GenericObject = GenericObjec
     path: MaybeRef<TPath>,
     config?: Partial<PathStateConfig>
   ): PathState<PathValue<TValues, TPath>>;
-  getPathState<TPath extends Path<TValues>>(path: TPath): PathState<PathValue<TValues, TPath>>;
+  getPathState<TPath extends Path<TValues>>(path: TPath): PathState<PathValue<TValues, TPath>> | undefined;
+  getAllPathStates(): PathState[];
+  removePathState<TPath extends Path<TValues>>(path: TPath): void;
+  unsetPathValue<TPath extends Path<TValues>>(path: TPath): void;
 }
 
 export interface FormContext<TValues extends Record<string, any> = Record<string, any>, TOutput = TValues>
   extends Omit<
     PrivateFormContext<TValues, TOutput>,
     | 'formId'
-    | 'register'
-    | 'unregister'
-    | 'fieldsByPath'
     | 'schema'
+    | 'getPathState'
+    | 'getAllPathStates'
+    | 'removePathState'
+    | 'unsetPathValue'
     | 'validateSchema'
     | 'setFieldErrorBag'
     | 'stageInitialValue'

--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -50,6 +50,24 @@ export interface FieldState<TValue = unknown> {
   errors: string[];
 }
 
+export interface PathStateConfig {
+  bails: boolean;
+  label: MaybeRef<string>;
+}
+
+export interface PathState<TValue = unknown> {
+  path: string;
+  touched: boolean;
+  dirty: boolean;
+  valid: boolean;
+  validated: boolean;
+  pending: boolean;
+  initialValue: TValue | undefined;
+  errors: string[];
+  bails: boolean;
+  label: string | undefined;
+}
+
 /**
  * validated-only: only mutate the previously validated fields
  * silent: do not mutate any field
@@ -189,7 +207,6 @@ export interface PrivateFormContext<TValues extends GenericObject = GenericObjec
   formId: number;
   values: TValues;
   controlledValues: Ref<TValues>;
-  fieldsByPath: Ref<FieldPathLookup>;
   fieldArrays: PrivateFieldArrayContext[];
   submitCount: Ref<number>;
   schema?: MaybeRef<RawFormSchema<TValues> | TypedSchema<TValues, TOutput> | YupSchema<TValues> | undefined>;
@@ -201,7 +218,7 @@ export interface PrivateFormContext<TValues extends GenericObject = GenericObjec
   validateSchema?: (mode: SchemaValidationMode) => Promise<FormValidationResult<TValues, TOutput>>;
   validate(opts?: Partial<ValidationOptions>): Promise<FormValidationResult<TValues, TOutput>>;
   validateField(field: Path<TValues>): Promise<ValidationResult>;
-  setFieldErrorBag(field: string, messages: string | string[]): void;
+  setFieldErrorBag(field: Path<TValues>, messages: string | string[]): void;
   stageInitialValue(path: string, value: unknown, updateOriginal?: boolean): void;
   unsetInitialValue(path: string): void;
   register(field: PrivateFieldContext): void;
@@ -212,6 +229,10 @@ export interface PrivateFormContext<TValues extends GenericObject = GenericObjec
   useFieldModel<TPaths extends readonly [...MaybeRef<Path<TValues>>[]]>(
     paths: TPaths
   ): MapValuesPathsToRefs<TValues, TPaths>;
+  createPathState<TPath extends Path<TValues>>(
+    path: MaybeRef<TPath>,
+    config?: Partial<PathStateConfig>
+  ): PathState<PathValue<TValues, TPath>>;
 }
 
 export interface FormContext<TValues extends Record<string, any> = Record<string, any>, TOutput = TValues>

--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -233,6 +233,7 @@ export interface PrivateFormContext<TValues extends GenericObject = GenericObjec
     path: MaybeRef<TPath>,
     config?: Partial<PathStateConfig>
   ): PathState<PathValue<TValues, TPath>>;
+  getPathState<TPath extends Path<TValues>>(path: TPath): PathState<PathValue<TValues, TPath>>;
 }
 
 export interface FormContext<TValues extends Record<string, any> = Record<string, any>, TOutput = TValues>

--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -69,7 +69,7 @@ export interface PathStateConfig {
   bails: boolean;
   label: MaybeRef<string | undefined>;
   type: InputType;
-  validator: FieldValidator;
+  validate: FieldValidator;
 }
 
 export interface PathState<TValue = unknown> {
@@ -88,7 +88,7 @@ export interface PathState<TValue = unknown> {
   type: InputType;
   multiple: boolean;
   fieldsCount: number;
-  validator?: FieldValidator;
+  validate?: FieldValidator;
 }
 
 export interface FieldEntry<TValue = unknown> {

--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -218,6 +218,7 @@ export interface PrivateFormContext<TValues extends GenericObject = GenericObjec
   extends FormActions<TValues> {
   formId: number;
   values: TValues;
+  initialValues: Ref<Partial<TValues>>;
   controlledValues: Ref<TValues>;
   fieldArrays: PrivateFieldArrayContext[];
   submitCount: Ref<number>;
@@ -255,6 +256,7 @@ export interface FormContext<TValues extends Record<string, any> = Record<string
     PrivateFormContext<TValues, TOutput>,
     | 'formId'
     | 'schema'
+    | 'initialValues'
     | 'getPathState'
     | 'getAllPathStates'
     | 'removePathState'

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -3,14 +3,14 @@ import {
   isRef,
   computed,
   onMounted,
-  onBeforeUnmount,
   unref,
-  WatchStopHandle,
   provide,
-  nextTick,
   getCurrentInstance,
   Ref,
   ComponentInternalInstance,
+  onBeforeUnmount,
+  nextTick,
+  WatchStopHandle,
 } from 'vue';
 import { klona as deepCopy } from 'klona/full';
 import { validate as validateValue } from './validate';
@@ -27,6 +27,7 @@ import {
   PrivateFormContext,
   YupSchema,
   MaybeRefOrLazy,
+  InputType,
 } from './types';
 import {
   normalizeRules,
@@ -42,6 +43,7 @@ import {
   isEqual,
   isTypedSchema,
   lazyToRef,
+  unravel,
 } from './utils';
 import { isCallable } from '../../shared';
 import { FieldContextKey, FormContextKey, IS_ABSENT } from './symbols';
@@ -53,7 +55,7 @@ export interface FieldOptions<TValue = unknown> {
   validateOnValueUpdate: boolean;
   validateOnMount?: boolean;
   bails?: boolean;
-  type?: string;
+  type?: InputType;
   valueProp?: MaybeRef<TValue>;
   checkedValue?: MaybeRef<TValue>;
   uncheckedValue?: MaybeRef<TValue>;
@@ -84,7 +86,7 @@ export function useField<TValue = unknown>(
   opts?: Partial<FieldOptions<TValue>>
 ): FieldContext<TValue> {
   if (hasCheckedAttr(opts?.type)) {
-    return useCheckboxField(path, rules, opts);
+    return useFieldWithChecked(path, rules, opts);
   }
 
   return _useField(path, rules, opts);
@@ -115,11 +117,33 @@ function _useField<TValue = unknown>(
   const form = (controlForm as PrivateFormContext | undefined) || injectedForm;
   const name = lazyToRef(path);
 
-  // a flag indicating if the field is about to be removed/unmounted.
-  let markedForRemoval = false;
+  const validator = computed(() => {
+    const schema = unref(form?.schema);
+    if (schema) {
+      return undefined;
+    }
+
+    const rulesValue = unref(rules);
+
+    if (
+      isYupValidator(rulesValue) ||
+      isTypedSchema(rulesValue) ||
+      isCallable(rulesValue) ||
+      Array.isArray(rulesValue)
+    ) {
+      return rulesValue;
+    }
+
+    return normalizeRules(rulesValue);
+  });
+
   const { id, value, initialValue, meta, setState, errors } = useFieldState(name, {
     modelValue,
     form,
+    bails,
+    label,
+    type,
+    validator: validator.value ? validate : undefined,
   });
 
   const errorMessage = computed(() => errors.value[0]);
@@ -135,36 +159,21 @@ function _useField<TValue = unknown>(
     meta.touched = true;
   };
 
-  const normalizedRules = computed(() => {
-    let rulesValue = unref(rules);
-    const schema = unref(form?.schema);
-    if (schema && !isYupValidator(schema) && !isTypedSchema(schema)) {
-      rulesValue = extractRuleFromSchema<TValue>(schema, unref(name)) || rulesValue;
-    }
-
-    if (
-      isYupValidator(rulesValue) ||
-      isTypedSchema(rulesValue) ||
-      isCallable(rulesValue) ||
-      Array.isArray(rulesValue)
-    ) {
-      return rulesValue;
-    }
-
-    return normalizeRules(rulesValue);
-  });
-
   async function validateCurrentValue(mode: SchemaValidationMode) {
     if (form?.validateSchema) {
       return (await form.validateSchema(mode)).results[unref(name)] ?? { valid: true, errors: [] };
     }
 
-    return validateValue(value.value, normalizedRules.value, {
-      name: unref(name),
-      label: unref(label),
-      values: form?.values ?? {},
-      bails,
-    });
+    if (validator.value) {
+      return validateValue(value.value, validator.value, {
+        name: unref(name),
+        label: unref(label),
+        values: form?.values ?? {},
+        bails,
+      });
+    }
+
+    return { valid: true, errors: [] };
   }
 
   const validateWithStateMutation = withLatest(
@@ -175,13 +184,9 @@ function _useField<TValue = unknown>(
       return validateCurrentValue('validated-only');
     },
     result => {
-      if (markedForRemoval) {
-        result.valid = true;
-        result.errors = [];
-      }
-
       setState({ errors: result.errors });
       meta.pending = false;
+      meta.valid = result.valid;
 
       return result;
     }
@@ -192,10 +197,6 @@ function _useField<TValue = unknown>(
       return validateCurrentValue('silent');
     },
     result => {
-      if (markedForRemoval) {
-        result.valid = true;
-      }
-
       meta.valid = result.valid;
 
       return result;
@@ -243,6 +244,10 @@ function _useField<TValue = unknown>(
     unwatchValue = watch(
       value,
       (val, oldVal) => {
+        if (form?.isResetting.value) {
+          return;
+        }
+
         if (isEqual(val, oldVal) && isEqual(val, lastWatchedValue)) {
           return;
         }
@@ -348,16 +353,10 @@ function _useField<TValue = unknown>(
   }
 
   // associate the field with the given form
-  form.register(field);
-
-  onBeforeUnmount(() => {
-    markedForRemoval = true;
-    form.unregister(field);
-  });
 
   // extract cross-field dependencies in a computed prop
   const dependencies = computed(() => {
-    const rulesVal = normalizedRules.value;
+    const rulesVal = validator.value;
     // is falsy, a function schema or a yup schema
     if (
       !rulesVal ||
@@ -399,6 +398,40 @@ function _useField<TValue = unknown>(
     if (shouldValidate) {
       meta.validated ? validateWithStateMutation() : validateValidStateOnly();
     }
+  });
+
+  onBeforeUnmount(() => {
+    const shouldKeepValue = unref(field.keepValueOnUnmount) ?? unref(form.keepValuesOnUnmount);
+    if (shouldKeepValue || !form) {
+      return;
+    }
+
+    const path = unravel(name);
+    const pathState = form.getPathState(path);
+    const matchesId =
+      Array.isArray(pathState?.id) && pathState?.multiple
+        ? pathState?.id.includes(field.id)
+        : pathState?.id === field.id;
+    if (!matchesId) {
+      return;
+    }
+
+    if (pathState?.multiple && Array.isArray(pathState.value)) {
+      const valueIdx = pathState.value.findIndex(i => isEqual(i, unref(field.checkedValue)));
+      if (valueIdx > -1) {
+        const newVal = [...pathState.value];
+        newVal.splice(valueIdx, 1);
+        form.setFieldValue(path, newVal);
+      }
+
+      if (Array.isArray(pathState.id)) {
+        pathState.id.splice(pathState.id.indexOf(field.id), 1);
+      }
+    } else {
+      form.unsetPathValue(path);
+    }
+
+    form.removePathState(path);
   });
 
   return field;
@@ -459,7 +492,7 @@ export function extractRuleFromSchema<TValue>(
   return schema[fieldName];
 }
 
-function useCheckboxField<TValue = unknown>(
+function useFieldWithChecked<TValue = unknown>(
   name: MaybeRefOrLazy<string>,
   rules?: MaybeRef<RuleExpression<TValue>>,
   opts?: Partial<FieldOptions<TValue>>
@@ -468,7 +501,7 @@ function useCheckboxField<TValue = unknown>(
   const checkedValue = opts?.checkedValue;
   const uncheckedValue = opts?.uncheckedValue;
 
-  function patchCheckboxApi(
+  function patchCheckedApi(
     field: FieldContext<TValue> & { originalHandleChange?: FieldContext['handleChange'] }
   ): FieldContext<TValue> {
     const handleChange = field.handleChange;
@@ -490,9 +523,14 @@ function useCheckboxField<TValue = unknown>(
         return;
       }
 
-      let newValue = normalizeEventValue(e) as TValue;
-      // Single checkbox field without a form to toggle it's value
-      if (!form) {
+      const path = unravel(name);
+      const pathState = form?.getPathState(path);
+      const value = normalizeEventValue(e);
+      let newValue!: TValue;
+      if (form && pathState?.multiple && pathState.type === 'checkbox') {
+        newValue = resolveNextCheckboxValue(getFromPath(form.values, path) || [], value, undefined) as TValue;
+      } else {
+        // Single checkbox field without a form to toggle it's value
         newValue = resolveNextCheckboxValue(unref(field.value), unref(checkedValue), unref(uncheckedValue)) as TValue;
       }
 
@@ -508,7 +546,7 @@ function useCheckboxField<TValue = unknown>(
     };
   }
 
-  return patchCheckboxApi(_useField<TValue>(name, rules, opts));
+  return patchCheckedApi(_useField<TValue>(name, rules, opts));
 }
 
 interface ModelOpts<TValue> {

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -117,10 +117,12 @@ function _useField<TValue = unknown>(
 
   // a flag indicating if the field is about to be removed/unmounted.
   let markedForRemoval = false;
-  const { id, value, initialValue, meta, setState, errors, errorMessage } = useFieldState(name, {
+  const { id, value, initialValue, meta, setState, errors } = useFieldState(name, {
     modelValue,
     form,
   });
+
+  const errorMessage = computed(() => errors.value[0]);
 
   if (syncVModel) {
     useVModel({ value, prop: modelPropName, handleChange });

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -482,22 +482,6 @@ function normalizeOptions<TValue>(opts: Partial<FieldOptions<TValue>> | undefine
   } as FieldOptions<TValue>;
 }
 
-/**
- * Extracts the validation rules from a schema
- */
-export function extractRuleFromSchema<TValue>(
-  schema: Record<string, RuleExpression<TValue>> | undefined,
-  fieldName: string
-) {
-  // no schema at all
-  if (!schema) {
-    return undefined;
-  }
-
-  // there is a key on the schema object for this field
-  return schema[fieldName];
-}
-
 function useFieldWithChecked<TValue = unknown>(
   name: MaybeRefOrLazy<string>,
   rules?: MaybeRef<RuleExpression<TValue>>,

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -144,7 +144,7 @@ function _useField<TValue = unknown>(
     bails,
     label,
     type,
-    validator: validator.value ? validate : undefined,
+    validate: validator.value ? validate : undefined,
   });
 
   const errorMessage = computed(() => errors.value[0]);

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -116,6 +116,7 @@ function _useField<TValue = unknown>(
   const injectedForm = controlled ? injectWithSelf(FormContextKey) : undefined;
   const form = (controlForm as PrivateFormContext | undefined) || injectedForm;
   const name = lazyToRef(path);
+  let PENDING_UNMOUNT = false;
 
   const validator = computed(() => {
     const schema = unref(form?.schema);
@@ -184,6 +185,10 @@ function _useField<TValue = unknown>(
       return validateCurrentValue('validated-only');
     },
     result => {
+      if (PENDING_UNMOUNT) {
+        return;
+      }
+
       setState({ errors: result.errors });
       meta.pending = false;
       meta.valid = result.valid;
@@ -401,6 +406,7 @@ function _useField<TValue = unknown>(
   });
 
   onBeforeUnmount(() => {
+    PENDING_UNMOUNT = true;
     const shouldKeepValue = unref(field.keepValueOnUnmount) ?? unref(form.keepValuesOnUnmount);
     if (shouldKeepValue || !form) {
       return;

--- a/packages/vee-validate/src/useFieldArray.ts
+++ b/packages/vee-validate/src/useFieldArray.ts
@@ -49,6 +49,10 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): Fi
 
   function initFields() {
     const currentValues = getCurrentValues();
+    if (!Array.isArray(currentValues)) {
+      return;
+    }
+
     fields.value = currentValues.map((v, idx) => createEntry(v, idx, fields.value));
     updateEntryFlags();
   }

--- a/packages/vee-validate/src/useFieldArray.ts
+++ b/packages/vee-validate/src/useFieldArray.ts
@@ -1,11 +1,11 @@
 import { Ref, unref, ref, onBeforeUnmount, watch } from 'vue';
 import { isNullOrUndefined } from '../../shared';
 import { FormContextKey } from './symbols';
-import { FieldArrayContext, FieldEntry, MaybeRef, PrivateFieldArrayContext } from './types';
-import { computedDeep, getFromPath, injectWithSelf, warn, isEqual } from './utils';
+import { FieldArrayContext, FieldEntry, MaybeRef, PrivateFieldArrayContext, PrivateFormContext } from './types';
+import { computedDeep, getFromPath, injectWithSelf, warn, isEqual, setInPath } from './utils';
 
 export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): FieldArrayContext<TValue> {
-  const form = injectWithSelf(FormContextKey, undefined);
+  const form = injectWithSelf(FormContextKey, undefined) as PrivateFormContext;
   const fields: Ref<FieldEntry<TValue>[]> = ref([]);
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -49,7 +49,7 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): Fi
 
   function initFields() {
     const currentValues = getCurrentValues();
-    fields.value = currentValues.map(createEntry);
+    fields.value = currentValues.map((v, idx) => createEntry(v, idx, fields.value));
     updateEntryFlags();
   }
 
@@ -64,7 +64,14 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): Fi
     }
   }
 
-  function createEntry(value: TValue): FieldEntry<TValue> {
+  function createEntry(value: TValue, idx?: number, currentFields?: FieldEntry<TValue>[]): FieldEntry<TValue> {
+    // Skips the work by returning the current entry if it already exists
+    // This should make the `key` prop stable and doesn't cause more re-renders than needed
+    // The value is computed and should update anyways
+    if (currentFields && !isNullOrUndefined(idx) && currentFields[idx]) {
+      return currentFields[idx];
+    }
+
     const key = entryCounter++;
 
     const entry: FieldEntry<TValue> = {
@@ -108,8 +115,9 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): Fi
 
     const newValue = [...pathValue];
     newValue.splice(idx, 1);
-    form?.unsetInitialValue(pathName + `[${idx}]`);
-    form?.setFieldValue(pathName, newValue);
+    const fieldPath = pathName + `[${idx}]`;
+    form.unsetInitialValue(fieldPath);
+    setInPath(form.values, pathName, newValue);
     fields.value.splice(idx, 1);
     afterMutation();
   }
@@ -124,8 +132,8 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): Fi
 
     const newValue = [...normalizedPathValue];
     newValue.push(value);
-    form?.stageInitialValue(pathName + `[${newValue.length - 1}]`, value);
-    form?.setFieldValue(pathName, newValue);
+    form.stageInitialValue(pathName + `[${newValue.length - 1}]`, value);
+    setInPath(form.values, pathName, newValue);
     fields.value.push(createEntry(value));
     afterMutation();
   }
@@ -148,8 +156,7 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): Fi
     const tempEntry = newFields[indexA];
     newFields[indexA] = newFields[indexB];
     newFields[indexB] = tempEntry;
-
-    form?.setFieldValue(pathName, newValue);
+    setInPath(form.values, pathName, newValue);
     fields.value = newFields;
     updateEntryFlags();
   }
@@ -166,14 +173,15 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): Fi
 
     newValue.splice(idx, 0, value);
     newFields.splice(idx, 0, createEntry(value));
-    form?.setFieldValue(pathName, newValue);
+    setInPath(form.values, pathName, newValue);
     fields.value = newFields;
     afterMutation();
   }
 
   function replace(arr: TValue[]) {
     const pathName = unref(arrayPath);
-    form?.setFieldValue(pathName, arr);
+    form.stageInitialValue(pathName, arr);
+    setInPath(form.values, pathName, arr);
     initFields();
     afterMutation();
   }
@@ -185,7 +193,7 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): Fi
       return;
     }
 
-    form?.setFieldValue(`${pathName}[${idx}]`, value);
+    setInPath(form.values, `${pathName}[${idx}]`, value);
     form?.validate({ mode: 'validated-only' });
   }
 
@@ -198,8 +206,8 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): Fi
     }
 
     const newValue = [value, ...normalizedPathValue];
-    form?.stageInitialValue(pathName + `[${newValue.length - 1}]`, value);
-    form?.setFieldValue(pathName, newValue);
+    form.stageInitialValue(pathName + `[${newValue.length - 1}]`, value);
+    setInPath(form.values, pathName, newValue);
     fields.value.unshift(createEntry(value));
     afterMutation();
   }
@@ -222,8 +230,7 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRef<string>): Fi
     const movedValue = newValue[oldIdx];
     newValue.splice(oldIdx, 1);
     newValue.splice(newIdx, 0, movedValue);
-
-    form?.setFieldValue(pathName, newValue);
+    setInPath(form.values, pathName, newValue);
     fields.value = newFields;
     afterMutation();
   }

--- a/packages/vee-validate/src/useFieldState.ts
+++ b/packages/vee-validate/src/useFieldState.ts
@@ -22,7 +22,7 @@ export interface StateInit<TValue = unknown> {
   bails: boolean;
   label?: MaybeRef<string | undefined>;
   type?: InputType;
-  validator?: FieldValidator;
+  validate?: FieldValidator;
 }
 
 let ID_COUNTER = 0;
@@ -71,7 +71,7 @@ export function useFieldState<TValue = unknown>(
     bails: init.bails,
     label: init.label,
     type: init.type,
-    validator: init.validator,
+    validate: init.validate,
   });
 
   const errors = computed(() => state.errors);

--- a/packages/vee-validate/src/useFieldState.ts
+++ b/packages/vee-validate/src/useFieldState.ts
@@ -1,6 +1,6 @@
-import { computed, isRef, reactive, ref, Ref, unref, watch } from 'vue';
+import { computed, isRef, reactive, ref, Ref, toRefs, unref, watch } from 'vue';
 import { FieldMeta, FieldState, MaybeRef, PrivateFormContext } from './types';
-import { getFromPath, isEqual } from './utils';
+import { getFromPath, isEqual, normalizeErrorItem } from './utils';
 
 export interface StateSetterInit<TValue = unknown> extends FieldState<TValue> {
   initialValue: TValue;
@@ -12,7 +12,6 @@ export interface FieldStateComposable<TValue = unknown> {
   meta: FieldMeta<TValue>;
   value: Ref<TValue>;
   initialValue: Ref<TValue>;
-  errorMessage: Ref<string | undefined>;
   errors: Ref<string[]>;
   setState(state: Partial<StateSetterInit<TValue>>): void;
 }
@@ -28,10 +27,44 @@ export function useFieldState<TValue = unknown>(
   path: MaybeRef<string>,
   init: Partial<StateInit<TValue>>
 ): FieldStateComposable<TValue> {
-  const { value, initialValue, setInitialValue } = _useFieldValue<TValue>(path, init.modelValue, init.form);
-  const { errorMessage, errors, setErrors } = _useFieldErrors(path, init.form);
-  const meta = _useFieldMeta(value, initialValue, errors);
   const id = ID_COUNTER >= Number.MAX_SAFE_INTEGER ? 0 : ++ID_COUNTER;
+  const { value, initialValue, setInitialValue } = _useFieldValue<TValue>(path, init.modelValue, init.form);
+
+  if (!init.form) {
+    const { errors, setErrors } = createFieldErrors();
+    const meta = createFieldMeta(value, initialValue, errors);
+
+    function setState(state: Partial<StateSetterInit<TValue>>) {
+      if ('value' in state) {
+        value.value = state.value as TValue;
+      }
+
+      if ('errors' in state) {
+        setErrors(state.errors);
+      }
+
+      if ('touched' in state) {
+        meta.touched = state.touched ?? meta.touched;
+      }
+
+      if ('initialValue' in state) {
+        setInitialValue(state.initialValue as TValue);
+      }
+    }
+
+    return {
+      id,
+      path,
+      value,
+      initialValue,
+      meta,
+      errors,
+      setState,
+    };
+  }
+
+  const state = init.form.createPathState(path);
+  const errors = computed(() => state.errors);
 
   function setState(state: Partial<StateSetterInit<TValue>>) {
     if ('value' in state) {
@@ -39,11 +72,11 @@ export function useFieldState<TValue = unknown>(
     }
 
     if ('errors' in state) {
-      setErrors(state.errors);
+      init.form?.setFieldError(unref(path), state.errors);
     }
 
     if ('touched' in state) {
-      meta.touched = state.touched ?? meta.touched;
+      init.form?.setFieldTouched(unref(path), state.touched ?? false);
     }
 
     if ('initialValue' in state) {
@@ -55,10 +88,9 @@ export function useFieldState<TValue = unknown>(
     id,
     path,
     value,
-    initialValue,
-    meta,
     errors,
-    errorMessage,
+    meta: state,
+    initialValue,
     setState,
   };
 }
@@ -158,7 +190,7 @@ function resolveModelValue<TValue>(
 /**
  * Creates meta flags state and some associated effects with them
  */
-function _useFieldMeta<TValue>(
+function createFieldMeta<TValue>(
   currentValue: Ref<TValue>,
   initialValue: MaybeRef<TValue> | undefined,
   errors: Ref<string[]>
@@ -191,34 +223,13 @@ function _useFieldMeta<TValue>(
 /**
  * Creates the error message state for the field state
  */
-export function _useFieldErrors(path: MaybeRef<string>, form?: PrivateFormContext) {
-  function normalizeErrors(messages: string | string[] | null | undefined) {
-    if (!messages) {
-      return [];
-    }
-
-    return Array.isArray(messages) ? messages : [messages];
-  }
-
-  if (!form) {
-    const errors = ref<string[]>([]);
-
-    return {
-      errors,
-      errorMessage: computed<string | undefined>(() => errors.value[0]),
-      setErrors: (messages: string | string[] | null | undefined) => {
-        errors.value = normalizeErrors(messages);
-      },
-    };
-  }
-
-  const errors = computed(() => form.errorBag.value[unref(path)] || []);
+export function createFieldErrors() {
+  const errors = ref<string[]>([]);
 
   return {
     errors,
-    errorMessage: computed<string | undefined>(() => errors.value[0]),
     setErrors: (messages: string | string[] | null | undefined) => {
-      form.setFieldErrorBag(unref(path), normalizeErrors(messages));
+      errors.value = normalizeErrorItem(messages);
     },
   };
 }

--- a/packages/vee-validate/src/useFieldState.ts
+++ b/packages/vee-validate/src/useFieldState.ts
@@ -126,7 +126,7 @@ export function _useFieldValue<TValue = unknown>(
       return unref(modelRef) as TValue;
     }
 
-    return getFromPath<TValue>(form.meta.value.initialValues, unref(path), unref(modelRef)) as TValue;
+    return getFromPath<TValue>(form.initialValues.value, unref(path), unref(modelRef)) as TValue;
   }
 
   function setInitialValue(value: TValue) {

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -264,7 +264,7 @@ export function useForm<
       value: currentValue,
       multiple: false,
       fieldsCount: 1,
-      validator: config?.validate,
+      validate: config?.validate,
       dirty: computed(() => {
         return !isEqual(unref(currentValue), unref(initialValue));
       }),

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -264,7 +264,7 @@ export function useForm<
       value: currentValue,
       multiple: false,
       fieldsCount: 1,
-      validator: config?.validator,
+      validator: config?.validate,
       dirty: computed(() => {
         return !isEqual(unref(currentValue), unref(initialValue));
       }),
@@ -643,7 +643,7 @@ export function useForm<
     // No schema, each field is responsible to validate itself
     const validations = await Promise.all(
       pathStates.value.map(state => {
-        if (!state.validator) {
+        if (!state.validate) {
           return Promise.resolve({
             key: state.path,
             valid: true,
@@ -651,7 +651,7 @@ export function useForm<
           });
         }
 
-        return state.validator(opts).then((result: ValidationResult) => {
+        return state.validate(opts).then((result: ValidationResult) => {
           return {
             key: state.path,
             valid: result.valid,
@@ -693,8 +693,8 @@ export function useForm<
       return results[path] || { errors: [], valid: true };
     }
 
-    if (state?.validator) {
-      return state.validator();
+    if (state?.validate) {
+      return state.validate();
     }
 
     warn(`field with path ${path} was not found`);

--- a/packages/vee-validate/src/useIsFieldDirty.ts
+++ b/packages/vee-validate/src/useIsFieldDirty.ts
@@ -1,28 +1,17 @@
-import { computed, inject, unref } from 'vue';
-import { FieldContextKey, FormContextKey } from './symbols';
+import { computed } from 'vue';
 import { MaybeRef } from './types';
-import { injectWithSelf, warn } from './utils';
+import { resolveFieldOrPathState } from './utils';
 
 /**
  * If a field is dirty or not
  */
 export function useIsFieldDirty(path?: MaybeRef<string>) {
-  const form = injectWithSelf(FormContextKey);
-  const field = path ? undefined : inject(FieldContextKey);
+  const fieldOrPath = resolveFieldOrPathState(path);
 
   return computed(() => {
-    if (path) {
-      const state = form?.getPathState(unref(path));
-
-      return state?.dirty;
-    }
-
-    if (!field) {
-      warn(`field with name ${unref(path)} was not found`);
-
+    if (!fieldOrPath) {
       return false;
     }
-
-    return field.meta.dirty;
+    return ('meta' in fieldOrPath ? fieldOrPath.meta.dirty : fieldOrPath?.value?.dirty) ?? false;
   });
 }

--- a/packages/vee-validate/src/useIsFieldDirty.ts
+++ b/packages/vee-validate/src/useIsFieldDirty.ts
@@ -1,18 +1,20 @@
 import { computed, inject, unref } from 'vue';
 import { FieldContextKey, FormContextKey } from './symbols';
-import { MaybeRef, PrivateFieldContext } from './types';
-import { injectWithSelf, normalizeField, warn } from './utils';
+import { MaybeRef } from './types';
+import { injectWithSelf, warn } from './utils';
 
 /**
  * If a field is dirty or not
  */
 export function useIsFieldDirty(path?: MaybeRef<string>) {
   const form = injectWithSelf(FormContextKey);
-  let field: PrivateFieldContext | undefined = path ? undefined : inject(FieldContextKey);
+  const field = path ? undefined : inject(FieldContextKey);
 
   return computed(() => {
     if (path) {
-      field = normalizeField(form?.fieldsByPath.value[unref(path)]);
+      const state = form?.getPathState(unref(path));
+
+      return state?.dirty;
     }
 
     if (!field) {

--- a/packages/vee-validate/src/useIsFieldTouched.ts
+++ b/packages/vee-validate/src/useIsFieldTouched.ts
@@ -1,28 +1,18 @@
-import { computed, inject, unref } from 'vue';
-import { FieldContextKey, FormContextKey } from './symbols';
+import { computed } from 'vue';
 import { MaybeRef } from './types';
-import { injectWithSelf, warn } from './utils';
+import { resolveFieldOrPathState } from './utils';
 
 /**
  * If a field is touched or not
  */
 export function useIsFieldTouched(path?: MaybeRef<string>) {
-  const form = injectWithSelf(FormContextKey);
-  const field = path ? undefined : inject(FieldContextKey);
+  const fieldOrPath = resolveFieldOrPathState(path);
 
   return computed(() => {
-    if (path) {
-      const state = form?.getPathState(unref(path));
-
-      return state?.touched;
-    }
-
-    if (!field) {
-      warn(`field with name ${unref(path)} was not found`);
-
+    if (!fieldOrPath) {
       return false;
     }
 
-    return field.meta.touched;
+    return ('meta' in fieldOrPath ? fieldOrPath.meta.touched : fieldOrPath?.value?.touched) ?? false;
   });
 }

--- a/packages/vee-validate/src/useIsFieldTouched.ts
+++ b/packages/vee-validate/src/useIsFieldTouched.ts
@@ -1,18 +1,20 @@
 import { computed, inject, unref } from 'vue';
 import { FieldContextKey, FormContextKey } from './symbols';
-import { MaybeRef, PrivateFieldContext } from './types';
-import { injectWithSelf, normalizeField, warn } from './utils';
+import { MaybeRef } from './types';
+import { injectWithSelf, warn } from './utils';
 
 /**
  * If a field is touched or not
  */
 export function useIsFieldTouched(path?: MaybeRef<string>) {
   const form = injectWithSelf(FormContextKey);
-  let field: PrivateFieldContext | undefined = path ? undefined : inject(FieldContextKey);
+  const field = path ? undefined : inject(FieldContextKey);
 
   return computed(() => {
     if (path) {
-      field = normalizeField(form?.fieldsByPath.value[unref(path)]);
+      const state = form?.getPathState(unref(path));
+
+      return state?.touched;
     }
 
     if (!field) {

--- a/packages/vee-validate/src/useIsFieldValid.ts
+++ b/packages/vee-validate/src/useIsFieldValid.ts
@@ -1,18 +1,20 @@
 import { computed, inject, unref } from 'vue';
 import { FieldContextKey, FormContextKey } from './symbols';
-import { MaybeRef, PrivateFieldContext } from './types';
-import { injectWithSelf, normalizeField, warn } from './utils';
+import { MaybeRef } from './types';
+import { injectWithSelf, warn } from './utils';
 
 /**
  * If a field is validated and is valid
  */
 export function useIsFieldValid(path?: MaybeRef<string>) {
   const form = injectWithSelf(FormContextKey);
-  let field: PrivateFieldContext | undefined = path ? undefined : inject(FieldContextKey);
+  const field = path ? undefined : inject(FieldContextKey);
 
   return computed(() => {
     if (path) {
-      field = normalizeField(form?.fieldsByPath.value[unref(path)]);
+      const state = form?.getPathState(unref(path));
+
+      return state?.valid;
     }
 
     if (!field) {

--- a/packages/vee-validate/src/useIsFieldValid.ts
+++ b/packages/vee-validate/src/useIsFieldValid.ts
@@ -1,28 +1,18 @@
-import { computed, inject, unref } from 'vue';
-import { FieldContextKey, FormContextKey } from './symbols';
+import { computed } from 'vue';
 import { MaybeRef } from './types';
-import { injectWithSelf, warn } from './utils';
+import { resolveFieldOrPathState } from './utils';
 
 /**
  * If a field is validated and is valid
  */
 export function useIsFieldValid(path?: MaybeRef<string>) {
-  const form = injectWithSelf(FormContextKey);
-  const field = path ? undefined : inject(FieldContextKey);
+  const fieldOrPath = resolveFieldOrPathState(path);
 
   return computed(() => {
-    if (path) {
-      const state = form?.getPathState(unref(path));
-
-      return state?.valid;
-    }
-
-    if (!field) {
-      warn(`field with name ${unref(path)} was not found`);
-
+    if (!fieldOrPath) {
       return false;
     }
 
-    return field.meta.valid;
+    return ('meta' in fieldOrPath ? fieldOrPath.meta.valid : fieldOrPath?.value?.valid) ?? false;
   });
 }

--- a/packages/vee-validate/src/useValidateField.ts
+++ b/packages/vee-validate/src/useValidateField.ts
@@ -1,29 +1,29 @@
 import { inject, unref } from 'vue';
 import { FieldContextKey, FormContextKey } from './symbols';
-import { MaybeRef, PrivateFieldContext, ValidationResult } from './types';
-import { injectWithSelf, normalizeField, warn } from './utils';
+import { MaybeRef, ValidationResult } from './types';
+import { injectWithSelf, warn } from './utils';
 
 /**
  * Validates a single field
  */
 export function useValidateField(path?: MaybeRef<string>) {
   const form = injectWithSelf(FormContextKey);
-  let field: PrivateFieldContext | undefined = path ? undefined : inject(FieldContextKey);
+  const field = path ? undefined : inject(FieldContextKey);
 
   return function validateField(): Promise<ValidationResult> {
-    if (path) {
-      field = normalizeField(form?.fieldsByPath.value[unref(path)]);
+    if (field) {
+      return field.validate();
     }
 
-    if (!field) {
-      warn(`field with name ${unref(path)} was not found`);
-
-      return Promise.resolve({
-        errors: [],
-        valid: true,
-      });
+    if (form && path) {
+      return form?.validateField(unref(path));
     }
 
-    return field.validate();
+    warn(`field with name ${unref(path)} was not found`);
+
+    return Promise.resolve({
+      errors: [],
+      valid: true,
+    });
   };
 }

--- a/packages/vee-validate/src/utils/assertions.ts
+++ b/packages/vee-validate/src/utils/assertions.ts
@@ -8,20 +8,6 @@ export function isLocator(value: unknown): value is Locator {
   return isCallable(value) && !!(value as Locator).__locatorRef;
 }
 
-/**
- * Checks if an tag name is a native HTML tag and not a Vue component
- */
-export function isHTMLTag(tag: string) {
-  return ['input', 'textarea', 'select'].includes(tag);
-}
-
-/**
- * Checks if an input is of type file
- */
-export function isFileInputNode(tag: string, attrs: Record<string, unknown>) {
-  return isHTMLTag(tag) && attrs.type === 'file';
-}
-
 export function isTypedSchema(value: unknown): value is TypedSchema {
   return !!value && isCallable((value as TypedSchema).parse) && (value as TypedSchema).__type === 'VVTypedSchema';
 }

--- a/packages/vee-validate/src/utils/common.ts
+++ b/packages/vee-validate/src/utils/common.ts
@@ -164,19 +164,6 @@ export function warn(message: string) {
   vueWarning(`[vee-validate]: ${message}`);
 }
 
-/**
- * Ensures we deal with a singular field value
- */
-export function normalizeField<TValue = unknown>(
-  field: PrivateFieldContext<TValue> | PrivateFieldContext<TValue>[] | undefined
-): PrivateFieldContext<TValue> | undefined {
-  if (Array.isArray(field)) {
-    return field[0];
-  }
-
-  return field;
-}
-
 export function resolveNextCheckboxValue<T>(currentValue: T, checkedValue: T, uncheckedValue: T): T;
 export function resolveNextCheckboxValue<T>(currentValue: T[], checkedValue: T, uncheckedValue: T): T[];
 export function resolveNextCheckboxValue<T>(currentValue: T | T[], checkedValue: T, uncheckedValue: T): T | T[] {

--- a/packages/vee-validate/src/utils/common.ts
+++ b/packages/vee-validate/src/utils/common.ts
@@ -13,7 +13,8 @@ import {
 import { klona as deepCopy } from 'klona/full';
 import { isCallable, isIndex, isNullOrUndefined, isObject, toNumber } from '../../../shared';
 import { isContainerValue, isEmptyContainer, isEqual, isNotNestedPath } from './assertions';
-import { MaybeRefOrLazy, PrivateFieldContext } from '../types';
+import { MaybeRef, MaybeRefOrLazy, PrivateFieldContext } from '../types';
+import { FormContextKey, FieldContextKey } from '../symbols';
 
 function cleanupNonNestedPath(path: string) {
   if (isNotNestedPath(path)) {
@@ -178,7 +179,7 @@ export function normalizeField<TValue = unknown>(
 
 export function resolveNextCheckboxValue<T>(currentValue: T, checkedValue: T, uncheckedValue: T): T;
 export function resolveNextCheckboxValue<T>(currentValue: T[], checkedValue: T, uncheckedValue: T): T[];
-export function resolveNextCheckboxValue<T>(currentValue: T | T[], checkedValue: T, uncheckedValue: T) {
+export function resolveNextCheckboxValue<T>(currentValue: T | T[], checkedValue: T, uncheckedValue: T): T | T[] {
   if (Array.isArray(currentValue)) {
     const newVal = [...currentValue];
     // Use isEqual since checked object values can possibly fail the equality check #3883
@@ -325,4 +326,16 @@ export function lazyToRef<T>(value: MaybeRefOrLazy<T>): Ref<T> {
 
 export function normalizeErrorItem(message: string | string[] | null | undefined) {
   return Array.isArray(message) ? message : message ? [message] : [];
+}
+
+export function resolveFieldOrPathState(path?: MaybeRef<string>) {
+  const form = injectWithSelf(FormContextKey);
+  const state = path ? computed(() => form?.getPathState(unref(path))) : undefined;
+  const field = path ? undefined : inject(FieldContextKey);
+
+  if (!field || !state?.value) {
+    warn(`field with name ${unref(path)} was not found`);
+  }
+
+  return state || field;
 }

--- a/packages/vee-validate/src/utils/common.ts
+++ b/packages/vee-validate/src/utils/common.ts
@@ -322,3 +322,7 @@ export function unravel<T>(value: MaybeRefOrLazy<T>): T {
 export function lazyToRef<T>(value: MaybeRefOrLazy<T>): Ref<T> {
   return computed(() => unravel(value));
 }
+
+export function normalizeErrorItem(message: string | string[] | null | undefined) {
+  return Array.isArray(message) ? message : message ? [message] : [];
+}

--- a/packages/vee-validate/tests/FieldArray.spec.ts
+++ b/packages/vee-validate/tests/FieldArray.spec.ts
@@ -653,7 +653,7 @@ test('clears old errors path when last item is removed and value update validati
     setup(props) {
       const { value, handleChange, errors } = useField(toRef(props, 'name'), props.rules, {
         label: props.label,
-        type: props.type,
+        type: props.type as 'checkbox',
       });
 
       return {

--- a/packages/vee-validate/tests/useFieldArray.spec.ts
+++ b/packages/vee-validate/tests/useFieldArray.spec.ts
@@ -1,5 +1,5 @@
 import { useForm, useFieldArray, FieldEntry, FormContext, FieldArrayContext } from '@/vee-validate';
-import { nextTick, onMounted, Ref } from 'vue';
+import { onMounted, Ref } from 'vue';
 import * as yup from 'yup';
 import { mountWithHoc, flushPromises } from './helpers';
 
@@ -104,6 +104,26 @@ test('warns when updating a no-longer existing item', async () => {
   spy.mockRestore();
 });
 
+test('warns when no form context is present', async () => {
+  const spy = vi.spyOn(console, 'warn').mockImplementation(() => {
+    // NOOP
+  });
+  mountWithHoc({
+    setup() {
+      const { push } = useFieldArray('users');
+      push('');
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+
+  expect(spy).toHaveBeenCalled();
+  spy.mockRestore();
+});
+
 test('duplicate calls yields the same instance', async () => {
   let removeFn!: (idx: number) => void;
   mountWithHoc({
@@ -172,6 +192,33 @@ test('array push should trigger a silent validation', async () => {
   expect(form.meta.value.valid).toBe(false);
 });
 
+test('array push noop when path is not an array', async () => {
+  let arr!: FieldArrayContext;
+  mountWithHoc({
+    setup() {
+      const form = useForm<any>({
+        initialValues: {
+          users: 'test',
+        },
+        validationSchema: yup.object({
+          users: yup.array().of(yup.string().required().min(1)),
+        }),
+      });
+
+      arr = useFieldArray('users');
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+  arr.push('');
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+});
+
 // #4096
 test('array prepend should trigger a silent validation', async () => {
   let form!: FormContext;
@@ -201,6 +248,33 @@ test('array prepend should trigger a silent validation', async () => {
   expect(form.meta.value.valid).toBe(false);
 });
 
+test('array prepend noop when path is not an array', async () => {
+  let arr!: FieldArrayContext;
+  mountWithHoc({
+    setup() {
+      const form = useForm<any>({
+        initialValues: {
+          users: 'test',
+        },
+        validationSchema: yup.object({
+          users: yup.array().of(yup.string().required().min(1)),
+        }),
+      });
+
+      arr = useFieldArray('users');
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+  arr.prepend('');
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+});
+
 // #4096
 test('array insert should trigger a silent validation', async () => {
   let form!: FormContext;
@@ -228,4 +302,220 @@ test('array insert should trigger a silent validation', async () => {
   arr.insert(1, '');
   await flushPromises();
   expect(form.meta.value.valid).toBe(false);
+});
+
+test('array insert noop when path is not an array', async () => {
+  let arr!: FieldArrayContext;
+  mountWithHoc({
+    setup() {
+      useForm<any>({
+        initialValues: {
+          users: 'test',
+        },
+        validationSchema: yup.object({
+          users: yup.array().of(yup.string().required().min(1)),
+        }),
+      });
+
+      arr = useFieldArray('users');
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+  arr.insert(0, '');
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+});
+
+test('array move noop when path is not an array', async () => {
+  let arr!: FieldArrayContext;
+  mountWithHoc({
+    setup() {
+      useForm<any>({
+        initialValues: {
+          users: 'test',
+        },
+        validationSchema: yup.object({
+          users: yup.array().of(yup.string().required().min(1)),
+        }),
+      });
+
+      arr = useFieldArray('users');
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+  arr.move(0, 1);
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+});
+
+test('array swap noop when path is not an array', async () => {
+  let arr!: FieldArrayContext;
+  mountWithHoc({
+    setup() {
+      useForm<any>({
+        initialValues: {
+          users: 'test',
+        },
+        validationSchema: yup.object({
+          users: yup.array().of(yup.string().required().min(1)),
+        }),
+      });
+
+      arr = useFieldArray('users');
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+  arr.swap(0, 1);
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+});
+
+test('array remove noop when path is not an array', async () => {
+  let arr!: FieldArrayContext;
+  mountWithHoc({
+    setup() {
+      useForm<any>({
+        initialValues: {
+          users: 'test',
+        },
+        validationSchema: yup.object({
+          users: yup.array().of(yup.string().required().min(1)),
+        }),
+      });
+
+      arr = useFieldArray('users');
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+  arr.remove(0);
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+});
+
+test('array update noop when path is not an array', async () => {
+  let arr!: FieldArrayContext;
+  mountWithHoc({
+    setup() {
+      useForm<any>({
+        initialValues: {
+          users: 'test',
+        },
+        validationSchema: yup.object({
+          users: yup.array().of(yup.string().required().min(1)),
+        }),
+      });
+
+      arr = useFieldArray('users');
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+  arr.update(0, '');
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+});
+
+test('array push initializes the array if undefined', async () => {
+  let arr!: FieldArrayContext;
+  mountWithHoc({
+    setup() {
+      useForm<any>({
+        initialValues: {
+          users: undefined,
+        },
+        validationSchema: yup.object({
+          users: yup.array().of(yup.string().required().min(1)),
+        }),
+      });
+
+      arr = useFieldArray('users');
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+  arr.push('');
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(1);
+});
+
+test('array prepend initializes the array if undefined', async () => {
+  let arr!: FieldArrayContext;
+  mountWithHoc({
+    setup() {
+      useForm<any>({
+        initialValues: {
+          users: undefined,
+        },
+        validationSchema: yup.object({
+          users: yup.array().of(yup.string().required().min(1)),
+        }),
+      });
+
+      arr = useFieldArray('users');
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+  arr.prepend('');
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(1);
+});
+
+test('array move initializes the array if undefined', async () => {
+  let arr!: FieldArrayContext;
+  mountWithHoc({
+    setup() {
+      useForm<any>({
+        initialValues: {
+          users: undefined,
+        },
+        validationSchema: yup.object({
+          users: yup.array().of(yup.string().required().min(1)),
+        }),
+      });
+
+      arr = useFieldArray('users');
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
+  arr.move(0, 0);
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(0);
 });


### PR DESCRIPTION
🔎 __Overview__

Previously, vee-validate used `FieldInstance` to track fields in memory and generate aggregated states based on their paths. This meant unless a field was created with `useField` it won't be tracked which limited a few use cases:

- `useModel` would be unconfigurable and has no meta.
- No concept of virtual fields which has no UI or anything similar.

This refactor redoes that part, the form will create path states and maintain itself. `useField` will mirror the path state with the same `path` as the field `name`. This means a few things will change:

- All fields sharing the same name will have the same meta state, this could be a minor breaking change but I have not seen any cases where you would track the `touched` state of a single checkbox within a group, if anything they should act as the same control.
- Faster mounting/unmounting process, field name changing like in a loop will also be more performant.
- Allows for more ways to create managed field paths.

 
