### PR TITLE
fix: remove non-existent `required` property from `FieldMeta` types

### DIFF
--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -52,7 +52,6 @@ export interface FieldMeta<TValue> {
   dirty: boolean;
   valid: boolean;
   validated: boolean;
-  required: boolean;
   pending: boolean;
   initialValue?: TValue;
 }


### PR DESCRIPTION
🔎 __Overview__

<!-- Explain the why behind adding this PR, here is a couple of examples -->
<!--
  This PR {adds/fixes/improves} the {feature/bug/something}.
  This PR changes the {locale} messages style because {reason}
-->

I noticed that this "property" was `undefined`, and then realised the docs don't include it so it should be removed from the types.