### PR TITLE
feat: initial support for valibot

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,6 +10,7 @@
       "@vee-validate/rules",
       "@vee-validate/zod",
       "@vee-validate/yup",
+      "@vee-validate/valibot",
       "@vee-validate/nuxt"
     ]
   ],

--- a/.changeset/shiny-apricots-fix.md
+++ b/.changeset/shiny-apricots-fix.md
@@ -1,0 +1,5 @@
+---
+'@vee-validate/valibot': minor
+---
+
+feat: initial support for valibot

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist
 .DS_STORE
 
 lerna-debug.log
+packages/*/src/playground.ts

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@vee-validate/valibot",
+  "version": "4.10.8",
+  "description": "vee-validate integration with valibot schema validation",
+  "author": "Abdelrahman Awad <logaretm1@gmail.com>",
+  "license": "MIT",
+  "module": "dist/vee-validate-valibot.esm.js",
+  "unpkg": "dist/vee-validate-valibot.js",
+  "main": "dist/vee-validate-valibot.js",
+  "types": "dist/vee-validate-valibot.d.ts",
+  "homepage": "https://vee-validate.logaretm.com/v4/integrations/zod-schema-validation/",
+  "repository": {
+    "url": "https://github.com/logaretm/vee-validate.git",
+    "type": "git",
+    "directory": "packages/valibot"
+  },
+  "sideEffects": false,
+  "keywords": [
+    "VueJS",
+    "Vue",
+    "validation",
+    "validator",
+    "inputs",
+    "form"
+  ],
+  "files": [
+    "dist/*.js",
+    "dist/*.d.ts"
+  ],
+  "dependencies": {
+    "type-fest": "^4.0.0",
+    "valibot": "^0.5.0",
+    "vee-validate": "^4.10.8"
+  }
+}

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "type-fest": "^4.0.0",
-    "valibot": "^0.6.0",
+    "valibot": "^0.7.0",
     "vee-validate": "^4.10.8"
   }
 }

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "type-fest": "^4.0.0",
-    "valibot": "^0.5.0",
+    "valibot": "^0.6.0",
     "vee-validate": "^4.10.8"
   }
 }

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vee-validate/valibot",
-  "version": "4.10.8",
+  "version": "4.10.9",
   "description": "vee-validate integration with valibot schema validation",
   "author": "Abdelrahman Awad <logaretm1@gmail.com>",
   "license": "MIT",

--- a/packages/valibot/src/index.ts
+++ b/packages/valibot/src/index.ts
@@ -1,0 +1,61 @@
+import { PartialDeep } from 'type-fest';
+import type { TypedSchema, TypedSchemaError } from 'vee-validate';
+import { Output, Input, BaseSchema, safeParseAsync, parse, Issue } from 'valibot';
+import { normalizeFormPath } from '../../shared';
+
+export function toTypedSchema<
+  TSchema extends BaseSchema,
+  TOutput = Output<TSchema>,
+  TInput = PartialDeep<Input<TSchema>>,
+>(valibotSchema: TSchema): TypedSchema<TInput, TOutput> {
+  const schema: TypedSchema = {
+    __type: 'VVTypedSchema',
+    async parse(value) {
+      const result = await safeParseAsync(valibotSchema, value);
+      if (result.success) {
+        return {
+          value: result.data,
+          errors: [],
+        };
+      }
+
+      const errors: Record<string, TypedSchemaError> = {};
+      processIssues(result.error.issues, errors);
+
+      return {
+        errors: Object.values(errors),
+      };
+    },
+    cast(values) {
+      try {
+        return parse(valibotSchema, values);
+      } catch {
+        return values;
+      }
+    },
+  };
+
+  return schema;
+}
+
+function processIssues(issues: Issue[], errors: Record<string, TypedSchemaError>): void {
+  issues.forEach(issue => {
+    const path = normalizeFormPath((issue.path || []).map(p => p.key).join('.'));
+    if (issue.issues?.length) {
+      processIssues(
+        issue.issues.flatMap(ue => ue.issues || []),
+        errors,
+      );
+
+      if (!path) {
+        return;
+      }
+    }
+
+    if (!errors[path]) {
+      errors[path] = { errors: [], path };
+    }
+
+    errors[path].errors.push(issue.message);
+  });
+}

--- a/packages/valibot/tests/valibot.spec.ts
+++ b/packages/valibot/tests/valibot.spec.ts
@@ -1,0 +1,369 @@
+import { Ref } from 'vue';
+import { useField, useForm } from '@/vee-validate';
+import { string, minLength, email as emailV, object, coerce, any, number, useDefault, optional } from 'valibot';
+import { toTypedSchema } from '@/valibot';
+import { mountWithHoc, flushPromises, setValue } from 'vee-validate/tests/helpers';
+
+const REQUIRED_MSG = 'field is required';
+const MIN_MSG = 'field is too short';
+const EMAIL_MSG = 'field must be a valid email';
+
+describe('valibot', () => {
+  test('validates typed field with valibot', async () => {
+    const wrapper = mountWithHoc({
+      setup() {
+        const schema = string([minLength(1, REQUIRED_MSG), minLength(8, MIN_MSG)]);
+        const rules = toTypedSchema(schema);
+        const { value, errorMessage } = useField('test', rules);
+
+        return {
+          value,
+          errorMessage,
+        };
+      },
+      template: `
+      <div>
+          <input v-model="value" type="text">
+          <p>{{ errorMessage }}</p>
+      </div>
+    `,
+    });
+
+    const input = wrapper.$el.querySelector('input');
+    const error = wrapper.$el.querySelector('p');
+
+    setValue(input, '');
+    await flushPromises();
+    expect(error.textContent).toBe(REQUIRED_MSG);
+    setValue(input, '12');
+    await flushPromises();
+    expect(error.textContent).toBe(MIN_MSG);
+    setValue(input, '12345678');
+    await flushPromises();
+    expect(error.textContent).toBe('');
+  });
+
+  // TODO: Does not seem to be supported at the moment.
+  test.skip('generates multiple errors for any given field', async () => {
+    let errors!: Ref<string[]>;
+    const wrapper = mountWithHoc({
+      setup() {
+        const schema = string([minLength(1, REQUIRED_MSG), minLength(8, MIN_MSG)]);
+        const rules = toTypedSchema(schema);
+        const { value, errors: fieldErrors } = useField('test', rules);
+
+        errors = fieldErrors;
+        return {
+          value,
+        };
+      },
+      template: `
+      <div>
+          <input v-model="value" type="text">
+      </div>
+    `,
+    });
+
+    const input = wrapper.$el.querySelector('input');
+
+    setValue(input, '');
+    await flushPromises();
+    expect(errors.value).toHaveLength(2);
+    expect(errors.value).toEqual([REQUIRED_MSG, MIN_MSG]);
+  });
+
+  // TODO: Does not seem supported at the moment.
+  test.skip('shows multiple errors using error bag', async () => {
+    const wrapper = mountWithHoc({
+      setup() {
+        const schema = toTypedSchema(
+          object({
+            email: string([emailV(EMAIL_MSG), minLength(7, MIN_MSG)]),
+            password: string([minLength(8, MIN_MSG)]),
+          }),
+        );
+
+        const { useFieldModel, errorBag } = useForm({
+          validationSchema: schema,
+          validateOnMount: true,
+        });
+
+        const [email, password] = useFieldModel(['email', 'password']);
+
+        return {
+          schema,
+          email,
+          password,
+          errorBag,
+        };
+      },
+      template: `
+      <div>
+        <input id="email" name="email" v-model="email" />
+        <span id="emailErr">{{ errorBag.email?.join(',') }}</span>
+
+        <input id="password" name="password" type="password" v-model="password" />
+        <span id="passwordErr">{{ errorBag.password?.join(',') }}</span>
+      </div>
+    `,
+    });
+
+    const email = wrapper.$el.querySelector('#email');
+    const password = wrapper.$el.querySelector('#password');
+    const emailError = wrapper.$el.querySelector('#emailErr');
+    const passwordError = wrapper.$el.querySelector('#passwordErr');
+
+    await flushPromises();
+
+    setValue(email, 'hello@');
+    setValue(password, '1234');
+    await flushPromises();
+
+    expect(emailError.textContent).toBe([EMAIL_MSG, MIN_MSG].join(','));
+    expect(passwordError.textContent).toBe([MIN_MSG].join(','));
+
+    setValue(email, 'hello@email.com');
+    setValue(password, '12346789');
+    await flushPromises();
+
+    expect(emailError.textContent).toBe('');
+    expect(passwordError.textContent).toBe('');
+  });
+
+  test('validates typed schema form with valibot', async () => {
+    const wrapper = mountWithHoc({
+      setup() {
+        const schema = toTypedSchema(
+          object({
+            email: string([emailV(EMAIL_MSG), minLength(1, MIN_MSG)]),
+            password: string([minLength(8, MIN_MSG)]),
+          }),
+        );
+
+        const { useFieldModel, errors } = useForm({
+          validationSchema: schema,
+          validateOnMount: true,
+        });
+
+        const [email, password] = useFieldModel(['email', 'password']);
+
+        return {
+          schema,
+          email,
+          password,
+          errors,
+        };
+      },
+      template: `
+    <div>
+      <input id="email" name="email" v-model="email" />
+      <span id="emailErr">{{ errors.email }}</span>
+
+      <input id="password" name="password" type="password" v-model="password" />
+      <span id="passwordErr">{{ errors.password }}</span>
+    </div>
+    `,
+    });
+
+    const email = wrapper.$el.querySelector('#email');
+    const password = wrapper.$el.querySelector('#password');
+    const emailError = wrapper.$el.querySelector('#emailErr');
+    const passwordError = wrapper.$el.querySelector('#passwordErr');
+
+    await flushPromises();
+
+    setValue(email, 'hello');
+    setValue(password, '1234');
+    await flushPromises();
+
+    expect(emailError.textContent).toBe(EMAIL_MSG);
+    expect(passwordError.textContent).toBe(MIN_MSG);
+
+    setValue(email, 'hello@email.com');
+    setValue(password, '12346789');
+    await flushPromises();
+
+    expect(emailError.textContent).toBe('');
+    expect(passwordError.textContent).toBe('');
+  });
+
+  test('uses valibot for form values transformations and parsing', async () => {
+    const submitSpy = vi.fn();
+    mountWithHoc({
+      setup() {
+        const schema = toTypedSchema(
+          object({
+            age: coerce(any(), v => Number(v)),
+          }),
+        );
+
+        const { handleSubmit } = useForm({
+          validationSchema: schema,
+          initialValues: { age: '11' },
+        });
+
+        // submit now
+        handleSubmit(submitSpy)();
+
+        return {
+          schema,
+        };
+      },
+      template: `<div></div>`,
+    });
+
+    await flushPromises();
+    await expect(submitSpy).toHaveBeenCalledTimes(1);
+    await expect(submitSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        age: 11,
+      }),
+      expect.anything(),
+    );
+  });
+
+  test('uses valibot default values for submission', async () => {
+    const submitSpy = vi.fn();
+
+    mountWithHoc({
+      setup() {
+        const schema = toTypedSchema(
+          object({
+            age: useDefault(number(), 11),
+          }),
+        );
+
+        const { handleSubmit } = useForm({
+          validationSchema: schema,
+        });
+
+        // submit now
+        handleSubmit(submitSpy)();
+
+        return {
+          schema,
+        };
+      },
+      template: `<div></div>`,
+    });
+
+    await flushPromises();
+    await expect(submitSpy).toHaveBeenCalledTimes(1);
+    await expect(submitSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        age: 11,
+      }),
+      expect.anything(),
+    );
+  });
+
+  test('uses valibot default values for initial values', async () => {
+    const initialSpy = vi.fn();
+    mountWithHoc({
+      setup() {
+        const schema = toTypedSchema(
+          object({
+            name: useDefault(string(), 'test'),
+            age: useDefault(number(), 11),
+            unknownKey: optional(string()),
+            object: useDefault(
+              object({
+                nestedKey: optional(string()),
+                nestedDefault: useDefault(string(), 'nested'),
+              }),
+              {} as any,
+            ),
+          }),
+        );
+
+        const { values } = useForm({
+          validationSchema: schema,
+        });
+
+        // submit now
+        initialSpy(values);
+
+        return {
+          schema,
+        };
+      },
+      template: `<div></div>`,
+    });
+
+    await flushPromises();
+    await expect(initialSpy).toHaveBeenCalledTimes(1);
+    await expect(initialSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        age: 11,
+        name: 'test',
+        object: {
+          nestedDefault: 'nested',
+        },
+      }),
+    );
+  });
+
+  test('reset form should cast the values', async () => {
+    const valueSpy = vi.fn();
+    mountWithHoc({
+      setup() {
+        const schema = toTypedSchema(
+          object({
+            age: coerce(any(), arg => Number(arg)),
+          }),
+        );
+
+        const { values, resetForm } = useForm({
+          validationSchema: schema,
+        });
+
+        resetForm({ values: { age: '12' } });
+        // submit now
+        valueSpy(values);
+
+        return {
+          schema,
+        };
+      },
+      template: `<div></div>`,
+    });
+
+    await flushPromises();
+    await expect(valueSpy).toHaveBeenCalledTimes(1);
+    await expect(valueSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        age: 12,
+      }),
+    );
+  });
+
+  // #4186
+  test('default values should not be undefined', async () => {
+    const initialSpy = vi.fn();
+    mountWithHoc({
+      setup() {
+        const schema = toTypedSchema(
+          object({
+            email: string([minLength(1)]),
+          }),
+        );
+
+        const { values } = useForm({
+          validationSchema: schema,
+        });
+
+        // submit now
+        initialSpy(values);
+
+        return {
+          schema,
+        };
+      },
+      template: `<div></div>`,
+    });
+
+    await flushPromises();
+    await expect(initialSpy).toHaveBeenCalledTimes(1);
+    await expect(initialSpy).toHaveBeenLastCalledWith(expect.objectContaining({}));
+  });
+});

--- a/packages/valibot/tests/valibot.spec.ts
+++ b/packages/valibot/tests/valibot.spec.ts
@@ -2,7 +2,7 @@ import { Ref } from 'vue';
 import { useField, useForm } from '@/vee-validate';
 import { string, minLength, email as emailV, object, coerce, any, number, useDefault, optional } from 'valibot';
 import { toTypedSchema } from '@/valibot';
-import { mountWithHoc, flushPromises, setValue } from 'vee-validate/tests/helpers';
+import { mountWithHoc, flushPromises, setValue } from '../../vee-validate/tests/helpers';
 
 const REQUIRED_MSG = 'field is required';
 const MIN_MSG = 'field is too short';
@@ -43,8 +43,7 @@ describe('valibot', () => {
     expect(error.textContent).toBe('');
   });
 
-  // TODO: Does not seem to be supported at the moment.
-  test.skip('generates multiple errors for any given field', async () => {
+  test('generates multiple errors for any given field', async () => {
     let errors!: Ref<string[]>;
     const wrapper = mountWithHoc({
       setup() {
@@ -72,8 +71,7 @@ describe('valibot', () => {
     expect(errors.value).toEqual([REQUIRED_MSG, MIN_MSG]);
   });
 
-  // TODO: Does not seem supported at the moment.
-  test.skip('shows multiple errors using error bag', async () => {
+  test('shows multiple errors using error bag', async () => {
     const wrapper = mountWithHoc({
       setup() {
         const schema = toTypedSchema(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,18 @@ importers:
         specifier: ^4.10.9
         version: link:../vee-validate
 
+  packages/valibot:
+    dependencies:
+      type-fest:
+        specifier: ^4.0.0
+        version: 4.0.0
+      valibot:
+        specifier: ^0.5.0
+        version: 0.5.0
+      vee-validate:
+        specifier: ^4.10.8
+        version: link:../vee-validate
+
   packages/vee-validate:
     dependencies:
       '@vue/devtools-api':
@@ -11649,6 +11661,10 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
     dev: true
+
+  /valibot@0.5.0:
+    resolution: {integrity: sha512-xjL/zMuQloTyK6sVzGO4HVg3AcPb970kIi2H3yMgl7gadBKKzepje31DWRyvOxhXJnIrFX8rJM0mhkMcmWz4bg==}
+    dev: false
 
   /validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,11 +261,11 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       valibot:
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.7.0
+        version: 0.7.0
       vee-validate:
         specifier: ^4.10.8
-        version: link:../vee-validate
+        version: 4.10.9(vue@3.3.4)
 
   packages/vee-validate:
     dependencies:
@@ -936,13 +936,6 @@ packages:
       '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
-
-  /@babel/parser@7.21.8:
-    resolution: {integrity: sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.22.5
 
   /@babel/parser@7.22.5:
     resolution: {integrity: sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==}
@@ -3584,7 +3577,7 @@ packages:
   /@vue/compiler-core@3.3.4:
     resolution: {integrity: sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==}
     dependencies:
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.22.7
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
       source-map-js: 1.0.2
@@ -3598,15 +3591,15 @@ packages:
   /@vue/compiler-sfc@3.3.4:
     resolution: {integrity: sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==}
     dependencies:
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.22.7
       '@vue/compiler-core': 3.3.4
       '@vue/compiler-dom': 3.3.4
       '@vue/compiler-ssr': 3.3.4
       '@vue/reactivity-transform': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.1
-      postcss: 8.4.23
+      magic-string: 0.30.2
+      postcss: 8.4.27
       source-map-js: 1.0.2
 
   /@vue/compiler-ssr@3.3.4:
@@ -3621,11 +3614,11 @@ packages:
   /@vue/reactivity-transform@3.3.4:
     resolution: {integrity: sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==}
     dependencies:
-      '@babel/parser': 7.21.8
+      '@babel/parser': 7.22.7
       '@vue/compiler-core': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.1
+      magic-string: 0.30.2
 
   /@vue/reactivity@3.3.4:
     resolution: {integrity: sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==}
@@ -7532,6 +7525,12 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  /magic-string@0.30.2:
+    resolution: {integrity: sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
@@ -9622,14 +9621,6 @@ packages:
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  /postcss@8.4.23:
-    resolution: {integrity: sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.6
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
-
   /postcss@8.4.25:
     resolution: {integrity: sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -11662,8 +11653,8 @@ packages:
       convert-source-map: 1.9.0
     dev: true
 
-  /valibot@0.6.0:
-    resolution: {integrity: sha512-H2r15tWnHMTwCvPDN4EYBc+4ofgBjZ7J+zyJDUi1tPHhkmwDnZPPfGWtWswWU7dZqBuSovRDbZKvWPC2PExOrQ==}
+  /valibot@0.7.0:
+    resolution: {integrity: sha512-QNxqDtYuVUILZtWnLsfCEg4IXrhnIuwGIJlF7tmI8+gWgkB0ujzrXrl607rGmjwbxAhBevQ2RpNxmCO+isNYJg==}
     dev: false
 
   /validate-npm-package-license@3.0.4:
@@ -11672,6 +11663,16 @@ packages:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
     dev: true
+
+  /vee-validate@4.10.9(vue@3.3.4):
+    resolution: {integrity: sha512-owylPGQWtbcS5qoBmb+bZ0Agzl2DPhp6/aKlvIdLQ8ZpF2Ex9csTASweH2ErM3uys8qb0MbTjddGgkhn4aN/8w==}
+    peerDependencies:
+      vue: ^3.3.4
+    dependencies:
+      '@vue/devtools-api': 6.5.0
+      type-fest: 4.0.0
+      vue: 3.3.4
+    dev: false
 
   /vfile-location@4.1.0:
     resolution: {integrity: sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,8 +261,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       valibot:
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       vee-validate:
         specifier: ^4.10.8
         version: link:../vee-validate
@@ -11662,8 +11662,8 @@ packages:
       convert-source-map: 1.9.0
     dev: true
 
-  /valibot@0.5.0:
-    resolution: {integrity: sha512-xjL/zMuQloTyK6sVzGO4HVg3AcPb970kIi2H3yMgl7gadBKKzepje31DWRyvOxhXJnIrFX8rJM0mhkMcmWz4bg==}
+  /valibot@0.6.0:
+    resolution: {integrity: sha512-H2r15tWnHMTwCvPDN4EYBc+4ofgBjZ7J+zyJDUi1tPHhkmwDnZPPfGWtWswWU7dZqBuSovRDbZKvWPC2PExOrQ==}
     dev: false
 
   /validate-npm-package-license@3.0.4:

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -106,6 +106,10 @@ async function build(pkg) {
     await build('yup');
   }
 
+  if (arg === 'valibot' || !arg) {
+    await build('valibot');
+  }
+
   if (arg === 'nuxt' || !arg) {
     await build('nuxt');
   }

--- a/scripts/config.mjs
+++ b/scripts/config.mjs
@@ -15,6 +15,7 @@ const formatNameMap = {
   i18n: 'VeeValidateI18n',
   zod: 'VeeValidateZod',
   yup: 'VeeValidateYup',
+  valibot: 'VeeValidateValibot',
 };
 
 const pkgNameMap = {
@@ -23,6 +24,7 @@ const pkgNameMap = {
   i18n: 'vee-validate-i18n',
   zod: 'vee-validate-zod',
   yup: 'vee-validate-yup',
+  valibot: 'vee-validate-valibot',
 };
 
 const formatMap = {
@@ -49,7 +51,9 @@ async function createConfig(pkg, format) {
   const config = {
     input: {
       input: slashes(path.resolve(__dirname, `../packages/${pkg}/src/index.ts`)),
-      external: ['vue', isEsm ? '@vue/devtools-api' : undefined, 'zod', 'yup', 'vee-validate'].filter(Boolean),
+      external: ['vue', isEsm ? '@vue/devtools-api' : undefined, 'zod', 'yup', 'vee-validate', 'valibot'].filter(
+        Boolean,
+      ),
       plugins: [
         replace({
           preventAssignment: true,


### PR DESCRIPTION
🔎 __Overview__

[Valibot](https://github.com/fabian-hiller/valibot) seems like a nice addition especially since it is a small bundle-size alternative to yup and zod.

A few things I would like to ask/check with valibot team before releasing:

- [x] Does it support multiple messages per schema? For example both `min` and `email` error messages for a single string schema.
- [ ] Default typings seem dodgy in a case like this:


```ts
  const schema = object({
    name: useDefault(string(), 'test'),
    age: useDefault(number(), 11),
    unknownKey: optional(string()),
    object: useDefault(
      object({
        nestedKey: optional(string()),
        nestedDefault: useDefault(string(), 'nested'),
      }),
      {}, // <--- this has a type error even tho both keys are either optional or already have a default, which should make this object safe to be empty.
    ),
  });
```

closes #4390 