### PR TITLE
feat: path descriptors for typed schemas

### DIFF
--- a/packages/valibot/src/index.ts
+++ b/packages/valibot/src/index.ts
@@ -10,8 +10,10 @@ import {
   Issue,
   getDefault,
   optional,
+  ArraySchema,
+  ObjectSchema,
 } from 'valibot';
-import { isObject, merge, normalizeFormPath } from '../../shared';
+import { isIndex, isObject, merge, normalizeFormPath } from '../../shared';
 
 export function toTypedSchema<
   TSchema extends BaseSchema | BaseSchemaAsync,
@@ -53,6 +55,18 @@ export function toTypedSchema<
 
       return values;
     },
+    describe(path) {
+      const description = getSchemaForPath(path, valibotSchema);
+      if (!description) {
+        return {};
+      }
+
+      const isOptional = (description as any).type === 'optional';
+
+      return {
+        required: !isOptional,
+      };
+    },
   };
 
   return schema;
@@ -78,4 +92,38 @@ function processIssues(issues: Issue[], errors: Record<string, TypedSchemaError>
 
     errors[path].errors.push(issue.message);
   });
+}
+
+function getSchemaForPath(path: string, schema: any): BaseSchema | null {
+  if (!isObjectSchema(schema)) {
+    return null;
+  }
+
+  const paths = (path || '').split(/\.|\[(\d+)\]/).filter(Boolean);
+
+  let currentSchema: BaseSchema = schema;
+  for (let i = 0; i < paths.length; i++) {
+    const p = paths[i];
+    if (isObjectSchema(currentSchema) && p in currentSchema.entries) {
+      currentSchema = currentSchema.entries[p];
+    }
+
+    if (isIndex(p) && isArraySchema(currentSchema)) {
+      currentSchema = currentSchema.item;
+    }
+
+    if (i === paths.length - 1) {
+      return currentSchema;
+    }
+  }
+
+  return null;
+}
+
+function isArraySchema(schema: unknown): schema is ArraySchema<any> {
+  return isObject(schema) && schema.type === 'array';
+}
+
+function isObjectSchema(schema: unknown): schema is ObjectSchema<any> {
+  return isObject(schema) && schema.type === 'object';
 }

--- a/packages/vee-validate/src/index.ts
+++ b/packages/vee-validate/src/index.ts
@@ -1,7 +1,7 @@
 export { validate, validateObjectSchema as validateObject } from './validate';
 export { defineRule } from './defineRule';
 export { configure } from './config';
-export { normalizeRules } from './utils';
+export { normalizeRules, isNotNestedPath, cleanupNonNestedPath } from './utils';
 export { Field } from './Field';
 export { Form } from './Form';
 export { FieldArray } from './FieldArray';

--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -13,11 +13,15 @@ export interface TypedSchemaError {
   path?: string;
   errors: string[];
 }
+export interface TypedSchemaPathDescription {
+  required: boolean;
+}
 
 export interface TypedSchema<TInput = any, TOutput = TInput> {
   __type: 'VVTypedSchema';
   parse(values: TInput): Promise<{ value?: TOutput; errors: TypedSchemaError[] }>;
   cast?(values: Partial<TInput>): TInput;
+  describe?(path: Path<TInput>): Partial<TypedSchemaPathDescription>;
 }
 
 export type InferOutput<TSchema extends TypedSchema> = TSchema extends TypedSchema<any, infer TOutput>
@@ -39,6 +43,7 @@ export interface FieldMeta<TValue> {
   dirty: boolean;
   valid: boolean;
   validated: boolean;
+  required: boolean;
   pending: boolean;
   initialValue?: TValue;
 }
@@ -87,6 +92,7 @@ export interface PathState<TValue = unknown> {
   touched: boolean;
   dirty: boolean;
   valid: boolean;
+  required: boolean;
   validated: boolean;
   pending: boolean;
   initialValue: TValue | undefined;

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -298,6 +298,9 @@ export function useForm<
       pending: false,
       valid: true,
       validated: !!initialErrors[pathValue]?.length,
+      required: computed(() =>
+        isTypedSchema(schema) ? (schema as TypedSchema).describe?.(toValue(path)).required ?? false : false,
+      ),
       initialValue,
       errors: shallowRef([]),
       bails: config?.bails ?? false,

--- a/packages/vee-validate/src/utils/common.ts
+++ b/packages/vee-validate/src/utils/common.ts
@@ -17,7 +17,7 @@ import { isContainerValue, isEmptyContainer, isEqual, isNotNestedPath } from './
 import { GenericObject, MaybePromise } from '../types';
 import { FormContextKey, FieldContextKey } from '../symbols';
 
-function cleanupNonNestedPath(path: string) {
+export function cleanupNonNestedPath(path: string) {
   if (isNotNestedPath(path)) {
     return path.replace(/\[|\]/gi, '');
   }

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -763,7 +763,7 @@ describe('useForm()', () => {
 
   // #4320
   test('Initial values are merged with previous values to ensure meta.dirty is stable', async () => {
-    let meta!: Ref<FieldMeta<any>>;
+    let meta!: Ref<FormMeta<any>>;
 
     mountWithHoc({
       setup() {

--- a/packages/yup/src/index.ts
+++ b/packages/yup/src/index.ts
@@ -1,7 +1,15 @@
-import { AnyObjectSchema, InferType, Schema, SchemaFieldDescription, ValidateOptions, ValidationError } from 'yup';
+import {
+  AnyObjectSchema,
+  ArraySchema,
+  InferType,
+  Schema,
+  SchemaFieldDescription,
+  ValidateOptions,
+  ValidationError,
+} from 'yup';
 import { TypedSchema, TypedSchemaError } from 'vee-validate';
 import { PartialDeep } from 'type-fest';
-import { isObject, merge } from '../../shared';
+import { isIndex, isObject, merge } from '../../shared';
 import { cleanupNonNestedPath, isNotNestedPath } from '@/vee-validate';
 
 export function toTypedSchema<TSchema extends Schema, TOutput = InferType<TSchema>, TInput = PartialDeep<TOutput>>(
@@ -100,6 +108,8 @@ function getDescriptionForPath(path: string, schema: AnyObjectSchema): SchemaFie
     const p = paths[i];
     if (isObjectSchema(currentSchema) && p in currentSchema.fields) {
       currentSchema = currentSchema.fields[p] as AnyObjectSchema;
+    } else if (isIndex(p) && isArraySchema(currentSchema)) {
+      currentSchema = currentSchema.innerType as AnyObjectSchema;
     }
 
     if (i === paths.length - 1) {
@@ -112,4 +122,8 @@ function getDescriptionForPath(path: string, schema: AnyObjectSchema): SchemaFie
 
 function isObjectSchema(schema: unknown): schema is AnyObjectSchema {
   return isObject(schema) && schema.type === 'object';
+}
+
+function isArraySchema(schema: unknown): schema is ArraySchema<any, any> {
+  return isObject(schema) && schema.type === 'array';
 }

--- a/packages/yup/src/index.ts
+++ b/packages/yup/src/index.ts
@@ -1,7 +1,8 @@
-import { InferType, Schema, ValidateOptions, ValidationError } from 'yup';
+import { AnyObjectSchema, InferType, Schema, SchemaFieldDescription, ValidateOptions, ValidationError } from 'yup';
 import { TypedSchema, TypedSchemaError } from 'vee-validate';
 import { PartialDeep } from 'type-fest';
 import { isObject, merge } from '../../shared';
+import { cleanupNonNestedPath, isNotNestedPath } from '@/vee-validate';
 
 export function toTypedSchema<TSchema extends Schema, TOutput = InferType<TSchema>, TInput = PartialDeep<TOutput>>(
   yupSchema: TSchema,
@@ -60,7 +61,55 @@ export function toTypedSchema<TSchema extends Schema, TOutput = InferType<TSchem
         return values;
       }
     },
+    describe(path) {
+      if (!isObjectSchema(yupSchema)) {
+        return {};
+      }
+
+      const description = getDescriptionForPath(path, yupSchema);
+      if (!description || !('tests' in description)) {
+        return {};
+      }
+
+      const required = description?.tests?.some(t => t.name === 'required') || false;
+
+      return {
+        required,
+      };
+    },
   };
 
   return schema;
+}
+
+function getDescriptionForPath(path: string, schema: AnyObjectSchema): SchemaFieldDescription | null {
+  if (!isObjectSchema(schema)) {
+    return null;
+  }
+
+  if (isNotNestedPath(path)) {
+    const field = schema.fields[cleanupNonNestedPath(path)];
+
+    return field?.describe() || null;
+  }
+
+  const paths = (path || '').split(/\.|\[(\d+)\]/).filter(Boolean);
+
+  let currentSchema = schema;
+  for (let i = 0; i < paths.length; i++) {
+    const p = paths[i];
+    if (isObjectSchema(currentSchema) && p in currentSchema.fields) {
+      currentSchema = currentSchema.fields[p] as AnyObjectSchema;
+    }
+
+    if (i === paths.length - 1) {
+      return currentSchema.describe();
+    }
+  }
+
+  return null;
+}
+
+function isObjectSchema(schema: unknown): schema is AnyObjectSchema {
+  return isObject(schema) && schema.type === 'object';
 }

--- a/packages/yup/tests/yup.spec.ts
+++ b/packages/yup/tests/yup.spec.ts
@@ -330,6 +330,7 @@ test('reports required state on fields', async () => {
           name: yup.string(),
           email: yup.string().required(),
           nested: yup.object({
+            arr: yup.array().of(yup.object({ req: yup.string().required(), nreq: yup.string() })),
             obj: yup.object({
               req: yup.string().required(),
               nreq: yup.string(),
@@ -346,12 +347,16 @@ test('reports required state on fields', async () => {
       const { meta: email } = useField('email');
       const { meta: req } = useField('nested.obj.req');
       const { meta: nreq } = useField('nested.obj.nreq');
+      const { meta: arrReq } = useField('nested.arr.0.req');
+      const { meta: arrNreq } = useField('nested.arr.1.nreq');
 
       metaSpy({
         name: name.required,
         email: email.required,
         objReq: req.required,
         objNreq: nreq.required,
+        arrReq: arrReq.required,
+        arrNreq: arrNreq.required,
       });
 
       return {
@@ -368,6 +373,8 @@ test('reports required state on fields', async () => {
       email: true,
       objReq: true,
       objNreq: false,
+      arrReq: true,
+      arrNreq: false,
     }),
   );
 });

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,7 +1,19 @@
-import { ZodObject, input, output, ZodDefault, ZodSchema, ParseParams, ZodIssue } from 'zod';
+import {
+  ZodObject,
+  input,
+  output,
+  ZodDefault,
+  ZodSchema,
+  ParseParams,
+  ZodIssue,
+  AnyZodObject,
+  ZodArrayDef,
+  ZodArray,
+  ZodFirstPartyTypeKind,
+} from 'zod';
 import { PartialDeep } from 'type-fest';
 import type { TypedSchema, TypedSchemaError } from 'vee-validate';
-import { isObject, merge, normalizeFormPath } from '../../shared';
+import { isIndex, isObject, merge, normalizeFormPath } from '../../shared';
 
 /**
  * Transforms a Zod object schema to Yup's schema
@@ -41,6 +53,16 @@ export function toTypedSchema<
 
         return values;
       }
+    },
+    describe(path) {
+      const description = getDescriptionForPath(path, zodSchema);
+      if (!description) {
+        return {};
+      }
+
+      return {
+        required: !description.isOptional(),
+      };
     },
   };
 
@@ -102,3 +124,41 @@ const toFieldValidator = toTypedSchema;
 const toFormValidator = toTypedSchema;
 
 export { toFieldValidator, toFormValidator };
+
+function getDescriptionForPath(path: string, schema: ZodSchema): ZodSchema | null {
+  if (!isObjectSchema(schema)) {
+    return null;
+  }
+
+  const paths = (path || '').split(/\.|\[(\d+)\]/).filter(Boolean);
+
+  let currentSchema: ZodSchema = schema;
+  for (let i = 0; i < paths.length; i++) {
+    const p = paths[i];
+    if (isObjectSchema(currentSchema) && p in currentSchema.shape) {
+      currentSchema = currentSchema.shape[p];
+    }
+
+    if (isIndex(p) && isArraySchema(currentSchema)) {
+      currentSchema = (currentSchema._def as ZodArrayDef).type;
+    }
+
+    if (i === paths.length - 1) {
+      return currentSchema;
+    }
+  }
+
+  return null;
+}
+
+function getDefType(schema: ZodSchema) {
+  return (schema._def as any).typeName as ZodFirstPartyTypeKind;
+}
+
+function isArraySchema(schema: ZodSchema): schema is ZodArray<any, any> {
+  return getDefType(schema) === ZodFirstPartyTypeKind.ZodArray;
+}
+
+function isObjectSchema(schema: ZodSchema): schema is AnyZodObject {
+  return getDefType(schema) === ZodFirstPartyTypeKind.ZodObject;
+}

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -55,7 +55,7 @@ export function toTypedSchema<
       }
     },
     describe(path) {
-      const description = getDescriptionForPath(path, zodSchema);
+      const description = getSchemaForPath(path, zodSchema);
       if (!description) {
         return {};
       }
@@ -125,7 +125,7 @@ const toFormValidator = toTypedSchema;
 
 export { toFieldValidator, toFormValidator };
 
-function getDescriptionForPath(path: string, schema: ZodSchema): ZodSchema | null {
+function getSchemaForPath(path: string, schema: ZodSchema): ZodSchema | null {
   if (!isObjectSchema(schema)) {
     return null;
   }


### PR DESCRIPTION
# What

This is preliminary support for "descriptors" for fields, which would report certain things from the schema like the field's required state for now.

I will need to support both object and array paths descriptors for the 3 main schema providers:

- [x] Yup
- [x] Zod
- [x] Valibot

