### PR TITLE
[Docs] Remove redundant type text

### DIFF
--- a/docs/src/pages/api/use-field.mdx
+++ b/docs/src/pages/api/use-field.mdx
@@ -375,7 +375,6 @@ import { useField } from 'vee-validate';
 // a simple `company` field with some options passed into it
 const { value, errorMessage } = useField('company', ..., {
   label: 'Your company',
-  type: 'text',
   initialValue: ''
 });
 </script>


### PR DESCRIPTION
🔎 __Overview__

I wrote this small piece of documentation a while ago, since then I learned that type 'text' doesn't actually exist from the TypeScript defintion of `InputType`. Type can be 'checkbox', 'radio' or 'default', so type 'text' just makes it revert to the 'default'. 

So I'd like to remove this redundant line so people don't make this mistake.

🤓 __Code snippets/examples (if applicable)__

```js
// the InputType export

export type InputType = 'checkbox' | 'radio' | 'default';
```

✔ __Issues affected__

N/A
