### PR TITLE
feat(yup): dynamic re-describe for conditionals

### DIFF
--- a/packages/vee-validate/src/types/forms.ts
+++ b/packages/vee-validate/src/types/forms.ts
@@ -31,7 +31,7 @@ export interface TypedSchema<TInput = any, TOutput = TInput> {
   __type: 'VVTypedSchema';
   parse(values: TInput, context?: TypedSchemaContext): Promise<{ value?: TOutput; errors: TypedSchemaError[] }>;
   cast?(values: Partial<TInput>): TInput;
-  describe?(path?: Path<TInput>): Partial<TypedSchemaPathDescription>;
+  describe?(path?: Path<TInput>, values?: TInput): Partial<TypedSchemaPathDescription>;
 }
 
 export type InferOutput<TSchema extends TypedSchema> =


### PR DESCRIPTION
🔎 __Overview__

This PR dynamically re-describes the yup schema if it detects any conditions that need to be evaluated before being able to give a up-to-date description. 

There are a few issues with the current code:
1. It uses `conditions` of yups `Schema` class, which are marked as private. I initially tried to use `deps`, but this leads to cases where it would not detect a condition for this example, because it has no direct dependencies:
```js
const required = true

const yupSchema = object({
  test: object({
    id: string().matches(/^\d+$/).required(),
  })
    .when(([], schema) => {
      if (required) {
        return schema.required()
      }
      return schema.notRequired()
    })
    .nullable(),
})
```

2. This currently only works for `Schema`, i.e. not for `Lazy`. We probably could make this work for `Lazy` as well by resolving it to a `Schema` and then describing it, but i am not sure if that is in the spirit of it. Although it has to be said that this is exactly what `describe` of lazy is currently doing if `options` are passed.

3.  I am not sure about the `isSchema` typeguard. It is probably not very robust, maybe you have a better idea of doing this?

🤓 Motivation
This motivation for this was mostly for doing something like this in Quasar and Vue 3:

```js
const [model, attrs] = defineField(path, bindingConfig)

const bindingConfig = (state: PublicPathState<TValue>) => {
  return {
    props: {
      error: !!state.errors[0],
      'error-message': state.errors[0],
      class: { 'input-required': state.required },
    },
  }
}
```

This now automatically updates the UI (i.e. class of `input-required`) when a field becomes required through a met condition (or vice versa)

✔ __Issues affected__

closes #4848 
 
