### PR TITLE
Update typed-schema.mdx - fixed typo

### DIFF
--- a/docs/src/pages/guide/composition-api/typed-schema.mdx
+++ b/docs/src/pages/guide/composition-api/typed-schema.mdx
@@ -83,7 +83,7 @@ Form values can exist in two types/versions:
 - The **"input"** type which is the one the user is filling/interacting with, it is the one that captures the user input.
 - The **"output"** type which is the one the user ends up submitting.
 
-You can tell vee-validate about this information by using the typed schema resolvers available in compainion packages.
+You can tell vee-validate about this information by using the typed schema resolvers available in companion packages.
 
 ## Yup
 


### PR DESCRIPTION
Fixed Typo

🔎 __Overview__

<!-- Explain the why behind adding this PR, here is a couple of examples -->
<!--
 
-->
This PR improves the documentation

🤓 __Code snippets/examples (if applicable)__

```js

Fixed typo in the following line of the typed schema documentation:

"You can tell vee-validate about this information by using the typed schema resolvers available in compainion packages."
```

✔ __Issues affected__

<!-- list of issues formatted like this

 -->
 Changed the incorrect spelling of compainion to companion.
