### PR TITLE
fix(types): align error object types with JS object structure

### DIFF
--- a/.changeset/angry-pens-hug.md
+++ b/.changeset/angry-pens-hug.md
@@ -1,0 +1,5 @@
+---
+"vee-validate": patch
+---
+
+Align FormErrors type with its actual structure at runtime.

--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -182,8 +182,8 @@ export interface FormState<TValues> {
   submitCount: number;
 }
 
-export type FormErrors<TValues extends GenericObject> = Partial<Record<Path<TValues>, string | undefined>>;
-export type FormErrorBag<TValues extends GenericObject> = Partial<Record<Path<TValues>, string[]>>;
+export type FormErrors<TValues extends GenericObject> = Partial<Record<Path<TValues> | '', string | undefined>>;
+export type FormErrorBag<TValues extends GenericObject> = Partial<Record<Path<TValues> | '', string[]>>;
 
 export interface ResetFormOpts {
   force: boolean;

--- a/packages/vee-validate/src/types/paths.ts
+++ b/packages/vee-validate/src/types/paths.ts
@@ -72,37 +72,68 @@ type AnyIsEqual<T1, T2> = T1 extends T2 ? (IsEqual<T1, T2> extends true ? true :
 type TupleKeys<T extends ReadonlyArray<any>> = Exclude<keyof T, keyof any[]>;
 
 /**
- * Helper type for recursively constructing paths through a type.
- * This actually constructs the strings and recurses into nested
- * object types.
+ * Helper type to construct tuple key paths and recurse into its elements.
  *
  * See {@link Path}
  */
-type PathImpl<K extends string | number, V, TraversedTypes> = V extends Primitive | BrowserNativeObject
-  ? `${K}`
-  : // Check so that we don't recurse into the same type
-    // by ensuring that the types are mutually assignable
-    // mutually required to avoid false positives of subtypes
-    true extends AnyIsEqual<TraversedTypes, V>
-    ? `${K}`
-    : `${K}` | `${K}.${PathInternal<V, TraversedTypes | V>}`;
+type PathInternalTuple<TValue extends ReadonlyArray<any>, TraversedTypes> = {
+  [Key in TupleKeys<TValue> & string]: `[${Key}]` | `[${Key}]${PathInternal<TValue[Key], TraversedTypes, false>}`;
+}[TupleKeys<TValue> & string];
+
+/**
+ * Helper type to construct array key paths and recurse into its elements.
+ *
+ * See {@link Path}
+ */
+type PathInternalArray<TValue extends ReadonlyArray<any>, TraversedTypes> =
+  | `[${ArrayKey}]`
+  | `[${ArrayKey}]${PathInternal<TValue[ArrayKey], TraversedTypes, false>}`;
+
+/**
+ * Helper type to construct object key paths and recurse into its nested values.
+ *
+ * See {@link Path}
+ */
+type PathInternalObject<TValue, TraversedTypes, First extends boolean> = {
+  [Key in keyof TValue & string]: First extends true
+    ? '' | `${Key}` | `${Key}${PathInternal<TValue[Key], TraversedTypes, false>}`
+    : `.${Key}` | `.${Key}${PathInternal<TValue[Key], TraversedTypes, false>}`;
+}[keyof TValue & string];
+
+/**
+ * Helper type to construct nested any object key paths.
+ *
+ * See {@link Path}
+ */
+type PathInternalAny<First extends boolean> =
+  | (First extends true ? '' : never)
+  | `.${string}`
+  | `[${string}]`
+  | `[${string}].${string}`;
 
 /**
  * Helper type for recursively constructing paths through a type.
- * This obscures the internal type param TraversedTypes from ed contract.
+ *
+ * This obscures internal type params TraversedTypes and First from ed contract.
  *
  * See {@link Path}
  */
-type PathInternal<T, TraversedTypes = T> =
-  T extends ReadonlyArray<infer V>
-    ? IsTuple<T> extends true
-      ? {
-          [K in TupleKeys<T>]-?: PathImpl<K & string, T[K], TraversedTypes>;
-        }[TupleKeys<T>]
-      : PathImpl<ArrayKey, V, TraversedTypes>
-    : {
-        [K in keyof T]-?: PathImpl<K & string, T[K], TraversedTypes>;
-      }[keyof T];
+type PathInternal<TValue, TraversedTypes, First extends boolean> = TValue extends Primitive | BrowserNativeObject
+  ? IsAny<TValue> extends true
+    ? PathInternalAny<First>
+    : never
+  : TValue extends ReadonlyArray<any>
+    ? // Check so that we don't recurse into the same type by ensuring that the
+      // types are mutually assignable mutually required to avoid false
+      // positives of subtypes
+      true extends AnyIsEqual<TraversedTypes, TValue>
+      ? never
+      : IsTuple<TValue> extends true
+        ? PathInternalTuple<TValue, TraversedTypes | TValue>
+        : PathInternalArray<TValue, TraversedTypes | TValue>
+    : TValue extends Record<string, any>
+      ? PathInternalObject<TValue, TraversedTypes | TValue, First>
+      : '';
 
 /**
  * Helper type for recursively constructing paths through a type.
@@ -200,4 +231,4 @@ export type PathValue<T, P extends Path<T> | ArrayPath<T>> = T extends any
  */
 // We want to explode the union type and process each individually
 // so assignable types don't leak onto the stack from the base.
-export type Path<T> = T extends any ? PathInternal<T> : never;
+export type Path<T> = T extends any ? PathInternal<T, T, true> & string : never;

--- a/packages/vee-validate/src/types/paths.ts
+++ b/packages/vee-validate/src/types/paths.ts
@@ -96,7 +96,7 @@ type PathInternalArray<TValue extends ReadonlyArray<any>, TraversedTypes> =
  */
 type PathInternalObject<TValue, TraversedTypes, First extends boolean> = {
   [Key in keyof TValue & string]: First extends true
-    ? '' | `${Key}` | `${Key}${PathInternal<TValue[Key], TraversedTypes, false>}`
+    ? `${Key}` | `${Key}${PathInternal<TValue[Key], TraversedTypes, false>}`
     : `.${Key}` | `.${Key}${PathInternal<TValue[Key], TraversedTypes, false>}`;
 }[keyof TValue & string];
 
@@ -105,11 +105,7 @@ type PathInternalObject<TValue, TraversedTypes, First extends boolean> = {
  *
  * See {@link Path}
  */
-type PathInternalAny<First extends boolean> =
-  | (First extends true ? '' : never)
-  | `.${string}`
-  | `[${string}]`
-  | `[${string}].${string}`;
+type PathInternalAny = `.${string}` | `[${string}]` | `[${string}].${string}`;
 
 /**
  * Helper type for recursively constructing paths through a type.
@@ -120,7 +116,7 @@ type PathInternalAny<First extends boolean> =
  */
 type PathInternal<TValue, TraversedTypes, First extends boolean> = TValue extends Primitive | BrowserNativeObject
   ? IsAny<TValue> extends true
-    ? PathInternalAny<First>
+    ? PathInternalAny
     : never
   : TValue extends ReadonlyArray<any>
     ? // Check so that we don't recurse into the same type by ensuring that the


### PR DESCRIPTION
🔎 __Overview__

This PR aligns types of errors object destructured from useForm with the JS object that is actually returned (the issue is described in more detail in https://github.com/logaretm/vee-validate/issues/4295).

🤓 __Code snippets/examples (if applicable)__

Before:
```js
type Step = {
  name: string
}

type Form = {
  steps: Step[]
}

type Result = Path<Form> // `steps` | `steps.${number}` | `steps.${number}.name`, fails at runtime
```

Now:
```js
type Step = {
  name: string
}

type Form = {
  steps: Step[]
}

type Result = Path<Form> // `steps` | `steps[${number}]` | `steps[${number}].name`, works at runtime
```

✔ __Issues affected__

closes #4295
