### PR TITLE
docs: fix types for Field slot props

### DIFF
--- a/docs/src/pages/api/field.mdx
+++ b/docs/src/pages/api/field.mdx
@@ -309,7 +309,7 @@ The field name.
 
 <CodeTitle level="5">
 
-`field.onBlur: Function[]`
+`field.onBlur: (e: Event | unknown) => void`
 
 </CodeTitle>
 
@@ -317,7 +317,7 @@ An array containing a few listeners for the `blur` event, it involves updating s
 
 <CodeTitle level="5">
 
-`field.onInput: Function[]`
+`field.onInput: (e: Event | unknown) => void`
 
 </CodeTitle>
 
@@ -325,7 +325,7 @@ An array containing a few listeners for the `input` event, it involves updating 
 
 <CodeTitle level="5">
 
-`field.onChange: Function[]`
+`field.onChange: (e: Event | unknown) => void`
 
 </CodeTitle>
 


### PR DESCRIPTION
🔎 __Overview__

The types for the `field.on*` slot props of the `Field` component were changed in ce2f539, but the docs were never updated.