### PR TITLE
chore: useSetFormValues TS Support

### DIFF
--- a/packages/vee-validate/src/useSetFormValues.ts
+++ b/packages/vee-validate/src/useSetFormValues.ts
@@ -4,10 +4,10 @@ import { injectWithSelf, warn } from './utils';
 /**
  * Sets multiple fields values
  */
-export function useSetFormValues() {
+export function useSetFormValues<TValues extends Record<string, unknown> = Record<string, unknown>>() {
   const form = injectWithSelf(FormContextKey);
 
-  function setFormValues(fields: Record<string, unknown>, shouldValidate = true) {
+  function setFormValues(fields: TValues, shouldValidate = true) {
     if (form) {
       form.setValues(fields, shouldValidate);
       return;


### PR DESCRIPTION
🔎 __Overview__


This PR Adds Typescript support for the `useSetFormValues` hook.

---


```ts
type Form = {
username:string
}

const setFormValues = useSetFormValues<Form>()

setFormValues({
username: 'johndoe' // we get TS autocomplete here
})
```

✔ __Issues affected__
 
