### PR TITLE
feat: Component and Input binds helpers

### DIFF
--- a/packages/vee-validate/src/index.ts
+++ b/packages/vee-validate/src/index.ts
@@ -31,6 +31,10 @@ export {
   RawFormSchema,
   Path,
   PublicPathState as PathState,
+  ComponentBindsConfig,
+  InputBindsConfig,
+  LazyComponentBindsConfig,
+  LazyInputBindsConfig,
 } from './types';
 export { useResetForm } from './useResetForm';
 export { useIsFieldDirty } from './useIsFieldDirty';

--- a/packages/vee-validate/src/index.ts
+++ b/packages/vee-validate/src/index.ts
@@ -30,6 +30,7 @@ export {
   TypedSchemaError,
   RawFormSchema,
   Path,
+  PublicPathState as PathState,
 } from './types';
 export { useResetForm } from './useResetForm';
 export { useIsFieldDirty } from './useIsFieldDirty';

--- a/packages/vee-validate/src/types/common.ts
+++ b/packages/vee-validate/src/types/common.ts
@@ -1,6 +1,7 @@
 import { Ref } from 'vue';
 import { Path, PathValue } from './paths';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type GenericObject = Record<string, any>;
 
 export type MaybeRef<T> = Ref<T> | T;

--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -1,5 +1,5 @@
 import { ComputedRef, Ref } from 'vue';
-import { MapValuesPathsToRefs, MaybeRef, GenericObject } from './common';
+import { MapValuesPathsToRefs, MaybeRef, GenericObject, MaybeRefOrLazy } from './common';
 import { FieldValidationMetaInfo } from '../../../shared';
 import { Path, PathValue } from './paths';
 
@@ -21,7 +21,7 @@ export interface TypedSchema<TInput = any, TOutput = TInput> {
 
 export type YupSchema<TValues = any> = {
   __isYupSchema__: boolean;
-  validate(value: any, options: Record<string, any>): Promise<any>;
+  validate(value: any, options: GenericObject): Promise<any>;
 };
 
 export type Locator = { __locatorRef: string } & ((values: GenericObject) => unknown);
@@ -35,7 +35,7 @@ export interface FieldMeta<TValue> {
   initialValue?: TValue;
 }
 
-export interface FormMeta<TValues extends Record<string, any>> {
+export interface FormMeta<TValues extends GenericObject> {
   touched: boolean;
   dirty: boolean;
   valid: boolean;
@@ -203,9 +203,9 @@ export type InvalidSubmissionHandler<TValues extends GenericObject = GenericObje
   ctx: InvalidSubmissionContext<TValues>
 ) => void;
 
-export type RawFormSchema<TValues> = Record<Path<TValues>, string | GenericValidateFunction | Record<string, any>>;
+export type RawFormSchema<TValues> = Record<Path<TValues>, string | GenericValidateFunction | GenericObject>;
 
-export type FieldPathLookup<TValues extends Record<string, any> = Record<string, any>> = Partial<
+export type FieldPathLookup<TValues extends GenericObject = GenericObject> = Partial<
   Record<Path<TValues>, PrivateFieldContext | PrivateFieldContext[]>
 >;
 
@@ -251,7 +251,38 @@ export interface PrivateFormContext<TValues extends GenericObject = GenericObjec
   unsetPathValue<TPath extends Path<TValues>>(path: TPath): void;
 }
 
-export interface FormContext<TValues extends Record<string, any> = Record<string, any>, TOutput = TValues>
+export interface BaseComponentBinds<TValue> {
+  modelValue: TValue | undefined;
+  'onUpdate:modelValue': (value: TValue) => void;
+  onBlur: () => void;
+}
+
+export type PublicPathState<TValue = unknown> = Omit<
+  PathState<TValue>,
+  'bails' | 'label' | 'multiple' | 'fieldsCount' | 'validate' | 'id' | 'type'
+>;
+
+export interface ComponentBindsConfig<TValue, TExtraProps extends GenericObject = GenericObject> {
+  mapProps: (state: PublicPathState<TValue>) => TExtraProps;
+  validateOnBlur: boolean;
+  validateOnModelUpdate: boolean;
+}
+
+export interface BaseInputBinds<TValue> {
+  value: TValue | undefined;
+  onBlur: (e: Event) => void;
+  onChange: (e: Event) => void;
+  onInput: (e: Event) => void;
+}
+
+export interface InputBindsConfig<TValue, TExtraProps extends GenericObject = GenericObject> {
+  mapProps: (state: PublicPathState<TValue>) => TExtraProps;
+  validateOnBlur: boolean;
+  validateOnChange: boolean;
+  validateOnInput: boolean;
+}
+
+export interface FormContext<TValues extends GenericObject = GenericObject, TOutput = TValues>
   extends Omit<
     PrivateFormContext<TValues, TOutput>,
     | 'formId'
@@ -271,4 +302,20 @@ export interface FormContext<TValues extends Record<string, any> = Record<string
   > {
   handleReset: () => void;
   submitForm: (e?: unknown) => Promise<void>;
+  defineComponentBinds<
+    TPath extends Path<TValues>,
+    TValue = PathValue<TValues, TPath>,
+    TExtras extends GenericObject = GenericObject
+  >(
+    path: MaybeRefOrLazy<TPath>,
+    config?: Partial<ComponentBindsConfig<TValue, TExtras>>
+  ): Ref<BaseComponentBinds<TValue> & TExtras>;
+  defineInputBinds<
+    TPath extends Path<TValues>,
+    TValue = PathValue<TValues, TPath>,
+    TExtras extends GenericObject = GenericObject
+  >(
+    path: MaybeRefOrLazy<TPath>,
+    config?: Partial<InputBindsConfig<TValue, TExtras>>
+  ): Ref<BaseInputBinds<TValue> & TExtras>;
 }

--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -251,7 +251,7 @@ export interface PrivateFormContext<TValues extends GenericObject = GenericObjec
   unsetPathValue<TPath extends Path<TValues>>(path: TPath): void;
 }
 
-export interface BaseComponentBinds<TValue> {
+export interface BaseComponentBinds<TValue = unknown> {
   modelValue: TValue | undefined;
   'onUpdate:modelValue': (value: TValue) => void;
   onBlur: () => void;
@@ -262,25 +262,42 @@ export type PublicPathState<TValue = unknown> = Omit<
   'bails' | 'label' | 'multiple' | 'fieldsCount' | 'validate' | 'id' | 'type'
 >;
 
-export interface ComponentBindsConfig<TValue, TExtraProps extends GenericObject = GenericObject> {
+export interface ComponentBindsConfig<TValue = unknown, TExtraProps extends GenericObject = GenericObject> {
   mapProps: (state: PublicPathState<TValue>) => TExtraProps;
   validateOnBlur: boolean;
   validateOnModelUpdate: boolean;
 }
 
-export interface BaseInputBinds<TValue> {
+export type LazyComponentBindsConfig<TValue = unknown, TExtraProps extends GenericObject = GenericObject> = (
+  state: PublicPathState<TValue>
+) => Partial<{
+  props: TExtraProps;
+  validateOnBlur: boolean;
+  validateOnModelUpdate: boolean;
+}>;
+
+export interface BaseInputBinds<TValue = unknown> {
   value: TValue | undefined;
   onBlur: (e: Event) => void;
   onChange: (e: Event) => void;
   onInput: (e: Event) => void;
 }
 
-export interface InputBindsConfig<TValue, TExtraProps extends GenericObject = GenericObject> {
-  mapProps: (state: PublicPathState<TValue>) => TExtraProps;
+export interface InputBindsConfig<TValue = unknown, TExtraProps extends GenericObject = GenericObject> {
+  mapAttrs: (state: PublicPathState<TValue>) => TExtraProps;
   validateOnBlur: boolean;
   validateOnChange: boolean;
   validateOnInput: boolean;
 }
+
+export type LazyInputBindsConfig<TValue = unknown, TExtraProps extends GenericObject = GenericObject> = (
+  state: PublicPathState<TValue>
+) => Partial<{
+  attrs: TExtraProps;
+  validateOnBlur: boolean;
+  validateOnChange: boolean;
+  validateOnInput: boolean;
+}>;
 
 export interface FormContext<TValues extends GenericObject = GenericObject, TOutput = TValues>
   extends Omit<
@@ -308,7 +325,7 @@ export interface FormContext<TValues extends GenericObject = GenericObject, TOut
     TExtras extends GenericObject = GenericObject
   >(
     path: MaybeRefOrLazy<TPath>,
-    config?: Partial<ComponentBindsConfig<TValue, TExtras>>
+    config?: Partial<ComponentBindsConfig<TValue, TExtras>> | LazyComponentBindsConfig<TValue, TExtras>
   ): Ref<BaseComponentBinds<TValue> & TExtras>;
   defineInputBinds<
     TPath extends Path<TValues>,
@@ -316,6 +333,6 @@ export interface FormContext<TValues extends GenericObject = GenericObject, TOut
     TExtras extends GenericObject = GenericObject
   >(
     path: MaybeRefOrLazy<TPath>,
-    config?: Partial<InputBindsConfig<TValue, TExtras>>
+    config?: Partial<InputBindsConfig<TValue, TExtras>> | LazyInputBindsConfig<TValue, TExtras>
   ): Ref<BaseInputBinds<TValue> & TExtras>;
 }

--- a/packages/vee-validate/src/utils/common.ts
+++ b/packages/vee-validate/src/utils/common.ts
@@ -13,7 +13,7 @@ import {
 import { klona as deepCopy } from 'klona/full';
 import { isCallable, isIndex, isNullOrUndefined, isObject, toNumber } from '../../../shared';
 import { isContainerValue, isEmptyContainer, isEqual, isNotNestedPath } from './assertions';
-import { MaybeRef, MaybeRefOrLazy, PrivateFieldContext } from '../types';
+import { GenericObject, MaybeRef, MaybeRefOrLazy, PrivateFieldContext } from '../types';
 import { FormContextKey, FieldContextKey } from '../symbols';
 
 function cleanupNonNestedPath(path: string) {
@@ -325,4 +325,16 @@ export function resolveFieldOrPathState(path?: MaybeRef<string>) {
   }
 
   return state || field;
+}
+
+export function omit<TObj extends GenericObject>(obj: TObj, keys: (keyof GenericObject)[]) {
+  const target = {} as TObj;
+
+  for (const key in obj) {
+    if (!keys.includes(key)) {
+      target[key] = obj[key];
+    }
+  }
+
+  return target;
 }

--- a/packages/vee-validate/tests/helpers/ModelComp.ts
+++ b/packages/vee-validate/tests/helpers/ModelComp.ts
@@ -1,4 +1,6 @@
 export default {
-  props: ['value'],
-  template: `<input type="text" :value="value" @input="emit('input', $event)">`,
+  props: ['modelValue', 'test'],
+  emits: ['blur', 'update:modelValue'],
+  template: `<input type="text" :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" @blur="$emit('blur')">
+  <div v-if="test">{{ test }}</div>`,
 };

--- a/packages/yup/package.json
+++ b/packages/yup/package.json
@@ -28,9 +28,9 @@
     "dist/*.d.ts"
   ],
   "dependencies": {
-    "type-fest": "^3.6.1",
+    "type-fest": "^3.10.0",
     "vee-validate": "^4.8.6",
-    "yup": "^1.0.2"
+    "yup": "^1.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -28,7 +28,7 @@
     "dist/*.d.ts"
   ],
   "dependencies": {
-    "type-fest": "^3.6.1",
+    "type-fest": "^3.10.0",
     "vee-validate": "^4.8.6",
     "zod": "^3.21.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,20 +236,20 @@ importers:
   packages/yup:
     dependencies:
       type-fest:
-        specifier: ^3.6.1
-        version: 3.6.1
+        specifier: ^3.10.0
+        version: 3.10.0(typescript@5.0.4)
       vee-validate:
         specifier: ^4.8.6
         version: link:../vee-validate
       yup:
-        specifier: ^1.0.2
-        version: 1.0.2
+        specifier: ^1.1.1
+        version: 1.1.1
 
   packages/zod:
     dependencies:
       type-fest:
-        specifier: ^3.6.1
-        version: 3.6.1
+        specifier: ^3.10.0
+        version: 3.10.0(typescript@5.0.4)
       vee-validate:
         specifier: ^4.8.6
         version: link:../vee-validate
@@ -10576,12 +10576,6 @@ packages:
       typescript: '>=4.7.0'
     dependencies:
       typescript: 5.0.4
-    dev: true
-
-  /type-fest@3.6.1:
-    resolution: {integrity: sha512-htXWckxlT6U4+ilVgweNliPqlsVSSucbxVexRYllyMVJDtf5rTjv6kF/s+qAd4QSL1BZcnJPEJavYBPQiWuZDA==}
-    engines: {node: '>=14.16'}
-    dev: false
 
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
@@ -11683,15 +11677,6 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
-  /yup@1.0.2:
-    resolution: {integrity: sha512-Lpi8nITFKjWtCoK3yQP8MUk78LJmHWqbFd0OOMXTar+yjejlQ4OIIoZgnTW1bnEUKDw6dZBcy3/IdXnt2KDUow==}
-    dependencies:
-      property-expr: 2.0.5
-      tiny-case: 1.0.3
-      toposort: 2.0.2
-      type-fest: 2.19.0
-    dev: false
-
   /yup@1.1.1:
     resolution: {integrity: sha512-KfCGHdAErqFZWA5tZf7upSUnGKuTOnsI3hUsLr7fgVtx+DK04NPV01A68/FslI4t3s/ZWpvXJmgXhd7q6ICnag==}
     dependencies:
@@ -11699,7 +11684,6 @@ packages:
       tiny-case: 1.0.3
       toposort: 2.0.2
       type-fest: 2.19.0
-    dev: true
 
   /zhead@2.0.4:
     resolution: {integrity: sha512-V4R94t3ifk9AURym6OskbKcnowzgp5Z88tkoL/NF67vyryNxC62u6mx5F1Ux4oh4+YN7FFmKYEyWy6m5kfPH6g==}


### PR DESCRIPTION
🔎 __Overview__

This builds on the refactor of #4238 and adds a new couple of functions:

### component binds

Generates a bindable object that can be bound with `v-bind` directly to any component given it implements the `v-model` interface.

This means much easier component and 3rd party component integrations without the need to ever wrap it.

Example with Vuetify:

```vue
<script>
const schema = toTypedSchema(yup.object({
  email: yup.string().email().required().label('E-mail'),
  password: yup.string().min(6).required(),
}));

const { defineComponentBinds } = useForm({
  validationSchema: schema
});

const email = defineComponentBinds('email');
const password = defineComponentBinds('password');
</script>

<template>
  <v-text-field
    v-bind="email"
    label="email"
    type="email"
  />

  <v-text-field
    v-bind="password"
    label="password"
    type="password"
   />
</template>
```

Furthermore you can add extra properties to be mapped as well like this:

```ts
const vuetifyProps = (state: PathState) => {
  return {
    'error-messages': state.errors
  }
}

const email = defineComponentBinds('email', vuetifyProps);
const password = defineComponentBinds('password', vuetifyProps);
```

And for more fine-grained control over when to validate with components, you can pass a config object:

```ts
const name = defineComponentBinds('name', {
  validateOnModelUpdate: false,
  validateOnBlur: true,
  mapProps: vuetifyProps
});
```

### input binds

Exactly the same thing but for native HTML elements.

## Motivation

The reason for this is to provide a viable alternative to `useFieldModel` which doesn't have any kind of flexibility in that regard and avoid forcing the use of `useField` as state tracker.

Now you can avoid using `useField` at all and use these methods available on `useForm` instead.