### PR TITLE
docs: Add `validated` property to `FieldMeta`.

### DIFF
--- a/docs/src/pages/api/field.mdx
+++ b/docs/src/pages/api/field.mdx
@@ -172,6 +172,7 @@ interface FieldMeta {
   touched: boolean; // if the field has been blurred (via handleBlur)
   dirty: boolean; // if the field has been manipulated (via handleChange)
   valid: boolean; // if the field doesn't have any errors
+  validated: boolean; // if the field has been validated
   pending: boolean; // if validation is in progress
   initialValue?: any; // the field's initial value
 }


### PR DESCRIPTION
🔎 __Overview__

There is no `validated` property of `FieldMeta` on API Reference.

✔ __Issues affected__

<!-- list of issues formatted like this
closes #{issue id}
 -->
 
