### PR TITLE
fix(devtools): load Vue devtools lazily

### DIFF
--- a/.changeset/polite-spoons-swim.md
+++ b/.changeset/polite-spoons-swim.md
@@ -1,0 +1,5 @@
+---
+"vee-validate": patch
+---
+
+fix: lazy load the devtools dep to force it out of production bundle

--- a/packages/vee-validate/src/devtools.ts
+++ b/packages/vee-validate/src/devtools.ts
@@ -1,5 +1,4 @@
 import { App, ComponentInternalInstance, getCurrentInstance, nextTick, onUnmounted, toValue, unref } from 'vue';
-import { setupDevtoolsPlugin } from '@vue/devtools-api';
 import type { InspectorNodeTag, CustomInspectorState, CustomInspectorNode } from '@vue/devtools-kit';
 import { PathState, PrivateFieldContext, PrivateFormContext } from './types';
 import { keysOf, setInPath, throttle } from './utils';
@@ -33,9 +32,10 @@ let SELECTED_NODE:
  */
 let API: any;
 
-function installDevtoolsPlugin(app: App) {
+async function installDevtoolsPlugin(app: App) {
   if (__DEV__) {
-    setupDevtoolsPlugin(
+    const devtools = await import('@vue/devtools-api');
+    devtools.setupDevtoolsPlugin(
       {
         id: 'vee-validate-devtools-plugin',
         label: 'VeeValidate Plugin',


### PR DESCRIPTION
# What

It was noticed in #4943 that the devtools gets bundled in as a result of it being an imported dependency.

I will experiment with lazy loading it and see if it works well or not, since I do not think I can force it to be tree-shaken.