### PR TITLE
fix: create locator get wrong value when it is a falsy value

### DIFF
--- a/packages/vee-validate/src/utils/rules.ts
+++ b/packages/vee-validate/src/utils/rules.ts
@@ -119,7 +119,7 @@ export const parseRule = (rule: string) => {
 
 function createLocator(value: string): Locator {
   const locator: Locator = (crossTable: Record<string, unknown>) => {
-    const val = getFromPath(crossTable, value) || crossTable[value];
+    const val = getFromPath(crossTable, value) ?? crossTable[value];
 
     return val;
   };


### PR DESCRIPTION
When creating a rule to verify that one field matches another, using the shorthand '@' prefix may return an incorrect value if the field has a falsy value, such as 0 or false.