### PR TITLE
fix: mark form dirty when object keys are deleted

### DIFF
--- a/packages/vee-validate/src/utils/assertions.ts
+++ b/packages/vee-validate/src/utils/assertions.ts
@@ -108,6 +108,8 @@ export function isPropPresent(obj: Record<string, unknown>, prop: string) {
  * Compares if two values are the same borrowed from:
  * https://github.com/epoberezkin/fast-deep-equal
  * We added a case for file matching since `Object.keys` doesn't work with Files.
+ *
+ * NB: keys with the value undefined are ignored in the evaluation and considered equal to missing keys.
  * */
 export function isEqual(a: any, b: any) {
   if (a === b) return true;
@@ -162,7 +164,13 @@ export function isEqual(a: any, b: any) {
     if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
 
     keys = Object.keys(a);
-    length = keys.length;
+    length = keys.length - countUndefinedValues(a, keys);
+
+    if (length !== Object.keys(b).length - countUndefinedValues(b, Object.keys(b))) return false;
+
+    for (i = length; i-- !== 0; ) {
+      if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
+    }
 
     for (i = length; i-- !== 0; ) {
       // eslint-disable-next-line no-var
@@ -177,6 +185,17 @@ export function isEqual(a: any, b: any) {
   // true if both NaN, false otherwise
   // eslint-disable-next-line no-self-compare
   return a !== a && b !== b;
+}
+
+function countUndefinedValues(a: any, keys: string[]) {
+  let result = 0;
+  for (let i = keys.length; i-- !== 0; ) {
+    // eslint-disable-next-line no-var
+    var key = keys[i];
+
+    if (a[key] === undefined) result++;
+  }
+  return result;
 }
 
 export function isFile(a: unknown): a is File {

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -1133,6 +1133,32 @@ describe('useForm()', () => {
     expect(form.meta.value.dirty).toBe(false);
   });
 
+  // #4678
+  test('form is marked as dirty when key is removed', async () => {
+    let form!: FormContext<any>;
+    mountWithHoc({
+      setup() {
+        form = useForm({
+          initialValues: {
+            fname: {
+              key1: 'value1',
+              key2: 'value2',
+            },
+          },
+        });
+
+        useField('fname');
+
+        return {};
+      },
+      template: `<div></div>`,
+    });
+
+    form.setFieldValue('fname', { key1: 'value1' });
+    await flushPromises();
+    expect(form.meta.value.dirty).toBe(true);
+  });
+
   describe('error paths can have dot or square bracket for the same field', () => {
     test('path is bracket, mutations are dot', async () => {
       let field!: FieldContext<unknown>;


### PR DESCRIPTION
🔎 __Overview__

This PR fixes an issue where removed keys of objects in field values don't mark the form as dirty, because the `isEqual` method is not commutative. Please refer to this comment for a demonstration of the issue: https://github.com/logaretm/vee-validate/issues/4678#issuecomment-2015075349.

I read that a changeset was desired when submitting a PR, but I'm unsure what to include. Please advise.

✔ __Issues affected__

closes #4678


(Also credits to @SCBosch)