### PR TITLE
feat: provide form values as context for yup schema extending #4753

### DIFF
--- a/packages/vee-validate/src/validate.ts
+++ b/packages/vee-validate/src/validate.ts
@@ -310,7 +310,7 @@ export async function validateTypedSchema<TValues extends GenericObject, TOutput
   values: TValues,
 ): Promise<FormValidationResult<TValues, TOutput>> {
   const typedSchema = isTypedSchema(schema) ? schema : yupToTypedSchema(schema);
-  const validationResult = await typedSchema.parse(deepCopy(values));
+  const validationResult = await typedSchema.parse(deepCopy(values), { formData: deepCopy(values) });
 
   const results: Partial<FlattenAndMapPathsValidationResult<TValues, TOutput>> = {};
   const errors: Partial<Record<Path<TValues>, string>> = {};


### PR DESCRIPTION
🔎 __Overview__

This PR improves the implementation from #{4753} by passing the context to yup when passing to form the validation schema.

Example:

```js
    setup() {
      const validationSchema = yup.object({
        password: yup.string().required().min(3).label('Password'),
        confirmPassword: yup
          .string()
          .required()
          .oneOf([yup.ref('$password')])
          .label('Confirm Password'),
      });

      return {
        validationSchema,
      };
    },
    template: `
      <VForm  v-slot="{ errors }" :validation-schema="validationSchema">
        <Field id="password" name="password" type="password" />
        <span id="passwordErr">{{ errors.password }}</span>
        <Field id="confirmPassword" name="confirmPassword" type="password" />
        <span id="confirmPasswordErr">{{ errors.confirmPassword }}</span>
        <button>Validate</button>
      </VForm>
```

✔ __Issues affected__

extends #{4753}
 
