### PR TITLE
fix: remove non-existent `validated` property from `FormMeta` types

### DIFF
--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -61,7 +61,6 @@ export interface FormMeta<TValues extends GenericObject> {
   touched: boolean;
   dirty: boolean;
   valid: boolean;
-  validated: boolean;
   pending: boolean;
   initialValues?: Partial<TValues>;
 }


### PR DESCRIPTION
🔎 __Overview__

<!-- Explain the why behind adding this PR, here is a couple of examples -->
<!--
  This PR {adds/fixes/improves} the {feature/bug/something}.
  This PR changes the {locale} messages style because {reason}
-->

I noticed that this "property" was `undefined`, and then realised the docs don't include it so it should be removed from the types.

~It looks like the `FieldMeta` interface has `required` which doesn't exist either, but I'll do a dedicated PR to remove that~