### PR TITLE
yup should be a peerdependencies

### DIFF
--- a/packages/yup/package.json
+++ b/packages/yup/package.json
@@ -30,8 +30,10 @@
   "dependencies": {
     "type-fest": "^4.8.3",
     "vee-validate": "workspace:*",
-    "yup": "^1.3.2"
   },
+  "peerDependencies": {
+    "yup": "^1.3.2"
+  }
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
i have moved `yup` to `peerDependencies` to allow users the flexibility to manage the version of `yup` in their own projects.
 
