### PR TITLE
[Docs] SetValue documentation

### DIFF
--- a/docs/src/pages/api/use-field.mdx
+++ b/docs/src/pages/api/use-field.mdx
@@ -122,6 +122,20 @@ You can also bind it with `v-model` to get two-way value binding with validation
 
 <CodeTitle level="4">
 
+`setValue: Ref<TValue = unknown>`
+
+</CodeTitle>
+
+A method to update the fields value.
+
+```js
+const { setValue } = useField('field', value => !!value);
+
+setValue('hello world') // sets the value and validates the field
+```
+
+<CodeTitle level="4">
+
 `meta: FieldMeta<TValue = unknown>`
 
 </CodeTitle>


### PR DESCRIPTION
🔎 __Overview__

`setValue` is a cleaner alternative to changing `field.value.value` but was never documented. I have used it extensively in my own code.

🤓 __Code snippets/examples (if applicable)__

```js
const { setValue } = useField('field', value => !!value);

setValue('hello world') // sets the value and validates the field
```

✔ __Issues affected__

N/A
 
