### PR TITLE
fix: remove defineField event args for component compat closes #4637

### DIFF
--- a/.changeset/two-falcons-pull.md
+++ b/.changeset/two-falcons-pull.md
@@ -1,0 +1,5 @@
+---
+"vee-validate": patch
+---
+
+"fix: remove event arg from define field handlers for component compat closes #4637"

--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -239,9 +239,9 @@ export type PublicPathState<TValue = unknown> = Omit<
 >;
 
 export interface BaseFieldProps {
-  onBlur: (e: Event) => void;
-  onChange: (e: Event) => void;
-  onInput: (e: Event) => void;
+  onBlur: () => void;
+  onChange: () => void;
+  onInput: () => void;
 }
 
 export interface InputBindsConfig<TValue = unknown, TExtraProps extends GenericObject = GenericObject> {

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -1095,20 +1095,20 @@ export function useForm<
   ) {
     const [model, props] = defineField(path, config);
 
-    function onBlur(e: Event) {
-      props.value.onBlur(e);
+    function onBlur() {
+      props.value.onBlur();
     }
 
     function onInput(e: Event) {
       const value = normalizeEventValue(e) as PathValue<TValues, TPath>;
       setFieldValue(toValue(path), value, false);
-      props.value.onInput(e);
+      props.value.onInput();
     }
 
     function onChange(e: Event) {
       const value = normalizeEventValue(e) as PathValue<TValues, TPath>;
       setFieldValue(toValue(path), value, false);
-      props.value.onChange(e);
+      props.value.onChange();
     }
 
     return computed(() => {


### PR DESCRIPTION
# What

Fixes #4637 by removing the event args from handlers created by `defineField`, they were not used anyways and they only act as signals for the field to validate or apply meta changes.
