### PR TITLE
fix: allow passing valibot parsing config/option

### DIFF
--- a/packages/valibot/src/index.ts
+++ b/packages/valibot/src/index.ts
@@ -3,6 +3,7 @@ import { cleanupNonNestedPath, isNotNestedPath, type TypedSchema, type TypedSche
 import {
   InferOutput,
   InferInput,
+  InferIssue,
   BaseSchema,
   BaseSchemaAsync,
   safeParseAsync,

--- a/packages/valibot/src/index.ts
+++ b/packages/valibot/src/index.ts
@@ -23,6 +23,7 @@ import {
   StrictObjectSchema,
   LooseObjectSchema,
   getDotPath,
+  Config, 
 } from 'valibot';
 import { isIndex, isObject, merge, normalizeFormPath } from '../../shared';
 
@@ -32,11 +33,11 @@ export function toTypedSchema<
     | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
   TInferOutput = InferOutput<TSchema>,
   TInferInput = PartialDeep<InferInput<TSchema>>,
->(valibotSchema: TSchema): TypedSchema<TInferInput, TInferOutput> {
+>(valibotSchema: TSchema, config?: Config<InferIssue<TSchema>> ): TypedSchema<TInferInput, TInferOutput> {
   const schema: TypedSchema = {
     __type: 'VVTypedSchema',
     async parse(value) {
-      const result = await safeParseAsync(valibotSchema, value);
+      const result = await safeParseAsync(valibotSchema, value, config);
       if (result.success) {
         return {
           value: result.output,
@@ -56,7 +57,7 @@ export function toTypedSchema<
         return values;
       }
 
-      const result = safeParse(valibotSchema, values);
+      const result = safeParse(valibotSchema, values, config);
       if (result.success) {
         return result.output;
       }


### PR DESCRIPTION
```js
// before:
safeParseAsync(valibotSchema, value)
safeParse(valibotSchema, values)

// after:
safeParseAsync(valibotSchema, value, config)
safeParse(valibotSchema, values, config)
```
