### PR TITLE
fix: ensure transformed values in field-level schemas are used on submit

### DIFF
--- a/packages/rules/src/toTypedSchema.ts
+++ b/packages/rules/src/toTypedSchema.ts
@@ -1,5 +1,5 @@
 import { keysOf } from '../../vee-validate/src/utils';
-import { TypedSchema, RawFormSchema, validateObject, TypedSchemaError, validate } from 'vee-validate';
+import { TypedSchema, RawFormSchema, validateObject, TypedSchemaError, validate, GenericObject } from 'vee-validate';
 import { Optional, isObject } from '../../shared';
 
 export function toTypedSchema<TOutput = any, TInput extends Optional<TOutput> = Optional<TOutput>>(
@@ -21,7 +21,7 @@ export function toTypedSchema<TOutput = any, TInput extends Optional<TOutput> = 
         };
       }
 
-      const result = await validateObject<TInput, TOutput>(rawSchema, values);
+      const result = await validateObject(rawSchema, values as GenericObject | undefined);
 
       return {
         errors: keysOf(result.errors).map(path => {

--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -4,10 +4,15 @@ import { FieldValidationMetaInfo } from '../../../shared';
 import { Path, PathValue } from './paths';
 import { PartialDeep } from 'type-fest';
 
-export interface ValidationResult {
+export interface ValidationResult<TValue = unknown> {
   errors: string[];
   valid: boolean;
+  value?: TValue;
 }
+
+export type FlattenAndMapPathsValidationResult<TInput extends GenericObject, TOutput extends GenericObject> = {
+  [K in Path<TInput>]: ValidationResult<TOutput[K]>;
+};
 
 export interface TypedSchemaError {
   path?: string;
@@ -81,17 +86,17 @@ export interface ValidationOptions {
   warn: boolean;
 }
 
-export type FieldValidator = (opts?: Partial<ValidationOptions>) => Promise<ValidationResult>;
+export type FieldValidator<TOutput> = (opts?: Partial<ValidationOptions>) => Promise<ValidationResult<TOutput>>;
 
-export interface PathStateConfig {
+export interface PathStateConfig<TOutput> {
   bails: boolean;
   label: MaybeRefOrGetter<string | undefined>;
   type: InputType;
-  validate: FieldValidator;
+  validate: FieldValidator<TOutput>;
   schema?: MaybeRefOrGetter<TypedSchema | undefined>;
 }
 
-export interface PathState<TValue = unknown> {
+export interface PathState<TInput = unknown, TOutput = TInput> {
   id: number | number[];
   path: string;
   touched: boolean;
@@ -100,8 +105,8 @@ export interface PathState<TValue = unknown> {
   required: boolean;
   validated: boolean;
   pending: boolean;
-  initialValue: TValue | undefined;
-  value: TValue | undefined;
+  initialValue: TInput | undefined;
+  value: TInput | undefined;
   errors: string[];
   bails: boolean;
   label: string | undefined;
@@ -112,7 +117,7 @@ export interface PathState<TValue = unknown> {
     pendingUnmount: Record<string, boolean>;
     pendingReset: boolean;
   };
-  validate?: FieldValidator;
+  validate?: FieldValidator<TOutput>;
 }
 
 export interface FieldEntry<TValue = unknown> {
@@ -139,29 +144,29 @@ export interface PrivateFieldArrayContext<TValue = unknown> extends FieldArrayCo
   path: MaybeRefOrGetter<string>;
 }
 
-export interface PrivateFieldContext<TValue = unknown> {
+export interface PrivateFieldContext<TInput = unknown, TOutput = TInput> {
   id: number;
   name: MaybeRef<string>;
-  value: Ref<TValue>;
-  meta: FieldMeta<TValue>;
+  value: Ref<TInput>;
+  meta: FieldMeta<TInput>;
   errors: Ref<string[]>;
   errorMessage: Ref<string | undefined>;
   label?: MaybeRefOrGetter<string | undefined>;
   type?: string;
   bails?: boolean;
   keepValueOnUnmount?: MaybeRefOrGetter<boolean | undefined>;
-  checkedValue?: MaybeRefOrGetter<TValue>;
-  uncheckedValue?: MaybeRefOrGetter<TValue>;
+  checkedValue?: MaybeRefOrGetter<TInput>;
+  uncheckedValue?: MaybeRefOrGetter<TInput>;
   checked?: Ref<boolean>;
-  resetField(state?: Partial<FieldState<TValue>>): void;
+  resetField(state?: Partial<FieldState<TInput>>): void;
   handleReset(): void;
-  validate: FieldValidator;
+  validate: FieldValidator<TOutput>;
   handleChange(e: Event | unknown, shouldValidate?: boolean): void;
   handleBlur(e?: Event, shouldValidate?: boolean): void;
-  setState(state: Partial<FieldState<TValue>>): void;
+  setState(state: Partial<FieldState<TInput>>): void;
   setTouched(isTouched: boolean): void;
   setErrors(message: string | string[]): void;
-  setValue(value: TValue, shouldValidate?: boolean): void;
+  setValue(value: TInput, shouldValidate?: boolean): void;
 }
 
 export type FieldContext<TValue = unknown> = Omit<PrivateFieldContext<TValue>, 'id' | 'instances'>;
@@ -197,33 +202,37 @@ export interface FormActions<TValues extends GenericObject, TOutput = TValues> {
   resetField(field: Path<TValues>, state?: Partial<FieldState>): void;
 }
 
-export interface FormValidationResult<TValues, TOutput = TValues> {
+export interface FormValidationResult<TInput extends GenericObject, TOutput extends GenericObject = TInput> {
   valid: boolean;
-  results: Partial<Record<Path<TValues>, ValidationResult>>;
-  errors: Partial<Record<Path<TValues>, string>>;
-  values?: TOutput;
+  results: Partial<FlattenAndMapPathsValidationResult<TInput, TOutput>>;
+  errors: Partial<Record<Path<TInput>, string>>;
+  values?: Partial<TOutput>;
 }
 
-export interface SubmissionContext<TValues extends GenericObject = GenericObject> extends FormActions<TValues> {
+export interface SubmissionContext<TInput extends GenericObject = GenericObject> extends FormActions<TInput> {
   evt?: Event;
-  controlledValues: Partial<TValues>;
+  controlledValues: Partial<TInput>;
 }
 
-export type SubmissionHandler<TValues extends GenericObject = GenericObject, TOutput = TValues, TReturn = unknown> = (
+export type SubmissionHandler<TInput extends GenericObject = GenericObject, TOutput = TInput, TReturn = unknown> = (
   values: TOutput,
-  ctx: SubmissionContext<TValues>,
+  ctx: SubmissionContext<TInput>,
 ) => TReturn;
 
-export interface InvalidSubmissionContext<TValues extends GenericObject = GenericObject> {
-  values: TValues;
+export interface InvalidSubmissionContext<
+  TInput extends GenericObject = GenericObject,
+  TOutput extends GenericObject = TInput,
+> {
+  values: TInput;
   evt?: Event;
-  errors: Partial<Record<Path<TValues>, string>>;
-  results: Partial<Record<Path<TValues>, ValidationResult>>;
+  errors: Partial<Record<Path<TInput>, string>>;
+  results: FormValidationResult<TInput, TOutput>['results'];
 }
 
-export type InvalidSubmissionHandler<TValues extends GenericObject = GenericObject> = (
-  ctx: InvalidSubmissionContext<TValues>,
-) => void;
+export type InvalidSubmissionHandler<
+  TInput extends GenericObject = GenericObject,
+  TOutput extends GenericObject = TInput,
+> = (ctx: InvalidSubmissionContext<TInput, TOutput>) => void;
 
 export type RawFormSchema<TValues> = Record<Path<TValues>, string | GenericValidateFunction | GenericObject>;
 
@@ -231,9 +240,9 @@ export type FieldPathLookup<TValues extends GenericObject = GenericObject> = Par
   Record<Path<TValues>, PrivateFieldContext | PrivateFieldContext[]>
 >;
 
-type HandleSubmitFactory<TValues extends GenericObject, TOutput = TValues> = <TReturn = unknown>(
+type HandleSubmitFactory<TValues extends GenericObject, TOutput extends GenericObject = TValues> = <TReturn = unknown>(
   cb: SubmissionHandler<TValues, TOutput, TReturn>,
-  onSubmitValidationErrorCb?: InvalidSubmissionHandler<TValues>,
+  onSubmitValidationErrorCb?: InvalidSubmissionHandler<TValues, TOutput>,
 ) => (e?: Event) => Promise<TReturn | undefined>;
 
 export type PublicPathState<TValue = unknown> = Omit<
@@ -310,8 +319,10 @@ export interface BaseInputBinds<TValue = unknown> {
   onInput: (e: Event) => void;
 }
 
-export interface PrivateFormContext<TValues extends GenericObject = GenericObject, TOutput = TValues>
-  extends FormActions<TValues> {
+export interface PrivateFormContext<
+  TValues extends GenericObject = GenericObject,
+  TOutput extends GenericObject = TValues,
+> extends FormActions<TValues> {
   formId: number;
   values: TValues;
   initialValues: Ref<Partial<TValues>>;
@@ -327,14 +338,17 @@ export interface PrivateFormContext<TValues extends GenericObject = GenericObjec
   keepValuesOnUnmount: MaybeRef<boolean>;
   validateSchema?: (mode: SchemaValidationMode) => Promise<FormValidationResult<TValues, TOutput>>;
   validate(opts?: Partial<ValidationOptions>): Promise<FormValidationResult<TValues, TOutput>>;
-  validateField(field: Path<TValues>, opts?: Partial<ValidationOptions>): Promise<ValidationResult>;
+  validateField<TPath extends Path<TValues>>(
+    field: TPath,
+    opts?: Partial<ValidationOptions>,
+  ): Promise<ValidationResult<TOutput[TPath]>>;
   stageInitialValue(path: string, value: unknown, updateOriginal?: boolean): void;
   unsetInitialValue(path: string): void;
   handleSubmit: HandleSubmitFactory<TValues, TOutput> & { withControlled: HandleSubmitFactory<TValues, TOutput> };
   setFieldInitialValue(path: string, value: unknown, updateOriginal?: boolean): void;
   createPathState<TPath extends Path<TValues>>(
     path: MaybeRef<TPath>,
-    config?: Partial<PathStateConfig>,
+    config?: Partial<PathStateConfig<TOutput[TPath]>>,
   ): PathState<PathValue<TValues, TPath>>;
   getPathState<TPath extends Path<TValues>>(path: TPath): PathState<PathValue<TValues, TPath>> | undefined;
   getAllPathStates(): PathState[];
@@ -387,7 +401,7 @@ export interface PrivateFormContext<TValues extends GenericObject = GenericObjec
   ): Ref<BaseInputBinds<TValue> & TExtras>;
 }
 
-export interface FormContext<TValues extends GenericObject = GenericObject, TOutput = TValues>
+export interface FormContext<TValues extends GenericObject = GenericObject, TOutput extends GenericObject = TValues>
   extends Omit<
     PrivateFormContext<TValues, TOutput>,
     | 'formId'

--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -207,6 +207,7 @@ export interface FormValidationResult<TInput extends GenericObject, TOutput exte
   results: Partial<FlattenAndMapPathsValidationResult<TInput, TOutput>>;
   errors: Partial<Record<Path<TInput>, string>>;
   values?: Partial<TOutput>;
+  source: 'schema' | 'fields' | 'none';
 }
 
 export interface SubmissionContext<TInput extends GenericObject = GenericObject> extends FormActions<TInput> {

--- a/packages/vee-validate/src/useFieldState.ts
+++ b/packages/vee-validate/src/useFieldState.ts
@@ -18,14 +18,14 @@ export interface FieldStateComposable<TValue = unknown> {
   setState(state: Partial<StateSetterInit<TValue>>): void;
 }
 
-export interface StateInit<TValue = unknown> {
-  modelValue: MaybeRef<TValue>;
+export interface StateInit<TInput = unknown, TOutput = TInput> {
+  modelValue: MaybeRef<TInput>;
   form?: PrivateFormContext;
   bails: boolean;
   label?: MaybeRefOrGetter<string | undefined>;
   type?: InputType;
-  validate?: FieldValidator;
-  schema?: MaybeRefOrGetter<TypedSchema<TValue> | undefined>;
+  validate?: FieldValidator<TOutput>;
+  schema?: MaybeRefOrGetter<TypedSchema<TInput> | undefined>;
 }
 
 let ID_COUNTER = 0;

--- a/packages/vee-validate/src/useValidateField.ts
+++ b/packages/vee-validate/src/useValidateField.ts
@@ -6,13 +6,13 @@ import { injectWithSelf, warn } from './utils';
 /**
  * Validates a single field
  */
-export function useValidateField(path?: MaybeRefOrGetter<string>) {
+export function useValidateField<TOutput>(path?: MaybeRefOrGetter<string>) {
   const form = injectWithSelf(FormContextKey);
   const field = path ? undefined : inject(FieldContextKey);
 
-  return function validateField(): Promise<ValidationResult> {
+  return function validateField(): Promise<ValidationResult<TOutput>> {
     if (field) {
-      return field.validate();
+      return field.validate() as Promise<ValidationResult<TOutput>>;
     }
 
     if (form && path) {

--- a/packages/vee-validate/src/useValidateForm.ts
+++ b/packages/vee-validate/src/useValidateForm.ts
@@ -15,7 +15,7 @@ export function useValidateForm<TValues extends Record<string, unknown> = Record
 
   return function validateField(): Promise<FormValidationResult<TValues>> {
     if (!form) {
-      return Promise.resolve({ results: {}, errors: {}, valid: true });
+      return Promise.resolve({ results: {}, errors: {}, valid: true, source: 'none' });
     }
 
     return form.validate();

--- a/packages/vee-validate/src/validate.ts
+++ b/packages/vee-validate/src/validate.ts
@@ -73,7 +73,10 @@ export async function validate<TInput, TOutput>(
 /**
  * Starts the validation process.
  */
-async function _validate<TInput = unknown, TOutput = TInput>(field: FieldValidationContext<TInput, TOutput>, value: TInput) {
+async function _validate<TInput = unknown, TOutput = TInput>(
+  field: FieldValidationContext<TInput, TOutput>,
+  value: TInput,
+) {
   const rules = field.rules;
   if (isTypedSchema(rules) || isYupValidator(rules)) {
     return validateFieldWithTypedSchema(value, { ...field, rules });
@@ -329,6 +332,7 @@ export async function validateTypedSchema<TValues extends GenericObject, TOutput
     results,
     errors,
     values: validationResult.value,
+    source: 'schema',
   };
 }
 
@@ -374,5 +378,6 @@ export async function validateObjectSchema<TValues extends GenericObject, TOutpu
     valid: isAllValid,
     results,
     errors,
+    source: 'schema',
   };
 }

--- a/packages/vee-validate/src/validate.ts
+++ b/packages/vee-validate/src/validate.ts
@@ -6,9 +6,11 @@ import {
   ValidationResult,
   GenericValidateFunction,
   TypedSchema,
+  FlattenAndMapPathsValidationResult,
   FormValidationResult,
   RawFormSchema,
   YupSchema,
+  GenericObject,
   TypedSchemaError,
   Path,
   TypedSchemaContext,
@@ -18,13 +20,13 @@ import { isCallable, FieldValidationMetaInfo } from '../../shared';
 /**
  * Used internally
  */
-interface FieldValidationContext<TValue = unknown> {
+interface FieldValidationContext<TInput = unknown, TOutput = TInput> {
   name: string;
   label?: string;
   rules:
-    | GenericValidateFunction<TValue>
-    | GenericValidateFunction<TValue>[]
-    | TypedSchema<TValue>
+    | GenericValidateFunction<TInput>
+    | GenericValidateFunction<TInput>[]
+    | TypedSchema<TInput, TOutput>
     | string
     | Record<string, unknown>;
   bails: boolean;
@@ -41,18 +43,18 @@ interface ValidationOptions {
 /**
  * Validates a value against the rules.
  */
-export async function validate<TValue = unknown>(
-  value: TValue,
+export async function validate<TInput, TOutput>(
+  value: TInput,
   rules:
     | string
     | Record<string, unknown | unknown[]>
-    | GenericValidateFunction<TValue>
-    | GenericValidateFunction<TValue>[]
-    | TypedSchema<TValue>,
+    | GenericValidateFunction<TInput>
+    | GenericValidateFunction<TInput>[]
+    | TypedSchema<TInput, TOutput>,
   options: ValidationOptions = {},
-): Promise<ValidationResult> {
+): Promise<ValidationResult<TOutput>> {
   const shouldBail = options?.bails;
-  const field: FieldValidationContext<TValue> = {
+  const field: FieldValidationContext<TInput, TOutput> = {
     name: options?.name || '{field}',
     rules,
     label: options?.label,
@@ -61,18 +63,17 @@ export async function validate<TValue = unknown>(
   };
 
   const result = await _validate(field, value);
-  const errors = result.errors;
 
   return {
-    errors,
-    valid: !errors.length,
+    ...result,
+    valid: !result.errors.length,
   };
 }
 
 /**
  * Starts the validation process.
  */
-async function _validate<TValue = unknown>(field: FieldValidationContext<TValue>, value: TValue) {
+async function _validate<TInput = unknown, TOutput = TInput>(field: FieldValidationContext<TInput, TOutput>, value: TInput) {
   const rules = field.rules;
   if (isTypedSchema(rules) || isYupValidator(rules)) {
     return validateFieldWithTypedSchema(value, { ...field, rules });
@@ -222,6 +223,7 @@ async function validateFieldWithTypedSchema(
   }
 
   return {
+    value: result.value,
     errors: messages,
   };
 }
@@ -300,14 +302,14 @@ function fillTargetValues(params: unknown[] | Record<string, unknown>, crossTabl
   );
 }
 
-export async function validateTypedSchema<TValues, TOutput = TValues>(
+export async function validateTypedSchema<TValues extends GenericObject, TOutput extends GenericObject = TValues>(
   schema: TypedSchema<TValues> | YupSchema<TValues>,
   values: TValues,
 ): Promise<FormValidationResult<TValues, TOutput>> {
   const typedSchema = isTypedSchema(schema) ? schema : yupToTypedSchema(schema);
   const validationResult = await typedSchema.parse(deepCopy(values));
 
-  const results: Partial<Record<Path<TValues>, ValidationResult>> = {};
+  const results: Partial<FlattenAndMapPathsValidationResult<TValues, TOutput>> = {};
   const errors: Partial<Record<Path<TValues>, string>> = {};
   for (const error of validationResult.errors) {
     const messages = error.errors;
@@ -330,9 +332,9 @@ export async function validateTypedSchema<TValues, TOutput = TValues>(
   };
 }
 
-export async function validateObjectSchema<TValues, TOutput>(
+export async function validateObjectSchema<TValues extends GenericObject, TOutput extends GenericObject>(
   schema: RawFormSchema<TValues>,
-  values: TValues,
+  values: TValues | undefined,
   opts?: Partial<{ names: Record<string, { name: string; label: string }>; bailsMap: Record<string, boolean> }>,
 ): Promise<FormValidationResult<TValues, TOutput>> {
   const paths = keysOf(schema) as Path<TValues>[];
@@ -354,7 +356,7 @@ export async function validateObjectSchema<TValues, TOutput>(
   let isAllValid = true;
   const validationResults = await Promise.all(validations);
 
-  const results: Partial<Record<Path<TValues>, ValidationResult>> = {};
+  const results: Partial<FlattenAndMapPathsValidationResult<TValues, TOutput>> = {};
   const errors: Partial<Record<Path<TValues>, string>> = {};
   for (const result of validationResults) {
     results[result.path] = {

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -240,6 +240,7 @@ describe('useForm()', () => {
           errors: [REQUIRED_MESSAGE],
         },
       },
+      values: {},
     });
   });
 

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -226,6 +226,7 @@ describe('useForm()', () => {
     const result = await validate();
     expect(result).toEqual({
       valid: false,
+      source: 'fields',
       errors: {
         field1: REQUIRED_MESSAGE,
         field2: REQUIRED_MESSAGE,
@@ -270,6 +271,7 @@ describe('useForm()', () => {
     const result = await pending;
     expect(result).toEqual({
       valid: false,
+      source: 'schema',
       errors: {
         field1: REQUIRED_MESSAGE,
         field2: REQUIRED_MESSAGE,


### PR DESCRIPTION
🔎 __Overview__

This PR allows for the transformed value to pass through as the submitted value, when the transformation is declared in a field-level schema in `useField` (as opposed to a top-level schema declared in `useForm`).  This affects both Zod and Yup.

This is a revision of https://github.com/logaretm/vee-validate/pull/4692 

- ✅ Many internal types adjusted to allow for a `<TInput, TOutput>` vs `<TValues>`
- ✅ Typecheck passes
- ✅ Rebased
- ✅ All existing tests pass
- ✅ New test with zod and a new test with yup added for this behavior

🤓 __Code snippets/examples (if applicable)__

```ts
// in a field component

const testRules = toTypedSchema(z.string().transform(value => value.trim()));
const { value } = useField('test', testRules);

// in a form component / page

const { handleSubmit } = useForm<{ test: string }>();

handleSubmit((values) => {
  console.log(values.test); // logs "hello" (with this PR)
});
```

With the above field-level usage, on submission of the value `"  hello  "` (notice the spaces) with the `main` branch, the value in `values.test` is `"  hello  "`. Notice the transformation `.trim` has not been applied.

See the bundled tests for more detail.

✔ __Issues affected__

Closes #4713 
 
