### PR TITLE
feat(i18n): allow custom interpolation options for i18n

### DIFF
--- a/docs/src/pages/guide/i18n.mdx
+++ b/docs/src/pages/guide/i18n.mdx
@@ -234,6 +234,38 @@ Here is an example that show cases interpolation for different cases:
 
 <LiveExample client:visible id="vee-validate-v4-i18n-interpolation" />
 
+#### Custom Interpolation Prefix and Suffix
+
+You also have the ability to customize the `prefix` and `suffix` of the interpolated values, by default they are `{` and `}` respectively.
+
+Configure them by passing a third parameter of `InterpolateOptions` to the `localize` function:
+
+```js
+import { defineRule, configure } from 'vee-validate';
+import { between } from '@vee-validate/rules';
+import { localize } from '@vee-validate/i18n';
+
+// Define the rule globally
+defineRule('between', between);
+
+configure({
+  // Generates an English message locale generator
+  generateMessage: localize(
+    'en',
+    {
+      messages: {
+        // use double `{{` and `}}` i18next-like curly braces for the interpolated values, instead of the default `{` and `}`
+        between: `The {{field}} field must be between {{min}} and {{max}}`,
+      },
+    },
+    {
+      prefix: '{{',
+      suffix: '}}',
+    },
+  ),
+});
+```
+
 ### Loading Locale From CDN
 
 If you are using Vue.js over CDN, you can still load the locale files without having to copy them to your code, the `@vee-validate/i18n` library exposes a `loadLocaleFromURL` function that accepts a URL to a locale file.

--- a/docs/src/pages/guide/i18n.mdx
+++ b/docs/src/pages/guide/i18n.mdx
@@ -255,7 +255,7 @@ configure({
     {
       messages: {
         // use double `{{` and `}}` i18next-like curly braces for the interpolated values, instead of the default `{` and `}`
-        between: `The {{field}} field must be between {{min}} and {{max}}`,
+        between: `The {{field}} field must be between 0:{{min}} and 1:{{max}}`,
       },
     },
     {

--- a/packages/i18n/src/utils.ts
+++ b/packages/i18n/src/utils.ts
@@ -1,24 +1,30 @@
+import { InterpolateOptions } from '../../shared/types';
+
 /**
  * Replaces placeholder values in a string with their actual values
  */
-export function interpolate(template: string, values: Record<string, any>): string {
-  return template.replace(/(\d:)?{([^}]+)}/g, function (_, param, placeholder): string {
+export function interpolate(template: string, values: Record<string, any>, options: InterpolateOptions): string {
+  const { prefix, suffix } = options;
+
+  const regExp = new RegExp(`([0-9]:)?${prefix}([^${suffix}]+)${suffix}`, 'g');
+
+  return template.replace(regExp, function (_, param, placeholder): string {
     if (!param || !values.params) {
       return placeholder in values
         ? values[placeholder]
         : values.params && placeholder in values.params
           ? values.params[placeholder]
-          : `{${placeholder}}`;
+          : `${prefix}${placeholder}${suffix}`;
     }
 
     // Handles extended object params format
     if (!Array.isArray(values.params)) {
-      return placeholder in values.params ? values.params[placeholder] : `{${placeholder}}`;
+      return placeholder in values.params ? values.params[placeholder] : `${prefix}${placeholder}${suffix}`;
     }
 
     // Extended Params exit in the format of `paramIndex:{paramName}` where the index is optional
     const paramIndex = Number(param.replace(':', ''));
 
-    return paramIndex in values.params ? values.params[paramIndex] : `${param}{${placeholder}}`;
+    return paramIndex in values.params ? values.params[paramIndex] : `${param}${prefix}${placeholder}${suffix}`;
   });
 }

--- a/packages/i18n/tests/index.spec.ts
+++ b/packages/i18n/tests/index.spec.ts
@@ -4,29 +4,28 @@ import { required, between } from '@/rules';
 import { localize, setLocale } from '@/i18n';
 import { mountWithHoc, setValue, flushPromises } from '../../vee-validate/tests/helpers';
 
-describe('i18n', () => {
-  defineRule('required', required);
-  defineRule('between', between);
+defineRule('required', required);
+defineRule('between', between);
 
-  beforeEach(() => {
-    localize('en', {
+beforeEach(() => {
+  localize('en', {
+    messages: {
+      required: 'The {field} is required',
+    },
+  });
+});
+
+test('can define new locales', async () => {
+  configure({
+    generateMessage: localize('ar', {
       messages: {
-        required: 'The {field} is required',
+        required: 'هذا الحقل مطلوب',
       },
-    });
+    }),
   });
 
-  test('can define new locales', async () => {
-    configure({
-      generateMessage: localize('ar', {
-        messages: {
-          required: 'هذا الحقل مطلوب',
-        },
-      }),
-    });
-
-    const wrapper = mountWithHoc({
-      template: `
+  const wrapper = mountWithHoc({
+    template: `
       <div>
         <Field name="field" validateOnMount rules="required" v-slot="{ field, errors }">
           <input v-bind="field" type="text">
@@ -34,29 +33,29 @@ describe('i18n', () => {
         </Field>
       </div>
     `,
-    });
-
-    const error = wrapper.$el.querySelector('#error');
-
-    // flush the pending validation.
-    await flushPromises();
-
-    expect(error.textContent).toContain('هذا الحقل مطلوب');
   });
 
-  test('can define specific messages for specific fields', async () => {
-    configure({
-      generateMessage: localize('en', {
-        fields: {
-          test: {
-            required: 'WRONG!',
-          },
-        },
-      }),
-    });
+  const error = wrapper.$el.querySelector('#error');
 
-    const wrapper = mountWithHoc({
-      template: `
+  // flush the pending validation.
+  await flushPromises();
+
+  expect(error.textContent).toContain('هذا الحقل مطلوب');
+});
+
+test('can define specific messages for specific fields', async () => {
+  configure({
+    generateMessage: localize('en', {
+      fields: {
+        test: {
+          required: 'WRONG!',
+        },
+      },
+    }),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
         <div>
           <Field name="test" :validateOnMount="true" rules="required" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
@@ -69,30 +68,30 @@ describe('i18n', () => {
           </Field>
         </div>
       `,
-    });
-
-    await flushPromises();
-    const errors = wrapper.$el.querySelectorAll('.error');
-    expect(errors).toHaveLength(2);
-
-    expect(errors[0].textContent).toContain('WRONG!');
-    expect(errors[1].textContent).toContain('The name is required');
   });
 
-  // #4097
-  test('can define specific messages for specific fields with labels', async () => {
-    configure({
-      generateMessage: localize('en', {
-        fields: {
-          test: {
-            required: '{field} WRONG!',
-          },
-        },
-      }),
-    });
+  await flushPromises();
+  const errors = wrapper.$el.querySelectorAll('.error');
+  expect(errors).toHaveLength(2);
 
-    const wrapper = mountWithHoc({
-      template: `
+  expect(errors[0].textContent).toContain('WRONG!');
+  expect(errors[1].textContent).toContain('The name is required');
+});
+
+// #4097
+test('can define specific messages for specific fields with labels', async () => {
+  configure({
+    generateMessage: localize('en', {
+      fields: {
+        test: {
+          required: '{field} WRONG!',
+        },
+      },
+    }),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
         <div>
           <Field name="test" :validateOnMount="true" rules="required" v-slot="{ field, errors }" label="field">
             <input v-bind="field" type="text">
@@ -105,30 +104,30 @@ describe('i18n', () => {
           </Field>
         </div>
       `,
-    });
-
-    await flushPromises();
-    const errors = wrapper.$el.querySelectorAll('.error');
-    expect(errors).toHaveLength(2);
-
-    expect(errors[0].textContent).toContain('field WRONG!');
-    expect(errors[1].textContent).toContain('The name is required');
   });
 
-  // #4097
-  test('can define specific messages for specific fields with labels and form schema', async () => {
-    configure({
-      generateMessage: localize('en', {
-        fields: {
-          test: {
-            required: '{field} WRONG!',
-          },
-        },
-      }),
-    });
+  await flushPromises();
+  const errors = wrapper.$el.querySelectorAll('.error');
+  expect(errors).toHaveLength(2);
 
-    const wrapper = mountWithHoc({
-      template: `
+  expect(errors[0].textContent).toContain('field WRONG!');
+  expect(errors[1].textContent).toContain('The name is required');
+});
+
+// #4097
+test('can define specific messages for specific fields with labels and form schema', async () => {
+  configure({
+    generateMessage: localize('en', {
+      fields: {
+        test: {
+          required: '{field} WRONG!',
+        },
+      },
+    }),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
         <VForm :validation-schema="schema">
           <Field name="test" :validateOnMount="true" v-slot="{ field, errors }" label="field">
             <input v-bind="field" type="text">
@@ -141,37 +140,37 @@ describe('i18n', () => {
           </Field>
         </VForm>
       `,
-      setup() {
-        return {
-          schema: {
-            test: 'required',
-            name: 'required',
-          },
-        };
-      },
-    });
-
-    await flushPromises();
-    const errors = wrapper.$el.querySelectorAll('.error');
-    expect(errors).toHaveLength(2);
-
-    expect(errors[0].textContent).toContain('field WRONG!');
-    expect(errors[1].textContent).toContain('The name is required');
+    setup() {
+      return {
+        schema: {
+          test: 'required',
+          name: 'required',
+        },
+      };
+    },
   });
 
-  test('can define labels or names for fields', async () => {
-    configure({
-      generateMessage: localize('en', {
-        messages: { required: '{field} is required' },
-        names: {
-          first: 'First test',
-          second: 'Second test',
-        },
-      }),
-    });
+  await flushPromises();
+  const errors = wrapper.$el.querySelectorAll('.error');
+  expect(errors).toHaveLength(2);
 
-    const wrapper = mountWithHoc({
-      template: `
+  expect(errors[0].textContent).toContain('field WRONG!');
+  expect(errors[1].textContent).toContain('The name is required');
+});
+
+test('can define labels or names for fields', async () => {
+  configure({
+    generateMessage: localize('en', {
+      messages: { required: '{field} is required' },
+      names: {
+        first: 'First test',
+        second: 'Second test',
+      },
+    }),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
         <div>
           <Field name="first" :validateOnMount="true" rules="required" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
@@ -184,29 +183,29 @@ describe('i18n', () => {
           </Field>
         </div>
       `,
-    });
-
-    await flushPromises();
-    const errors = wrapper.$el.querySelectorAll('.error');
-    expect(errors).toHaveLength(2);
-
-    expect(errors[0].textContent).toContain('First test is required');
-    expect(errors[1].textContent).toContain('Second test is required');
   });
 
-  test('can define localized labels for fields', async () => {
-    configure({
-      generateMessage: localize('en', {
-        messages: { required: '{field} is required' },
-        names: {
-          first: 'First test',
-          second: 'Second test',
-        },
-      }),
-    });
+  await flushPromises();
+  const errors = wrapper.$el.querySelectorAll('.error');
+  expect(errors).toHaveLength(2);
 
-    const wrapper = mountWithHoc({
-      template: `
+  expect(errors[0].textContent).toContain('First test is required');
+  expect(errors[1].textContent).toContain('Second test is required');
+});
+
+test('can define localized labels for fields', async () => {
+  configure({
+    generateMessage: localize('en', {
+      messages: { required: '{field} is required' },
+      names: {
+        first: 'First test',
+        second: 'Second test',
+      },
+    }),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
         <div>
           <Field name="first.value" label="first" :validateOnMount="true" rules="required" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
@@ -219,51 +218,286 @@ describe('i18n', () => {
           </Field>
         </div>
       `,
-    });
-
-    await flushPromises();
-    const errors = wrapper.$el.querySelectorAll('.error');
-    expect(errors).toHaveLength(2);
-
-    expect(errors[0].textContent).toContain('First test is required');
-    expect(errors[1].textContent).toContain('Second test is required');
   });
 
-  // #4164
-  test('can define labels or names for fields with useField', async () => {
-    let errorMessage!: Ref<string | undefined>;
-    configure({
-      generateMessage: localize('en', {
-        messages: { required: '{field} is required' },
-        names: {
-          first: 'First test',
-          second: 'Second test',
-        },
-      }),
-    });
+  await flushPromises();
+  const errors = wrapper.$el.querySelectorAll('.error');
+  expect(errors).toHaveLength(2);
 
-    mountWithHoc({
-      setup() {
-        const field = useField('first', 'required', { validateOnMount: true });
-        errorMessage = field.errorMessage;
+  expect(errors[0].textContent).toContain('First test is required');
+  expect(errors[1].textContent).toContain('Second test is required');
+});
+
+// #4164
+test('can define labels or names for fields with useField', async () => {
+  let errorMessage!: Ref<string | undefined>;
+  configure({
+    generateMessage: localize('en', {
+      messages: { required: '{field} is required' },
+      names: {
+        first: 'First test',
+        second: 'Second test',
       },
-      template: `
+    }),
+  });
+
+  mountWithHoc({
+    setup() {
+      const field = useField('first', 'required', { validateOnMount: true });
+      errorMessage = field.errorMessage;
+    },
+    template: `
         <div>
         </div>
       `,
-    });
-
-    await flushPromises();
-    expect(errorMessage.value).toBe('First test is required');
   });
 
-  test('can merge locales without setting the current one', async () => {
+  await flushPromises();
+  expect(errorMessage.value).toBe('First test is required');
+});
+
+test('can merge locales without setting the current one', async () => {
+  configure({
+    generateMessage: localize({
+      ar: {
+        messages: {
+          required: 'هذا الحقل مطلوب',
+        },
+      },
+    }),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
+        <div>
+          <Field name="field" :validateOnMount="true" rules="required" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+  });
+
+  const error = wrapper.$el.querySelector('#error');
+  // flush the pending validation.
+  await flushPromises();
+
+  // locale wasn't set.
+  expect(error.textContent).toContain('The field is required');
+});
+
+test('falls back to the default message if rule without message exists', async () => {
+  defineRule('i18n', () => false);
+
+  const wrapper = mountWithHoc({
+    template: `
+      <div>
+        <Field name="name" rules="required|i18n" v-slot="{ field, errors }">
+          <input v-bind="field" type="text">
+          <span id="error">{{ errors[0] }}</span>
+        </Field>
+      </div>
+    `,
+  });
+
+  const error = wrapper.$el.querySelector('#error');
+  const input = wrapper.$el.querySelector('input');
+  setValue(input, '12');
+  await flushPromises();
+
+  expect(error.textContent).toContain('name is not valid');
+});
+
+test('falls back to a language specific default message if rule without message exists', async () => {
+  defineRule('i18n', () => false);
+  configure({
+    generateMessage: localize('nl', {
+      messages: {
+        _default: '{field} is ongeldig',
+      },
+    }),
+  });
+  setLocale('nl');
+
+  const wrapper = mountWithHoc({
+    template: `
+      <div>
+        <Field name="field" rules="required|i18n" v-slot="{ field, errors }">
+          <input v-bind="field" type="text">
+          <span id="error">{{ errors[0] }}</span>
+        </Field>
+      </div>
+    `,
+  });
+
+  const error = wrapper.$el.querySelector('#error');
+  const input = wrapper.$el.querySelector('input');
+  setValue(input, '12');
+  await flushPromises();
+
+  expect(error.textContent).toContain('field is ongeldig');
+});
+
+test('can switch between locales with setLocale', async () => {
+  configure({
+    generateMessage: localize({
+      en: {
+        messages: {
+          required: 'This field is required',
+        },
+      },
+      ar: {
+        messages: {
+          required: 'هذا الحقل مطلوب',
+        },
+      },
+    }),
+  });
+
+  setLocale('en');
+
+  const wrapper = mountWithHoc({
+    template: `
+      <div>
+        <Field name="field" validateOnMount rules="required" v-slot="{ field, errors }">
+          <input v-bind="field" type="text">
+          <span id="error">{{ errors[0] }}</span>
+        </Field>
+      </div>
+    `,
+  });
+
+  const error = wrapper.$el.querySelector('#error');
+
+  // flush the pending validation.
+  await flushPromises();
+
+  expect(error.textContent).toContain('This field is required');
+  setLocale('ar');
+  setValue(wrapper.$el.querySelector('input'), '');
+
+  await flushPromises();
+  expect(error.textContent).toContain('هذا الحقل مطلوب');
+});
+
+test('interpolates object params with short format', async () => {
+  configure({
+    generateMessage: localize('en', {
+      messages: {
+        between: `The {field} field must be between {min} and {max}`,
+      },
+    }),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+  });
+
+  const error = wrapper.$el.querySelector('#error');
+  // flush the pending validation.
+  await flushPromises();
+
+  // locale wasn't set.
+  expect(error.textContent).toContain('The name field must be between 1 and 10');
+});
+
+test('interpolates object params with extended format', async () => {
+  configure({
+    generateMessage: localize('en', {
+      messages: {
+        between: `The {field} field must be between 0:{min} and 1:{max}`,
+      },
+    }),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+  });
+
+  const error = wrapper.$el.querySelector('#error');
+  // flush the pending validation.
+  await flushPromises();
+
+  // locale wasn't set.
+  expect(error.textContent).toContain('The name field must be between 1 and 10');
+});
+
+test('interpolates array params', async () => {
+  configure({
+    generateMessage: localize('en', {
+      messages: {
+        between: 'The {field} field must be between 0:{min} and 1:{max}',
+      },
+    }),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: [1, 10] }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+  });
+
+  const error = wrapper.$el.querySelector('#error');
+  // flush the pending validation.
+  await flushPromises();
+
+  // locale wasn't set.
+  expect(error.textContent).toContain('The name field must be between 1 and 10');
+});
+
+test('interpolates string params', async () => {
+  configure({
+    generateMessage: localize('en', {
+      messages: {
+        between: 'The {field} field must be between 0:{min} and 1:{max}',
+      },
+    }),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" rules="between:1,10" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+  });
+
+  const error = wrapper.$el.querySelector('#error');
+  // flush the pending validation.
+  await flushPromises();
+
+  // locale wasn't set.
+  expect(error.textContent).toContain('The name field must be between 1 and 10');
+});
+
+describe('interpolation preserves placeholders if not found', () => {
+  test('array format', async () => {
     configure({
-      generateMessage: localize({
-        ar: {
-          messages: {
-            required: 'هذا الحقل مطلوب',
-          },
+      generateMessage: localize('en', {
+        messages: {
+          between: 'The {field} field must be between 0:{min} and 1:{max}',
         },
       }),
     });
@@ -271,7 +505,7 @@ describe('i18n', () => {
     const wrapper = mountWithHoc({
       template: `
         <div>
-          <Field name="field" :validateOnMount="true" rules="required" v-slot="{ field, errors }">
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: [1] }" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
             <span id="error">{{ errors[0] }}</span>
           </Field>
@@ -284,521 +518,283 @@ describe('i18n', () => {
     await flushPromises();
 
     // locale wasn't set.
-    expect(error.textContent).toContain('The field is required');
+    expect(error.textContent).toContain('The name field must be between 1 and 1:{max}');
   });
 
-  test('falls back to the default message if rule without message exists', async () => {
-    defineRule('i18n', () => false);
-
-    const wrapper = mountWithHoc({
-      template: `
-      <div>
-        <Field name="name" rules="required|i18n" v-slot="{ field, errors }">
-          <input v-bind="field" type="text">
-          <span id="error">{{ errors[0] }}</span>
-        </Field>
-      </div>
-    `,
-    });
-
-    const error = wrapper.$el.querySelector('#error');
-    const input = wrapper.$el.querySelector('input');
-    setValue(input, '12');
-    await flushPromises();
-
-    expect(error.textContent).toContain('name is not valid');
-  });
-
-  test('falls back to a language specific default message if rule without message exists', async () => {
-    defineRule('i18n', () => false);
+  test('object format', async () => {
     configure({
-      generateMessage: localize('nl', {
+      generateMessage: localize('en', {
         messages: {
-          _default: '{field} is ongeldig',
-        },
-      }),
-    });
-    setLocale('nl');
-
-    const wrapper = mountWithHoc({
-      template: `
-      <div>
-        <Field name="field" rules="required|i18n" v-slot="{ field, errors }">
-          <input v-bind="field" type="text">
-          <span id="error">{{ errors[0] }}</span>
-        </Field>
-      </div>
-    `,
-    });
-
-    const error = wrapper.$el.querySelector('#error');
-    const input = wrapper.$el.querySelector('input');
-    setValue(input, '12');
-    await flushPromises();
-
-    expect(error.textContent).toContain('field is ongeldig');
-  });
-
-  test('can switch between locales with setLocale', async () => {
-    configure({
-      generateMessage: localize({
-        en: {
-          messages: {
-            required: 'This field is required',
-          },
-        },
-        ar: {
-          messages: {
-            required: 'هذا الحقل مطلوب',
-          },
+          between: 'The {field} field must be between 0:{min} and 1:{max}',
         },
       }),
     });
 
-    setLocale('en');
-
     const wrapper = mountWithHoc({
       template: `
-      <div>
-        <Field name="field" validateOnMount rules="required" v-slot="{ field, errors }">
-          <input v-bind="field" type="text">
-          <span id="error">{{ errors[0] }}</span>
-        </Field>
-      </div>
-    `,
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 0 } }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
     });
 
     const error = wrapper.$el.querySelector('#error');
-
     // flush the pending validation.
     await flushPromises();
 
-    expect(error.textContent).toContain('This field is required');
-    setLocale('ar');
-    setValue(wrapper.$el.querySelector('input'), '');
-
-    await flushPromises();
-    expect(error.textContent).toContain('هذا الحقل مطلوب');
-  });
-  describe('default interpolation', () => {
-    test('interpolates object params with short format', async () => {
-      configure({
-        generateMessage: localize('en', {
-          messages: {
-            between: `The {field} field must be between {min} and {max}`,
-          },
-        }),
-      });
-
-      const wrapper = mountWithHoc({
-        template: `
-        <div>
-          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
-            <input v-bind="field" type="text">
-            <span id="error">{{ errors[0] }}</span>
-          </Field>
-        </div>
-      `,
-      });
-
-      const error = wrapper.$el.querySelector('#error');
-      // flush the pending validation.
-      await flushPromises();
-
-      // locale wasn't set.
-      expect(error.textContent).toContain('The name field must be between 1 and 10');
-    });
-
-    test('interpolates object params with extended format', async () => {
-      configure({
-        generateMessage: localize('en', {
-          messages: {
-            between: `The {field} field must be between 0:{min} and 1:{max}`,
-          },
-        }),
-      });
-
-      const wrapper = mountWithHoc({
-        template: `
-        <div>
-          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
-            <input v-bind="field" type="text">
-            <span id="error">{{ errors[0] }}</span>
-          </Field>
-        </div>
-      `,
-      });
-
-      const error = wrapper.$el.querySelector('#error');
-      // flush the pending validation.
-      await flushPromises();
-
-      // locale wasn't set.
-      expect(error.textContent).toContain('The name field must be between 1 and 10');
-    });
-
-    test('interpolates array params', async () => {
-      configure({
-        generateMessage: localize('en', {
-          messages: {
-            between: 'The {field} field must be between 0:{min} and 1:{max}',
-          },
-        }),
-      });
-
-      const wrapper = mountWithHoc({
-        template: `
-        <div>
-          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: [1, 10] }" v-slot="{ field, errors }">
-            <input v-bind="field" type="text">
-            <span id="error">{{ errors[0] }}</span>
-          </Field>
-        </div>
-      `,
-      });
-
-      const error = wrapper.$el.querySelector('#error');
-      // flush the pending validation.
-      await flushPromises();
-
-      // locale wasn't set.
-      expect(error.textContent).toContain('The name field must be between 1 and 10');
-    });
-
-    test('interpolates string params', async () => {
-      configure({
-        generateMessage: localize('en', {
-          messages: {
-            between: 'The {field} field must be between 0:{min} and 1:{max}',
-          },
-        }),
-      });
-
-      const wrapper = mountWithHoc({
-        template: `
-        <div>
-          <Field name="name" value="-1" :validateOnMount="true" rules="between:1,10" v-slot="{ field, errors }">
-            <input v-bind="field" type="text">
-            <span id="error">{{ errors[0] }}</span>
-          </Field>
-        </div>
-      `,
-      });
-
-      const error = wrapper.$el.querySelector('#error');
-      // flush the pending validation.
-      await flushPromises();
-
-      // locale wasn't set.
-      expect(error.textContent).toContain('The name field must be between 1 and 10');
-    });
-
-    describe('interpolation preserves placeholders if not found', () => {
-      test('array format', async () => {
-        configure({
-          generateMessage: localize('en', {
-            messages: {
-              between: 'The {field} field must be between 0:{min} and 1:{max}',
-            },
-          }),
-        });
-
-        const wrapper = mountWithHoc({
-          template: `
-        <div>
-          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: [1] }" v-slot="{ field, errors }">
-            <input v-bind="field" type="text">
-            <span id="error">{{ errors[0] }}</span>
-          </Field>
-        </div>
-      `,
-        });
-
-        const error = wrapper.$el.querySelector('#error');
-        // flush the pending validation.
-        await flushPromises();
-
-        // locale wasn't set.
-        expect(error.textContent).toContain('The name field must be between 1 and 1:{max}');
-      });
-
-      test('object format', async () => {
-        configure({
-          generateMessage: localize('en', {
-            messages: {
-              between: 'The {field} field must be between 0:{min} and 1:{max}',
-            },
-          }),
-        });
-
-        const wrapper = mountWithHoc({
-          template: `
-        <div>
-          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 0 } }" v-slot="{ field, errors }">
-            <input v-bind="field" type="text">
-            <span id="error">{{ errors[0] }}</span>
-          </Field>
-        </div>
-      `,
-        });
-
-        const error = wrapper.$el.querySelector('#error');
-        // flush the pending validation.
-        await flushPromises();
-
-        // locale wasn't set.
-        expect(error.textContent).toContain('The name field must be between 0 and {max}');
-      });
-    });
-
-    // #4726
-    describe('custom interpolation options', () => {
-      test('interpolates object params with short format', async () => {
-        configure({
-          generateMessage: localize(
-            'en',
-            {
-              messages: {
-                between: `The {{field}} field must be between {{min}} and {{max}}`,
-              },
-            },
-            {
-              prefix: '{{',
-              suffix: '}}',
-            },
-          ),
-        });
-
-        const wrapper = mountWithHoc({
-          template: `
-        <div>
-          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
-            <input v-bind="field" type="text">
-            <span id="error">{{ errors[0] }}</span>
-          </Field>
-        </div>
-      `,
-        });
-
-        const error = wrapper.$el.querySelector('#error');
-        // flush the pending validation.
-        await flushPromises();
-
-        // locale wasn't set.
-        expect(error.textContent).toContain('The name field must be between 1 and 10');
-      });
-
-      test('interpolates object params with short format and handlebars style interpolation', async () => {
-        configure({
-          generateMessage: localize(
-            'en',
-            {
-              messages: {
-                between: `The <%field%> field must be between <%min%> and <%max%>`,
-              },
-            },
-            {
-              prefix: '<%',
-              suffix: '%>',
-            },
-          ),
-        });
-
-        const wrapper = mountWithHoc({
-          template: `
-        <div>
-          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
-            <input v-bind="field" type="text">
-            <span id="error">{{ errors[0] }}</span>
-          </Field>
-        </div>
-      `,
-        });
-
-        const error = wrapper.$el.querySelector('#error');
-        // flush the pending validation.
-        await flushPromises();
-
-        // locale wasn't set.
-        expect(error.textContent).toContain('The name field must be between 1 and 10');
-      });
-
-      test('interpolates object params with extended format', async () => {
-        configure({
-          generateMessage: localize(
-            'en',
-            {
-              messages: {
-                between: `The {{field}} field must be between 0:{{min}} and 1:{{max}}`,
-              },
-            },
-            {
-              prefix: '{{',
-              suffix: '}}',
-            },
-          ),
-        });
-
-        const wrapper = mountWithHoc({
-          template: `
-        <div>
-          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
-            <input v-bind="field" type="text">
-            <span id="error">{{ errors[0] }}</span>
-          </Field>
-        </div>
-      `,
-        });
-
-        const error = wrapper.$el.querySelector('#error');
-        // flush the pending validation.
-        await flushPromises();
-
-        // locale wasn't set.
-        expect(error.textContent).toContain('The name field must be between 1 and 10');
-      });
-
-      test('interpolates array params', async () => {
-        configure({
-          generateMessage: localize(
-            'en',
-            {
-              messages: {
-                between: 'The {{field}} field must be between 0:{{min}} and 1:{{max}}',
-              },
-            },
-            {
-              prefix: '{{',
-              suffix: '}}',
-            },
-          ),
-        });
-
-        const wrapper = mountWithHoc({
-          template: `
-        <div>
-          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: [1, 10] }" v-slot="{ field, errors }">
-            <input v-bind="field" type="text">
-            <span id="error">{{ errors[0] }}</span>
-          </Field>
-        </div>
-      `,
-        });
-
-        const error = wrapper.$el.querySelector('#error');
-        // flush the pending validation.
-        await flushPromises();
-
-        // locale wasn't set.
-        expect(error.textContent).toContain('The name field must be between 1 and 10');
-      });
-
-      test('interpolates string params', async () => {
-        configure({
-          generateMessage: localize(
-            'en',
-            {
-              messages: {
-                between: 'The {{field}} field must be between 0:{{min}} and 1:{{max}}',
-              },
-            },
-            {
-              prefix: '{{',
-              suffix: '}}',
-            },
-          ),
-        });
-
-        const wrapper = mountWithHoc({
-          template: `
-        <div>
-          <Field name="name" value="-1" :validateOnMount="true" rules="between:1,10" v-slot="{ field, errors }">
-            <input v-bind="field" type="text">
-            <span id="error">{{ errors[0] }}</span>
-          </Field>
-        </div>
-      `,
-        });
-
-        const error = wrapper.$el.querySelector('#error');
-        // flush the pending validation.
-        await flushPromises();
-
-        // locale wasn't set.
-        expect(error.textContent).toContain('The name field must be between 1 and 10');
-      });
-
-      describe('interpolation preserves placeholders if not found', () => {
-        test('array format', async () => {
-          configure({
-            generateMessage: localize(
-              'en',
-              {
-                messages: {
-                  between: 'The {{field}} field must be between 0:{{min}} and 1:{{max}}',
-                },
-              },
-              {
-                prefix: '{{',
-                suffix: '}}',
-              },
-            ),
-          });
-
-          const wrapper = mountWithHoc({
-            template: `
-        <div>
-          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: [1] }" v-slot="{ field, errors }">
-            <input v-bind="field" type="text">
-            <span id="error">{{ errors[0] }}</span>
-          </Field>
-        </div>
-      `,
-          });
-
-          const error = wrapper.$el.querySelector('#error');
-          // flush the pending validation.
-          await flushPromises();
-
-          // locale wasn't set.
-          expect(error.textContent).toContain('The name field must be between 1 and 1:{{max}}');
-        });
-
-        test('object format', async () => {
-          configure({
-            generateMessage: localize(
-              'en',
-              {
-                messages: {
-                  between: 'The {{field}} field must be between 0:{{min}} and 1:{{max}}',
-                },
-              },
-              {
-                prefix: '{{',
-                suffix: '}}',
-              },
-            ),
-          });
-
-          const wrapper = mountWithHoc({
-            template: `
-        <div>
-          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 0 } }" v-slot="{ field, errors }">
-            <input v-bind="field" type="text">
-            <span id="error">{{ errors[0] }}</span>
-          </Field>
-        </div>
-      `,
-          });
-
-          const error = wrapper.$el.querySelector('#error');
-          // flush the pending validation.
-          await flushPromises();
-
-          // locale wasn't set.
-          expect(error.textContent).toContain('The name field must be between 0 and {{max}}');
-        });
-      });
-    });
+    // locale wasn't set.
+    expect(error.textContent).toContain('The name field must be between 0 and {max}');
   });
 });
+
+// begin - #4726 - custom interpolation options
+test('custom interpolation options - interpolates object params with short format', async () => {
+  configure({
+    generateMessage: localize(
+      'en',
+      {
+        messages: {
+          between: `The {{field}} field must be between {{min}} and {{max}}`,
+        },
+      },
+      {
+        prefix: '{{',
+        suffix: '}}',
+      },
+    ),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+  });
+
+  const error = wrapper.$el.querySelector('#error');
+  // flush the pending validation.
+  await flushPromises();
+
+  // locale wasn't set.
+  expect(error.textContent).toContain('The name field must be between 1 and 10');
+});
+
+test('custom interpolation options - interpolates object params with short format and handlebars style interpolation', async () => {
+  configure({
+    generateMessage: localize(
+      'en',
+      {
+        messages: {
+          between: `The <%field%> field must be between <%min%> and <%max%>`,
+        },
+      },
+      {
+        prefix: '<%',
+        suffix: '%>',
+      },
+    ),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+  });
+
+  const error = wrapper.$el.querySelector('#error');
+  // flush the pending validation.
+  await flushPromises();
+
+  // locale wasn't set.
+  expect(error.textContent).toContain('The name field must be between 1 and 10');
+});
+
+test('custom interpolation options - interpolates object params with extended format', async () => {
+  configure({
+    generateMessage: localize(
+      'en',
+      {
+        messages: {
+          between: `The {{field}} field must be between 0:{{min}} and 1:{{max}}`,
+        },
+      },
+      {
+        prefix: '{{',
+        suffix: '}}',
+      },
+    ),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+  });
+
+  const error = wrapper.$el.querySelector('#error');
+  // flush the pending validation.
+  await flushPromises();
+
+  // locale wasn't set.
+  expect(error.textContent).toContain('The name field must be between 1 and 10');
+});
+
+test('custom interpolation options - interpolates array params', async () => {
+  configure({
+    generateMessage: localize(
+      'en',
+      {
+        messages: {
+          between: 'The {{field}} field must be between 0:{{min}} and 1:{{max}}',
+        },
+      },
+      {
+        prefix: '{{',
+        suffix: '}}',
+      },
+    ),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: [1, 10] }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+  });
+
+  const error = wrapper.$el.querySelector('#error');
+  // flush the pending validation.
+  await flushPromises();
+
+  // locale wasn't set.
+  expect(error.textContent).toContain('The name field must be between 1 and 10');
+});
+
+test('custom interpolation options - interpolates string params', async () => {
+  configure({
+    generateMessage: localize(
+      'en',
+      {
+        messages: {
+          between: 'The {{field}} field must be between 0:{{min}} and 1:{{max}}',
+        },
+      },
+      {
+        prefix: '{{',
+        suffix: '}}',
+      },
+    ),
+  });
+
+  const wrapper = mountWithHoc({
+    template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" rules="between:1,10" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+  });
+
+  const error = wrapper.$el.querySelector('#error');
+  // flush the pending validation.
+  await flushPromises();
+
+  // locale wasn't set.
+  expect(error.textContent).toContain('The name field must be between 1 and 10');
+});
+
+describe('interpolation preserves placeholders if not found', () => {
+  test('custom interpolation options - array format', async () => {
+    configure({
+      generateMessage: localize(
+        'en',
+        {
+          messages: {
+            between: 'The {{field}} field must be between 0:{{min}} and 1:{{max}}',
+          },
+        },
+        {
+          prefix: '{{',
+          suffix: '}}',
+        },
+      ),
+    });
+
+    const wrapper = mountWithHoc({
+      template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: [1] }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+    });
+
+    const error = wrapper.$el.querySelector('#error');
+    // flush the pending validation.
+    await flushPromises();
+
+    // locale wasn't set.
+    expect(error.textContent).toContain('The name field must be between 1 and 1:{{max}}');
+  });
+
+  test('custom interpolation options - object format', async () => {
+    configure({
+      generateMessage: localize(
+        'en',
+        {
+          messages: {
+            between: 'The {{field}} field must be between 0:{{min}} and 1:{{max}}',
+          },
+        },
+        {
+          prefix: '{{',
+          suffix: '}}',
+        },
+      ),
+    });
+
+    const wrapper = mountWithHoc({
+      template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 0 } }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+    });
+
+    const error = wrapper.$el.querySelector('#error');
+    // flush the pending validation.
+    await flushPromises();
+
+    // locale wasn't set.
+    expect(error.textContent).toContain('The name field must be between 0 and {{max}}');
+  });
+});
+// end - #4726 - custom interpolation options tests

--- a/packages/i18n/tests/index.spec.ts
+++ b/packages/i18n/tests/index.spec.ts
@@ -4,28 +4,29 @@ import { required, between } from '@/rules';
 import { localize, setLocale } from '@/i18n';
 import { mountWithHoc, setValue, flushPromises } from '../../vee-validate/tests/helpers';
 
-defineRule('required', required);
-defineRule('between', between);
+describe('i18n', () => {
+  defineRule('required', required);
+  defineRule('between', between);
 
-beforeEach(() => {
-  localize('en', {
-    messages: {
-      required: 'The {field} is required',
-    },
-  });
-});
-
-test('can define new locales', async () => {
-  configure({
-    generateMessage: localize('ar', {
+  beforeEach(() => {
+    localize('en', {
       messages: {
-        required: 'هذا الحقل مطلوب',
+        required: 'The {field} is required',
       },
-    }),
+    });
   });
 
-  const wrapper = mountWithHoc({
-    template: `
+  test('can define new locales', async () => {
+    configure({
+      generateMessage: localize('ar', {
+        messages: {
+          required: 'هذا الحقل مطلوب',
+        },
+      }),
+    });
+
+    const wrapper = mountWithHoc({
+      template: `
       <div>
         <Field name="field" validateOnMount rules="required" v-slot="{ field, errors }">
           <input v-bind="field" type="text">
@@ -33,29 +34,29 @@ test('can define new locales', async () => {
         </Field>
       </div>
     `,
+    });
+
+    const error = wrapper.$el.querySelector('#error');
+
+    // flush the pending validation.
+    await flushPromises();
+
+    expect(error.textContent).toContain('هذا الحقل مطلوب');
   });
 
-  const error = wrapper.$el.querySelector('#error');
-
-  // flush the pending validation.
-  await flushPromises();
-
-  expect(error.textContent).toContain('هذا الحقل مطلوب');
-});
-
-test('can define specific messages for specific fields', async () => {
-  configure({
-    generateMessage: localize('en', {
-      fields: {
-        test: {
-          required: 'WRONG!',
+  test('can define specific messages for specific fields', async () => {
+    configure({
+      generateMessage: localize('en', {
+        fields: {
+          test: {
+            required: 'WRONG!',
+          },
         },
-      },
-    }),
-  });
+      }),
+    });
 
-  const wrapper = mountWithHoc({
-    template: `
+    const wrapper = mountWithHoc({
+      template: `
         <div>
           <Field name="test" :validateOnMount="true" rules="required" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
@@ -68,30 +69,30 @@ test('can define specific messages for specific fields', async () => {
           </Field>
         </div>
       `,
+    });
+
+    await flushPromises();
+    const errors = wrapper.$el.querySelectorAll('.error');
+    expect(errors).toHaveLength(2);
+
+    expect(errors[0].textContent).toContain('WRONG!');
+    expect(errors[1].textContent).toContain('The name is required');
   });
 
-  await flushPromises();
-  const errors = wrapper.$el.querySelectorAll('.error');
-  expect(errors).toHaveLength(2);
-
-  expect(errors[0].textContent).toContain('WRONG!');
-  expect(errors[1].textContent).toContain('The name is required');
-});
-
-// #4097
-test('can define specific messages for specific fields with labels', async () => {
-  configure({
-    generateMessage: localize('en', {
-      fields: {
-        test: {
-          required: '{field} WRONG!',
+  // #4097
+  test('can define specific messages for specific fields with labels', async () => {
+    configure({
+      generateMessage: localize('en', {
+        fields: {
+          test: {
+            required: '{field} WRONG!',
+          },
         },
-      },
-    }),
-  });
+      }),
+    });
 
-  const wrapper = mountWithHoc({
-    template: `
+    const wrapper = mountWithHoc({
+      template: `
         <div>
           <Field name="test" :validateOnMount="true" rules="required" v-slot="{ field, errors }" label="field">
             <input v-bind="field" type="text">
@@ -104,30 +105,30 @@ test('can define specific messages for specific fields with labels', async () =>
           </Field>
         </div>
       `,
+    });
+
+    await flushPromises();
+    const errors = wrapper.$el.querySelectorAll('.error');
+    expect(errors).toHaveLength(2);
+
+    expect(errors[0].textContent).toContain('field WRONG!');
+    expect(errors[1].textContent).toContain('The name is required');
   });
 
-  await flushPromises();
-  const errors = wrapper.$el.querySelectorAll('.error');
-  expect(errors).toHaveLength(2);
-
-  expect(errors[0].textContent).toContain('field WRONG!');
-  expect(errors[1].textContent).toContain('The name is required');
-});
-
-// #4097
-test('can define specific messages for specific fields with labels and form schema', async () => {
-  configure({
-    generateMessage: localize('en', {
-      fields: {
-        test: {
-          required: '{field} WRONG!',
+  // #4097
+  test('can define specific messages for specific fields with labels and form schema', async () => {
+    configure({
+      generateMessage: localize('en', {
+        fields: {
+          test: {
+            required: '{field} WRONG!',
+          },
         },
-      },
-    }),
-  });
+      }),
+    });
 
-  const wrapper = mountWithHoc({
-    template: `
+    const wrapper = mountWithHoc({
+      template: `
         <VForm :validation-schema="schema">
           <Field name="test" :validateOnMount="true" v-slot="{ field, errors }" label="field">
             <input v-bind="field" type="text">
@@ -140,37 +141,37 @@ test('can define specific messages for specific fields with labels and form sche
           </Field>
         </VForm>
       `,
-    setup() {
-      return {
-        schema: {
-          test: 'required',
-          name: 'required',
-        },
-      };
-    },
-  });
-
-  await flushPromises();
-  const errors = wrapper.$el.querySelectorAll('.error');
-  expect(errors).toHaveLength(2);
-
-  expect(errors[0].textContent).toContain('field WRONG!');
-  expect(errors[1].textContent).toContain('The name is required');
-});
-
-test('can define labels or names for fields', async () => {
-  configure({
-    generateMessage: localize('en', {
-      messages: { required: '{field} is required' },
-      names: {
-        first: 'First test',
-        second: 'Second test',
+      setup() {
+        return {
+          schema: {
+            test: 'required',
+            name: 'required',
+          },
+        };
       },
-    }),
+    });
+
+    await flushPromises();
+    const errors = wrapper.$el.querySelectorAll('.error');
+    expect(errors).toHaveLength(2);
+
+    expect(errors[0].textContent).toContain('field WRONG!');
+    expect(errors[1].textContent).toContain('The name is required');
   });
 
-  const wrapper = mountWithHoc({
-    template: `
+  test('can define labels or names for fields', async () => {
+    configure({
+      generateMessage: localize('en', {
+        messages: { required: '{field} is required' },
+        names: {
+          first: 'First test',
+          second: 'Second test',
+        },
+      }),
+    });
+
+    const wrapper = mountWithHoc({
+      template: `
         <div>
           <Field name="first" :validateOnMount="true" rules="required" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
@@ -183,29 +184,29 @@ test('can define labels or names for fields', async () => {
           </Field>
         </div>
       `,
+    });
+
+    await flushPromises();
+    const errors = wrapper.$el.querySelectorAll('.error');
+    expect(errors).toHaveLength(2);
+
+    expect(errors[0].textContent).toContain('First test is required');
+    expect(errors[1].textContent).toContain('Second test is required');
   });
 
-  await flushPromises();
-  const errors = wrapper.$el.querySelectorAll('.error');
-  expect(errors).toHaveLength(2);
+  test('can define localized labels for fields', async () => {
+    configure({
+      generateMessage: localize('en', {
+        messages: { required: '{field} is required' },
+        names: {
+          first: 'First test',
+          second: 'Second test',
+        },
+      }),
+    });
 
-  expect(errors[0].textContent).toContain('First test is required');
-  expect(errors[1].textContent).toContain('Second test is required');
-});
-
-test('can define localized labels for fields', async () => {
-  configure({
-    generateMessage: localize('en', {
-      messages: { required: '{field} is required' },
-      names: {
-        first: 'First test',
-        second: 'Second test',
-      },
-    }),
-  });
-
-  const wrapper = mountWithHoc({
-    template: `
+    const wrapper = mountWithHoc({
+      template: `
         <div>
           <Field name="first.value" label="first" :validateOnMount="true" rules="required" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
@@ -218,57 +219,57 @@ test('can define localized labels for fields', async () => {
           </Field>
         </div>
       `,
+    });
+
+    await flushPromises();
+    const errors = wrapper.$el.querySelectorAll('.error');
+    expect(errors).toHaveLength(2);
+
+    expect(errors[0].textContent).toContain('First test is required');
+    expect(errors[1].textContent).toContain('Second test is required');
   });
 
-  await flushPromises();
-  const errors = wrapper.$el.querySelectorAll('.error');
-  expect(errors).toHaveLength(2);
+  // #4164
+  test('can define labels or names for fields with useField', async () => {
+    let errorMessage!: Ref<string | undefined>;
+    configure({
+      generateMessage: localize('en', {
+        messages: { required: '{field} is required' },
+        names: {
+          first: 'First test',
+          second: 'Second test',
+        },
+      }),
+    });
 
-  expect(errors[0].textContent).toContain('First test is required');
-  expect(errors[1].textContent).toContain('Second test is required');
-});
-
-// #4164
-test('can define labels or names for fields with useField', async () => {
-  let errorMessage!: Ref<string | undefined>;
-  configure({
-    generateMessage: localize('en', {
-      messages: { required: '{field} is required' },
-      names: {
-        first: 'First test',
-        second: 'Second test',
+    mountWithHoc({
+      setup() {
+        const field = useField('first', 'required', { validateOnMount: true });
+        errorMessage = field.errorMessage;
       },
-    }),
-  });
-
-  mountWithHoc({
-    setup() {
-      const field = useField('first', 'required', { validateOnMount: true });
-      errorMessage = field.errorMessage;
-    },
-    template: `
+      template: `
         <div>
         </div>
       `,
+    });
+
+    await flushPromises();
+    expect(errorMessage.value).toBe('First test is required');
   });
 
-  await flushPromises();
-  expect(errorMessage.value).toBe('First test is required');
-});
-
-test('can merge locales without setting the current one', async () => {
-  configure({
-    generateMessage: localize({
-      ar: {
-        messages: {
-          required: 'هذا الحقل مطلوب',
+  test('can merge locales without setting the current one', async () => {
+    configure({
+      generateMessage: localize({
+        ar: {
+          messages: {
+            required: 'هذا الحقل مطلوب',
+          },
         },
-      },
-    }),
-  });
+      }),
+    });
 
-  const wrapper = mountWithHoc({
-    template: `
+    const wrapper = mountWithHoc({
+      template: `
         <div>
           <Field name="field" :validateOnMount="true" rules="required" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
@@ -276,21 +277,21 @@ test('can merge locales without setting the current one', async () => {
           </Field>
         </div>
       `,
+    });
+
+    const error = wrapper.$el.querySelector('#error');
+    // flush the pending validation.
+    await flushPromises();
+
+    // locale wasn't set.
+    expect(error.textContent).toContain('The field is required');
   });
 
-  const error = wrapper.$el.querySelector('#error');
-  // flush the pending validation.
-  await flushPromises();
+  test('falls back to the default message if rule without message exists', async () => {
+    defineRule('i18n', () => false);
 
-  // locale wasn't set.
-  expect(error.textContent).toContain('The field is required');
-});
-
-test('falls back to the default message if rule without message exists', async () => {
-  defineRule('i18n', () => false);
-
-  const wrapper = mountWithHoc({
-    template: `
+    const wrapper = mountWithHoc({
+      template: `
       <div>
         <Field name="name" rules="required|i18n" v-slot="{ field, errors }">
           <input v-bind="field" type="text">
@@ -298,29 +299,29 @@ test('falls back to the default message if rule without message exists', async (
         </Field>
       </div>
     `,
+    });
+
+    const error = wrapper.$el.querySelector('#error');
+    const input = wrapper.$el.querySelector('input');
+    setValue(input, '12');
+    await flushPromises();
+
+    expect(error.textContent).toContain('name is not valid');
   });
 
-  const error = wrapper.$el.querySelector('#error');
-  const input = wrapper.$el.querySelector('input');
-  setValue(input, '12');
-  await flushPromises();
+  test('falls back to a language specific default message if rule without message exists', async () => {
+    defineRule('i18n', () => false);
+    configure({
+      generateMessage: localize('nl', {
+        messages: {
+          _default: '{field} is ongeldig',
+        },
+      }),
+    });
+    setLocale('nl');
 
-  expect(error.textContent).toContain('name is not valid');
-});
-
-test('falls back to a language specific default message if rule without message exists', async () => {
-  defineRule('i18n', () => false);
-  configure({
-    generateMessage: localize('nl', {
-      messages: {
-        _default: '{field} is ongeldig',
-      },
-    }),
-  });
-  setLocale('nl');
-
-  const wrapper = mountWithHoc({
-    template: `
+    const wrapper = mountWithHoc({
+      template: `
       <div>
         <Field name="field" rules="required|i18n" v-slot="{ field, errors }">
           <input v-bind="field" type="text">
@@ -328,36 +329,36 @@ test('falls back to a language specific default message if rule without message 
         </Field>
       </div>
     `,
+    });
+
+    const error = wrapper.$el.querySelector('#error');
+    const input = wrapper.$el.querySelector('input');
+    setValue(input, '12');
+    await flushPromises();
+
+    expect(error.textContent).toContain('field is ongeldig');
   });
 
-  const error = wrapper.$el.querySelector('#error');
-  const input = wrapper.$el.querySelector('input');
-  setValue(input, '12');
-  await flushPromises();
-
-  expect(error.textContent).toContain('field is ongeldig');
-});
-
-test('can switch between locales with setLocale', async () => {
-  configure({
-    generateMessage: localize({
-      en: {
-        messages: {
-          required: 'This field is required',
+  test('can switch between locales with setLocale', async () => {
+    configure({
+      generateMessage: localize({
+        en: {
+          messages: {
+            required: 'This field is required',
+          },
         },
-      },
-      ar: {
-        messages: {
-          required: 'هذا الحقل مطلوب',
+        ar: {
+          messages: {
+            required: 'هذا الحقل مطلوب',
+          },
         },
-      },
-    }),
-  });
+      }),
+    });
 
-  setLocale('en');
+    setLocale('en');
 
-  const wrapper = mountWithHoc({
-    template: `
+    const wrapper = mountWithHoc({
+      template: `
       <div>
         <Field name="field" validateOnMount rules="required" v-slot="{ field, errors }">
           <input v-bind="field" type="text">
@@ -365,32 +366,32 @@ test('can switch between locales with setLocale', async () => {
         </Field>
       </div>
     `,
+    });
+
+    const error = wrapper.$el.querySelector('#error');
+
+    // flush the pending validation.
+    await flushPromises();
+
+    expect(error.textContent).toContain('This field is required');
+    setLocale('ar');
+    setValue(wrapper.$el.querySelector('input'), '');
+
+    await flushPromises();
+    expect(error.textContent).toContain('هذا الحقل مطلوب');
   });
+  describe('default interpolation', () => {
+    test('interpolates object params with short format', async () => {
+      configure({
+        generateMessage: localize('en', {
+          messages: {
+            between: `The {field} field must be between {min} and {max}`,
+          },
+        }),
+      });
 
-  const error = wrapper.$el.querySelector('#error');
-
-  // flush the pending validation.
-  await flushPromises();
-
-  expect(error.textContent).toContain('This field is required');
-  setLocale('ar');
-  setValue(wrapper.$el.querySelector('input'), '');
-
-  await flushPromises();
-  expect(error.textContent).toContain('هذا الحقل مطلوب');
-});
-
-test('interpolates object params with short format', async () => {
-  configure({
-    generateMessage: localize('en', {
-      messages: {
-        between: `The {field} field must be between {min} and {max}`,
-      },
-    }),
-  });
-
-  const wrapper = mountWithHoc({
-    template: `
+      const wrapper = mountWithHoc({
+        template: `
         <div>
           <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
@@ -398,27 +399,27 @@ test('interpolates object params with short format', async () => {
           </Field>
         </div>
       `,
-  });
+      });
 
-  const error = wrapper.$el.querySelector('#error');
-  // flush the pending validation.
-  await flushPromises();
+      const error = wrapper.$el.querySelector('#error');
+      // flush the pending validation.
+      await flushPromises();
 
-  // locale wasn't set.
-  expect(error.textContent).toContain('The name field must be between 1 and 10');
-});
+      // locale wasn't set.
+      expect(error.textContent).toContain('The name field must be between 1 and 10');
+    });
 
-test('interpolates object params with extended format', async () => {
-  configure({
-    generateMessage: localize('en', {
-      messages: {
-        between: `The {field} field must be between 0:{min} and 1:{max}`,
-      },
-    }),
-  });
+    test('interpolates object params with extended format', async () => {
+      configure({
+        generateMessage: localize('en', {
+          messages: {
+            between: `The {field} field must be between 0:{min} and 1:{max}`,
+          },
+        }),
+      });
 
-  const wrapper = mountWithHoc({
-    template: `
+      const wrapper = mountWithHoc({
+        template: `
         <div>
           <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
@@ -426,27 +427,27 @@ test('interpolates object params with extended format', async () => {
           </Field>
         </div>
       `,
-  });
+      });
 
-  const error = wrapper.$el.querySelector('#error');
-  // flush the pending validation.
-  await flushPromises();
+      const error = wrapper.$el.querySelector('#error');
+      // flush the pending validation.
+      await flushPromises();
 
-  // locale wasn't set.
-  expect(error.textContent).toContain('The name field must be between 1 and 10');
-});
+      // locale wasn't set.
+      expect(error.textContent).toContain('The name field must be between 1 and 10');
+    });
 
-test('interpolates array params', async () => {
-  configure({
-    generateMessage: localize('en', {
-      messages: {
-        between: 'The {field} field must be between 0:{min} and 1:{max}',
-      },
-    }),
-  });
+    test('interpolates array params', async () => {
+      configure({
+        generateMessage: localize('en', {
+          messages: {
+            between: 'The {field} field must be between 0:{min} and 1:{max}',
+          },
+        }),
+      });
 
-  const wrapper = mountWithHoc({
-    template: `
+      const wrapper = mountWithHoc({
+        template: `
         <div>
           <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: [1, 10] }" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
@@ -454,27 +455,27 @@ test('interpolates array params', async () => {
           </Field>
         </div>
       `,
-  });
+      });
 
-  const error = wrapper.$el.querySelector('#error');
-  // flush the pending validation.
-  await flushPromises();
+      const error = wrapper.$el.querySelector('#error');
+      // flush the pending validation.
+      await flushPromises();
 
-  // locale wasn't set.
-  expect(error.textContent).toContain('The name field must be between 1 and 10');
-});
+      // locale wasn't set.
+      expect(error.textContent).toContain('The name field must be between 1 and 10');
+    });
 
-test('interpolates string params', async () => {
-  configure({
-    generateMessage: localize('en', {
-      messages: {
-        between: 'The {field} field must be between 0:{min} and 1:{max}',
-      },
-    }),
-  });
+    test('interpolates string params', async () => {
+      configure({
+        generateMessage: localize('en', {
+          messages: {
+            between: 'The {field} field must be between 0:{min} and 1:{max}',
+          },
+        }),
+      });
 
-  const wrapper = mountWithHoc({
-    template: `
+      const wrapper = mountWithHoc({
+        template: `
         <div>
           <Field name="name" value="-1" :validateOnMount="true" rules="between:1,10" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
@@ -482,28 +483,28 @@ test('interpolates string params', async () => {
           </Field>
         </div>
       `,
-  });
+      });
 
-  const error = wrapper.$el.querySelector('#error');
-  // flush the pending validation.
-  await flushPromises();
+      const error = wrapper.$el.querySelector('#error');
+      // flush the pending validation.
+      await flushPromises();
 
-  // locale wasn't set.
-  expect(error.textContent).toContain('The name field must be between 1 and 10');
-});
-
-describe('interpolation preserves placeholders if not found', () => {
-  test('array format', async () => {
-    configure({
-      generateMessage: localize('en', {
-        messages: {
-          between: 'The {field} field must be between 0:{min} and 1:{max}',
-        },
-      }),
+      // locale wasn't set.
+      expect(error.textContent).toContain('The name field must be between 1 and 10');
     });
 
-    const wrapper = mountWithHoc({
-      template: `
+    describe('interpolation preserves placeholders if not found', () => {
+      test('array format', async () => {
+        configure({
+          generateMessage: localize('en', {
+            messages: {
+              between: 'The {field} field must be between 0:{min} and 1:{max}',
+            },
+          }),
+        });
+
+        const wrapper = mountWithHoc({
+          template: `
         <div>
           <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: [1] }" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
@@ -511,27 +512,27 @@ describe('interpolation preserves placeholders if not found', () => {
           </Field>
         </div>
       `,
-    });
+        });
 
-    const error = wrapper.$el.querySelector('#error');
-    // flush the pending validation.
-    await flushPromises();
+        const error = wrapper.$el.querySelector('#error');
+        // flush the pending validation.
+        await flushPromises();
 
-    // locale wasn't set.
-    expect(error.textContent).toContain('The name field must be between 1 and 1:{max}');
-  });
+        // locale wasn't set.
+        expect(error.textContent).toContain('The name field must be between 1 and 1:{max}');
+      });
 
-  test('object format', async () => {
-    configure({
-      generateMessage: localize('en', {
-        messages: {
-          between: 'The {field} field must be between 0:{min} and 1:{max}',
-        },
-      }),
-    });
+      test('object format', async () => {
+        configure({
+          generateMessage: localize('en', {
+            messages: {
+              between: 'The {field} field must be between 0:{min} and 1:{max}',
+            },
+          }),
+        });
 
-    const wrapper = mountWithHoc({
-      template: `
+        const wrapper = mountWithHoc({
+          template: `
         <div>
           <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 0 } }" v-slot="{ field, errors }">
             <input v-bind="field" type="text">
@@ -539,13 +540,265 @@ describe('interpolation preserves placeholders if not found', () => {
           </Field>
         </div>
       `,
+        });
+
+        const error = wrapper.$el.querySelector('#error');
+        // flush the pending validation.
+        await flushPromises();
+
+        // locale wasn't set.
+        expect(error.textContent).toContain('The name field must be between 0 and {max}');
+      });
     });
 
-    const error = wrapper.$el.querySelector('#error');
-    // flush the pending validation.
-    await flushPromises();
+    // #4726
+    describe('custom interpolation options', () => {
+      test('interpolates object params with short format', async () => {
+        configure({
+          generateMessage: localize(
+            'en',
+            {
+              messages: {
+                between: `The {{field}} field must be between {{min}} and {{max}}`,
+              },
+            },
+            {
+              prefix: '{{',
+              suffix: '}}',
+            },
+          ),
+        });
 
-    // locale wasn't set.
-    expect(error.textContent).toContain('The name field must be between 0 and {max}');
+        const wrapper = mountWithHoc({
+          template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+        });
+
+        const error = wrapper.$el.querySelector('#error');
+        // flush the pending validation.
+        await flushPromises();
+
+        // locale wasn't set.
+        expect(error.textContent).toContain('The name field must be between 1 and 10');
+      });
+
+      test('interpolates object params with short format and handlebars style interpolation', async () => {
+        configure({
+          generateMessage: localize(
+            'en',
+            {
+              messages: {
+                between: `The <%field%> field must be between <%min%> and <%max%>`,
+              },
+            },
+            {
+              prefix: '<%',
+              suffix: '%>',
+            },
+          ),
+        });
+
+        const wrapper = mountWithHoc({
+          template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+        });
+
+        const error = wrapper.$el.querySelector('#error');
+        // flush the pending validation.
+        await flushPromises();
+
+        // locale wasn't set.
+        expect(error.textContent).toContain('The name field must be between 1 and 10');
+      });
+
+      test('interpolates object params with extended format', async () => {
+        configure({
+          generateMessage: localize(
+            'en',
+            {
+              messages: {
+                between: `The {{field}} field must be between 0:{{min}} and 1:{{max}}`,
+              },
+            },
+            {
+              prefix: '{{',
+              suffix: '}}',
+            },
+          ),
+        });
+
+        const wrapper = mountWithHoc({
+          template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 1, max: 10 } }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+        });
+
+        const error = wrapper.$el.querySelector('#error');
+        // flush the pending validation.
+        await flushPromises();
+
+        // locale wasn't set.
+        expect(error.textContent).toContain('The name field must be between 1 and 10');
+      });
+
+      test('interpolates array params', async () => {
+        configure({
+          generateMessage: localize(
+            'en',
+            {
+              messages: {
+                between: 'The {{field}} field must be between 0:{{min}} and 1:{{max}}',
+              },
+            },
+            {
+              prefix: '{{',
+              suffix: '}}',
+            },
+          ),
+        });
+
+        const wrapper = mountWithHoc({
+          template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: [1, 10] }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+        });
+
+        const error = wrapper.$el.querySelector('#error');
+        // flush the pending validation.
+        await flushPromises();
+
+        // locale wasn't set.
+        expect(error.textContent).toContain('The name field must be between 1 and 10');
+      });
+
+      test('interpolates string params', async () => {
+        configure({
+          generateMessage: localize(
+            'en',
+            {
+              messages: {
+                between: 'The {{field}} field must be between 0:{{min}} and 1:{{max}}',
+              },
+            },
+            {
+              prefix: '{{',
+              suffix: '}}',
+            },
+          ),
+        });
+
+        const wrapper = mountWithHoc({
+          template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" rules="between:1,10" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+        });
+
+        const error = wrapper.$el.querySelector('#error');
+        // flush the pending validation.
+        await flushPromises();
+
+        // locale wasn't set.
+        expect(error.textContent).toContain('The name field must be between 1 and 10');
+      });
+
+      describe('interpolation preserves placeholders if not found', () => {
+        test('array format', async () => {
+          configure({
+            generateMessage: localize(
+              'en',
+              {
+                messages: {
+                  between: 'The {{field}} field must be between 0:{{min}} and 1:{{max}}',
+                },
+              },
+              {
+                prefix: '{{',
+                suffix: '}}',
+              },
+            ),
+          });
+
+          const wrapper = mountWithHoc({
+            template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: [1] }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+          });
+
+          const error = wrapper.$el.querySelector('#error');
+          // flush the pending validation.
+          await flushPromises();
+
+          // locale wasn't set.
+          expect(error.textContent).toContain('The name field must be between 1 and 1:{{max}}');
+        });
+
+        test('object format', async () => {
+          configure({
+            generateMessage: localize(
+              'en',
+              {
+                messages: {
+                  between: 'The {{field}} field must be between 0:{{min}} and 1:{{max}}',
+                },
+              },
+              {
+                prefix: '{{',
+                suffix: '}}',
+              },
+            ),
+          });
+
+          const wrapper = mountWithHoc({
+            template: `
+        <div>
+          <Field name="name" value="-1" :validateOnMount="true" :rules="{ between: { min: 0 } }" v-slot="{ field, errors }">
+            <input v-bind="field" type="text">
+            <span id="error">{{ errors[0] }}</span>
+          </Field>
+        </div>
+      `,
+          });
+
+          const error = wrapper.$el.querySelector('#error');
+          // flush the pending validation.
+          await flushPromises();
+
+          // locale wasn't set.
+          expect(error.textContent).toContain('The name field must be between 0 and {{max}}');
+        });
+      });
+    });
   });
 });

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -24,3 +24,8 @@ export type SimpleValidationRuleFunction<TValue = unknown, TParams = unknown[] |
 export type ValidationMessageGenerator = (ctx: FieldValidationMetaInfo) => string;
 
 export type Optional<T> = T extends Record<string, any> ? Partial<T> : T | undefined;
+
+export type InterpolateOptions = {
+  prefix: string;
+  suffix: string;
+};


### PR DESCRIPTION
Allow for specifying custom interpolation options for i18n. This is useful for custom interpolation patterns, such as `{{` and `}}`. Tests added, and scoped to the i18n module.

Closes #4726

🔎 __Overview__

Adds the ability to use custom interpolation options, such as prefix and suffix.

This allows the library to comply with the default i18next standard.

🤓 __Code snippets/examples (if applicable)__

```js
configure({
  generateMessage: localize(
    'en',
    {
      messages: {
        between: 'The {{field}} field must be between 0:{{min}} and 1:{{max}}',
      },
    },
    {
      prefix: '{{',
      suffix: '}}',
    },
  ),
});
```

✔ __Issues affected__

closes #4726
