### PR TITLE
Add `componentField` to Field's slot

### DIFF
--- a/docs/src/pages/api/field.mdx
+++ b/docs/src/pages/api/field.mdx
@@ -329,3 +329,7 @@ An array containing a few listeners for the `input` event, it involves updating 
 </CodeTitle>
 
 An array containing a few listeners for the `change` event, it involves updating the field value and triggering validation.
+
+#### `componentField`
+
+Same as `field`, but provides value as `modelValue` to use with components

--- a/packages/vee-validate/tests/helpers/ModelComp.ts
+++ b/packages/vee-validate/tests/helpers/ModelComp.ts
@@ -1,6 +1,7 @@
 export default {
-  props: ['modelValue', 'test'],
+  props: ['modelValue', 'name', 'test'],
   emits: ['blur', 'update:modelValue'],
-  template: `<input type="text" :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" @blur="$emit('blur')">
+  inheritAttrs: false,
+  template: `<input type="text" :name="name" :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" @blur="$emit('blur')">
   <div v-if="test">{{ test }}</div>`,
 };


### PR DESCRIPTION
🔎 __Overview__

This PR adds an ability to easily bind all useful props to complex components, same as it currently works with native elements.

🤓 __Code snippets/examples (if applicable)__

```vue
<Field name="name" v-slot="{ componentField }">
  <ComplexInput v-bind="componentField" /> // some component that expects value to be set as `modelValue` prop
</Field>
```

I was looking for such feature, as it's a bit tedious and too verbose binding all props / listeners to custom components manually. Probably there is already an easy solution that I've missed?
 
