### PR TITLE
chore: explicit dependencies for integrations

### DIFF
--- a/docs/src/pages/guide/composition-api/typed-schema.mdx
+++ b/docs/src/pages/guide/composition-api/typed-schema.mdx
@@ -286,11 +286,11 @@ You can use valibot as a typed schema with the `@vee-validate/valibot` package:
 
 ```sh
 # npm
-npm install @vee-validate/valibot
+npm install @vee-validate/valibot valibot
 # yarn
-yarn add @vee-validate/valibot
+yarn add @vee-validate/valibot valibot
 # pnpm
-pnpm add @vee-validate/valibot
+pnpm add @vee-validate/valibot valibot
 ```
 
 The `@vee-valdiate/valibot` package exposes a `toTypedSchema` function that accepts any valibot schema. Which then you can pass along to `validationSchema` option on `useForm`.

--- a/docs/src/pages/guide/composition-api/typed-schema.mdx
+++ b/docs/src/pages/guide/composition-api/typed-schema.mdx
@@ -186,11 +186,11 @@ You can use zod as a typed schema with the `@vee-validate/zod` package:
 
 ```sh
 # npm
-npm install @vee-validate/zod
+npm install @vee-validate/zod zod
 # yarn
-yarn add @vee-validate/zod
+yarn add @vee-validate/zod zod
 # pnpm
-pnpm add @vee-validate/zod
+pnpm add @vee-validate/zod zod
 ```
 
 The `@vee-valdiate/zod` package exposes a `toTypedSchema` function that accepts any zod schema. Which then you can pass along to `validationSchema` option on `useForm`.

--- a/docs/src/pages/guide/composition-api/typed-schema.mdx
+++ b/docs/src/pages/guide/composition-api/typed-schema.mdx
@@ -91,11 +91,11 @@ You can use yup as a typed schema with the `@vee-validate/yup` package:
 
 ```sh
 # npm
-npm install @vee-validate/yup
+npm install @vee-validate/yup yup
 # yarn
-yarn add @vee-validate/yup
+yarn add @vee-validate/yup yup
 # pnpm
-pnpm add @vee-validate/yup
+pnpm add @vee-validate/yup yup
 ```
 
 The `@vee-valdiate/yup` package exposes a `toTypedSchema` function that accepts any yup schema. Which then you can pass along to `validationSchema` option on `useForm`.

--- a/packages/joi/README.md
+++ b/packages/joi/README.md
@@ -30,11 +30,11 @@ You can use joi as a typed schema with the `@vee-validate/joi` package:
 
 ```sh
 # npm
-npm install @vee-validate/joi
+npm install @vee-validate/joi joi
 # yarn
-yarn add @vee-validate/joi
+yarn add @vee-validate/joi joi
 # pnpm
-pnpm add @vee-validate/joi
+pnpm add @vee-validate/joi joi
 ```
 
 The `@vee-valdiate/joi` package exposes a `toTypedSchema` function that accepts any joi schema. Which then you can pass along to `validationSchema` option on `useForm`.

--- a/packages/joi/package.json
+++ b/packages/joi/package.json
@@ -28,8 +28,13 @@
     "dist/*.d.ts"
   ],
   "dependencies": {
+    "type-fest": "^4.8.3"
+  },
+  "peerDependencies": {
     "joi": "17.11.0",
-    "type-fest": "^4.8.3",
     "vee-validate": "workspace:*"
+  },
+  "devDependencies": {
+    "joi": "17.11.0"
   }
 }

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -27,7 +27,7 @@
     "dist/*.js",
     "dist/*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "vee-validate": "workspace:*"
   }
 }

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -28,8 +28,13 @@
     "dist/*.d.ts"
   ],
   "dependencies": {
-    "type-fest": "^4.8.3",
+    "type-fest": "^4.8.3"
+  },
+  "peerDependencies": {
     "valibot": "^0.33.0",
     "vee-validate": "workspace:*"
+  },
+  "devDependencies": {
+    "valibot": "^0.33.0"
   }
 }

--- a/packages/yup/README.md
+++ b/packages/yup/README.md
@@ -21,11 +21,11 @@ You can use [yup](https://github.com/jquense/yup) as a typed schema with the `@v
 
 ```sh
 # npm
-npm install @vee-validate/yup
+npm install @vee-validate/yup yup
 # yarn
-yarn add @vee-validate/yup
+yarn add @vee-validate/yup yup
 # pnpm
-pnpm add @vee-validate/yup
+pnpm add @vee-validate/yup yup
 ```
 
 The `@vee-valdiate/yup` package exposes a `toTypedSchema` function that accepts any yup schema. Which then you can pass along to `validationSchema` option on `useForm`.

--- a/packages/yup/package.json
+++ b/packages/yup/package.json
@@ -28,8 +28,13 @@
     "dist/*.d.ts"
   ],
   "dependencies": {
-    "type-fest": "^4.8.3",
+    "type-fest": "^4.8.3"
+  },
+  "peerDependencies": {
     "vee-validate": "workspace:*",
+    "yup": "^1.3.2"
+  },
+  "devDependencies": {
     "yup": "^1.3.2"
   },
   "publishConfig": {

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -30,11 +30,11 @@ You can use zod as a typed schema with the `@vee-validate/zod` package:
 
 ```sh
 # npm
-npm install @vee-validate/zod
+npm install @vee-validate/zod zod
 # yarn
-yarn add @vee-validate/zod
+yarn add @vee-validate/zod zod
 # pnpm
-pnpm add @vee-validate/zod
+pnpm add @vee-validate/zod zod
 ```
 
 The `@vee-valdiate/zod` package exposes a `toTypedSchema` function that accepts any zod schema. Which then you can pass along to `validationSchema` option on `useForm`.

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -28,8 +28,13 @@
     "dist/*.d.ts"
   ],
   "dependencies": {
-    "type-fest": "^4.8.3",
+    "type-fest": "^4.8.3"
+  },
+  "peerDependencies": {
     "vee-validate": "workspace:*",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
     "zod": "^3.22.4"
   }
 }


### PR DESCRIPTION
🔎 __Overview__

This PR eliminates the implicit dependency for developers on integration with a specific validator. Since the vee-validate integration directly depends on the validator in `dependencies`, it is impossible to install a version higher or lower without duplication. The integration does not export the validator, so the developer needs to install it separately, leading to duplication and errors.

We constantly monitor dependencies in our project, and running npm update caused dependency duplication whenever a patch version of the validator was released. Because of this, we had to specify "overrides" for the integration with our validator. Additionally, Eslint rules will complain if we do not specify the dependency in `dependencies`.

In any case, if the developer forgets to install the dependencies, npm will handle it starting from version 9.