### PR TITLE
docs: clarify meaning of meta.valid

### DIFF
--- a/docs/src/pages/api/use-field.mdx
+++ b/docs/src/pages/api/use-field.mdx
@@ -130,7 +130,7 @@ interface FieldState<TValue = unknown> {
 export interface FieldMeta<TValue> {
   touched: boolean; // field was blurred or attempted submit
   dirty: boolean; // field value was changed
-  valid: boolean; // field passed all validations
+  valid: boolean; // field doesn't have any errors
   validated: boolean; // field was validated via user input
   pending: boolean; // field is pending validation
   initialValue: TValue | undefined; // initial field value
@@ -234,7 +234,7 @@ Combining your `valid` flag checks with `dirty` will yield the expected result b
 ```js
 const { meta } = useField('field', value => !!value);
 
-meta; // { valid: true, invalid: false, dirty: true, .... }
+meta; // { valid: true, dirty: true, .... }
 ```
 
 <CodeTitle level="4">


### PR DESCRIPTION
also removes mention of not existing `invalid` flag

🔎 __Overview__

As I said in https://github.com/logaretm/vee-validate/discussions/4271 I found this part to be confusing.

🤓 __Code snippets/examples (if applicable)__

```js
// some code
```

✔ __Issues affected__

<!-- list of issues formatted like this
closes #{issue id}
 -->
 
