### PR TITLE
doc: fix wording on i18N

### DIFF
--- a/docs/src/pages/guide/i18n.mdx
+++ b/docs/src/pages/guide/i18n.mdx
@@ -75,7 +75,7 @@ yarn add @vee-validate/i18n
 npm install @vee-validate/i18n
 ```
 
-\import the `localize()` function from `@vee-validate/i18n` which returns a message generator function:
+Import the `localize()` function from `@vee-validate/i18n` which returns a message generator function:
 
 ```js
 import { defineRule, configure } from 'vee-validate';


### PR DESCRIPTION
🔎 __Overview__

<!-- Explain the why behind adding this PR, here is a couple of examples -->
<!--
  This PR {adds/fixes/improves} the {feature/bug/something}.
  This PR changes the {locale} messages style because {reason}
-->

On https://vee-validate.logaretm.com/v4/guide/i18n/, you can see this following sentence:
<img width="822" alt="image" src="https://github.com/user-attachments/assets/e93f0c75-9854-40ff-a286-dda9df90452c">

The `\import` should be replaced by `Import`.  


🤓 __Code snippets/examples (if applicable)__

```js
// some code
```

✔ __Issues affected__

<!-- list of issues formatted like this
closes #{issue id}
 -->
 
