### PR TITLE
feat: allow setting a name for the form

### DIFF
--- a/packages/vee-validate/src/Form.ts
+++ b/packages/vee-validate/src/Form.ts
@@ -77,7 +77,7 @@ const FormImpl = /** #__PURE__ */ defineComponent({
     },
     name: {
       type: String,
-      default: undefined,
+      default: 'Form',
     },
   },
   setup(props, ctx) {

--- a/packages/vee-validate/src/Form.ts
+++ b/packages/vee-validate/src/Form.ts
@@ -75,6 +75,10 @@ const FormImpl = /** #__PURE__ */ defineComponent({
       type: Boolean,
       default: false,
     },
+    name: {
+      type: String,
+      default: undefined,
+    },
   },
   setup(props, ctx) {
     const validationSchema = toRef(props, 'validationSchema');
@@ -108,6 +112,7 @@ const FormImpl = /** #__PURE__ */ defineComponent({
       initialTouched: props.initialTouched,
       validateOnMount: props.validateOnMount,
       keepValuesOnUnmount: keepValues,
+      name: props.name,
     });
 
     const submitForm = handleSubmit((_, { evt }) => {

--- a/packages/vee-validate/src/devtools.ts
+++ b/packages/vee-validate/src/devtools.ts
@@ -254,7 +254,7 @@ function mapFormForDevtoolsInspector(form: PrivateFormContext): CustomInspectorN
 
   return {
     id: encodeNodeId(form),
-    label: 'Form',
+    label: form.name,
     children,
     tags: [
       {

--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -323,6 +323,7 @@ export interface PrivateFormContext<
   TValues extends GenericObject = GenericObject,
   TOutput extends GenericObject = TValues,
 > extends FormActions<TValues> {
+  name: string;
   formId: number;
   values: TValues;
   initialValues: Ref<Partial<TValues>>;

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -92,6 +92,7 @@ export interface FormOptions<
   initialTouched?: FlattenAndSetPathsType<TValues, boolean>;
   validateOnMount?: boolean;
   keepValuesOnUnmount?: MaybeRef<boolean>;
+  name?: string;
 }
 
 let FORM_COUNTER = 0;
@@ -117,6 +118,7 @@ export function useForm<
     | TypedSchema<TValues, TOutput>,
 >(opts?: FormOptions<TValues, TOutput, TSchema>): FormContext<TValues, TOutput> {
   const formId = FORM_COUNTER++;
+  const name = opts?.name || 'Form';
 
   // Prevents fields from double resetting their values, which causes checkboxes to toggle their initial value
   let FIELD_ID_COUNTER = 0;
@@ -638,6 +640,7 @@ export function useForm<
   }
 
   const formCtx: PrivateFormContext<TValues, TOutput> = {
+    name,
     formId,
     values: formValues,
     controlledValues,


### PR DESCRIPTION
🔎 __Overview__
This adds ability to set a `name` for a form so that it can be distinguished in the devtools.

![CleanShot X 2024-11-08 12 01 30](https://github.com/user-attachments/assets/a643328e-c2b2-49c2-a9bf-503f77aec210)


<!-- Explain the why behind adding this PR, here is a couple of examples -->
<!--
  This PR {adds/fixes/improves} the {feature/bug/something}.
  This PR changes the {locale} messages style because {reason}
-->

🤓 __Code snippets/examples (if applicable)__

A name can be set in the component:
```vue
<Form name="FormA">
....
</Form>
```

or in the composable:
```ts
const form = useForm({
   name: "FormA"
});

```

✔ __Issues affected__

Closes #4930
 
