### PR TITLE
fix: send transformed values as submitted values with useField

### DIFF
--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -4,9 +4,10 @@ import { FieldValidationMetaInfo } from '../../../shared';
 import { Path, PathValue } from './paths';
 import { PartialDeep } from 'type-fest';
 
-export interface ValidationResult {
+export interface ValidationResult<TValue = unknown> {
   errors: string[];
   valid: boolean;
+  value?: TValue;
 }
 
 export interface TypedSchemaError {

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -839,6 +839,7 @@ export function useForm<
             key: state.path,
             valid: true,
             errors: [],
+            value: state.value,
           });
         }
 
@@ -847,6 +848,7 @@ export function useForm<
             key: state.path,
             valid: result.valid,
             errors: result.errors,
+            value: result.value ?? state.value,
           };
         });
       }),
@@ -856,11 +858,15 @@ export function useForm<
 
     const results: Partial<FlattenAndSetPathsType<TValues, ValidationResult>> = {};
     const errors: Partial<FlattenAndSetPathsType<TValues, string>> = {};
+    const values: Partial<FlattenAndSetPathsType<TValues, TOutput>> = {};
+
     for (const validation of validations) {
       results[validation.key as Path<TValues>] = {
         valid: validation.valid,
         errors: validation.errors,
       };
+
+      values[validation.key as Path<TValues>] = validation.value as any;
 
       if (validation.errors.length) {
         errors[validation.key as Path<TValues>] = validation.errors[0];
@@ -869,6 +875,7 @@ export function useForm<
 
     return {
       valid: validations.every(r => r.valid),
+      values: values as any,
       results,
       errors,
     };

--- a/packages/vee-validate/src/validate.ts
+++ b/packages/vee-validate/src/validate.ts
@@ -49,7 +49,7 @@ export async function validate<TValue = unknown>(
     | GenericValidateFunction<TValue>[]
     | TypedSchema<TValue>,
   options: ValidationOptions = {},
-): Promise<ValidationResult> {
+): Promise<ValidationResult<TValue>> {
   const shouldBail = options?.bails;
   const field: FieldValidationContext<TValue> = {
     name: options?.name || '{field}',
@@ -65,6 +65,7 @@ export async function validate<TValue = unknown>(
   return {
     errors,
     valid: !errors.length,
+    value: result.value,
   };
 }
 
@@ -108,12 +109,14 @@ async function _validate<TValue = unknown>(field: FieldValidationContext<TValue>
 
       if (field.bails) {
         return {
+          value: undefined,
           errors,
         };
       }
     }
 
     return {
+      value: undefined,
       errors,
     };
   }
@@ -136,6 +139,7 @@ async function _validate<TValue = unknown>(field: FieldValidationContext<TValue>
       errors.push(result.error);
       if (field.bails) {
         return {
+          value: undefined,
           errors,
         };
       }
@@ -143,6 +147,7 @@ async function _validate<TValue = unknown>(field: FieldValidationContext<TValue>
   }
 
   return {
+    value: undefined,
     errors,
   };
 }
@@ -217,6 +222,7 @@ async function validateFieldWithTypedSchema(value: unknown, schema: TypedSchema 
   }
 
   return {
+    value: result.value,
     errors: messages,
   };
 }


### PR DESCRIPTION
🔎 __Overview__

This PR allows transforms to be sent through as the submitted value when the 
transform is used in `useField` and not as a high-level object schema.

🤓 __Code snippets/examples (if applicable)__

See the added test to `zod.spec.ts`

```
      const testRules = toTypedSchema(z.string().transform(value => `modified: ${value}`));
      const { value } = useField('test', testRules);
```

---

This _functionally_ works but definitely needs some help with the internal types. Not sure how to make them work in the greater scheme without a lot more effort and could use some guidance. Thank you!