### PR TITLE
fix(guide): property 'required' does not exist on type 'ZodString'

### DIFF
--- a/docs/src/pages/guide/composition-api/getting-started.mdx
+++ b/docs/src/pages/guide/composition-api/getting-started.mdx
@@ -261,7 +261,7 @@ import { z } from 'zod';
 // Creates a typed schema for vee-validate
 const schema = toTypedSchema(
   z.object({
-    email: z.string().required().email(),
+    email: z.string().email(),
   }),
 );
 

--- a/docs/src/pages/guide/composition-api/getting-started.mdx
+++ b/docs/src/pages/guide/composition-api/getting-started.mdx
@@ -261,7 +261,7 @@ import { z } from 'zod';
 // Creates a typed schema for vee-validate
 const schema = toTypedSchema(
   z.object({
-    email: z.string().email(),
+    email: z.string().nonempty().email(),
   }),
 );
 


### PR DESCRIPTION
🔎 __Overview__

Fix [Validating with Zod](https://vee-validate.logaretm.com/v4/guide/composition-api/getting-started/#validating-with-zod) guide wrong example.

 
