### PR TITLE
fix: check if the target is POJO before attempted merge

### DIFF
--- a/packages/shared/utils.ts
+++ b/packages/shared/utils.ts
@@ -51,7 +51,7 @@ export function isPlainObject(value: any) {
 
 export function merge(target: any, source: any) {
   Object.keys(source).forEach(key => {
-    if (isPlainObject(source[key])) {
+    if (isPlainObject(source[key]) && isPlainObject(target[key])) {
       if (!target[key]) {
         target[key] = {};
       }

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -1398,4 +1398,31 @@ describe('useForm()', () => {
     await flushPromises();
     await expect(form.errors.value.fname).toBe(undefined);
   });
+
+  test('checks if both source and target are POJO before setting properties', async () => {
+    let form!: FormContext<{ file: { name: string; size: number } }>;
+    const f1 = new File([''], 'f1.text');
+    const f2 = { name: 'f2.text', size: 123 };
+
+    mountWithHoc({
+      setup() {
+        form = useForm({
+          initialValues: { file: f1 },
+        });
+
+        form.defineField('file');
+
+        return {};
+      },
+      template: `
+        <div></div>
+      `,
+    });
+
+    await flushPromises();
+    expect(form.values.file).toBeInstanceOf(File);
+    expect(form.values.file).toBe(f1);
+    form.setValues({ file: f2 });
+    expect(form.values.file).toEqual(f2);
+  });
 });


### PR DESCRIPTION
# What

Fixes an issue where a target value is a POJO but the source value is not. This fix checks if both are POJOs before attempting to merge them.

This previously would've have caused crashes with Blob or File or any other JS builtin.