### PR TITLE
fix(Form): add GenericObject type parameter to SubmissionHandler

### DIFF
--- a/packages/vee-validate/src/Form.ts
+++ b/packages/vee-validate/src/Form.ts
@@ -1,8 +1,8 @@
-import { h, defineComponent, toRef, resolveDynamicComponent, PropType, VNode, UnwrapRef } from 'vue';
-import { useForm } from './useForm';
-import { SubmissionHandler, InvalidSubmissionHandler, GenericObject, FormMeta, FormContext, FormErrors } from './types';
-import { isEvent, isFormSubmitEvent, normalizeChildren } from './utils';
 import { klona as deepCopy } from 'klona/full';
+import { defineComponent, h, PropType, resolveDynamicComponent, toRef, UnwrapRef, VNode } from 'vue';
+import { FormContext, FormErrors, FormMeta, GenericObject, InvalidSubmissionHandler, SubmissionHandler } from './types';
+import { useForm } from './useForm';
+import { isEvent, isFormSubmitEvent, normalizeChildren } from './utils';
 
 export type FormSlotProps = UnwrapRef<
   Pick<
@@ -64,7 +64,7 @@ const FormImpl = /** #__PURE__ */ defineComponent({
       default: false,
     },
     onSubmit: {
-      type: Function as PropType<SubmissionHandler>,
+      type: Function as PropType<SubmissionHandler<GenericObject>>,
       default: undefined,
     },
     onInvalidSubmit: {


### PR DESCRIPTION
🔎 __Overview__

This PR fixes the type error in Form component's `onSubmit` prop type definition. The current implementation without type parameter for `SubmissionHandler` needs to be updated to explicitly use `GenericObject` to ensure proper type checking for form submissions.

🤓 __Code snippets/examples__

```typescript
// Type definition
export type StoreInput = z.infer<typeof storeSchema>

// Usage example causing error
<Form
  :validation-schema="validationSchema"
  @submit="onSubmit"  // Type '(values: StoreInput) => Promise<void>' is not assignable to type 'SubmissionHandler<GenericObject, GenericObject, unknown>'.

>

// Before
onSubmit: {
  type: Function as PropType<SubmissionHandler>,
  default: undefined,
},

// After
onSubmit: {
  type: Function as PropType<SubmissionHandler<GenericObject>>,
  default: undefined,
},
```

✔ __Issues affected__

