### PR TITLE
fix: typo in documentation (custom-inputs.mdx)

### DIFF
--- a/docs/src/pages/guide/composition-api/custom-inputs.mdx
+++ b/docs/src/pages/guide/composition-api/custom-inputs.mdx
@@ -427,7 +427,7 @@ This means checkboxes have three states to maintain:
 - The current from value and if it is a checkbox group or a single checkbox. This is usually the `modelValue` prop for components.
 - If it is checked or not, if the checked value equals or is in the form value then it is checked. This should be computed based on the previous fact.
 
-All of this can be hard to wrap your head around. However, `useField` makes this as it already handles the nuances of checkboxes.
+All of this can be hard to wrap your head around. However, `useField` makes this easy as it already handles the nuances of checkboxes.
 
 The `useField` function accepts a `type` option that you can use to tell vee-validate that the input type is a checkbox and also accepts a `checkedValue` option.
 


### PR DESCRIPTION
🔎 __Overview__

Fixes a missing word.