### PR TITLE
fix: valibot intersections

### DIFF
--- a/.changeset/famous-wombats-tan.md
+++ b/.changeset/famous-wombats-tan.md
@@ -1,0 +1,5 @@
+---
+"@vee-validate/valibot": patch
+---
+
+fix: valibot intersections


### PR DESCRIPTION
🔎 __Overview__

I use the `required` field on `useField#meta` to automatically show an "Optional" text on an input. I found that having intersections in Valibot breaks this. For example, I have a PasswordSchema for reusability:
```ts
export const PasswordSchema = v.pipe(
  v.object({
    password: v.pipe(v.string(), v.minLength(8)),
    confirmPassword: v.pipe(v.string(), v.minLength(8)),
  }),
  v.forward(
    v.partialCheck(
      [['password'], ['confirmPassword']],
      (input) => input.password === input.confirmPassword,
      'The two passwords do not match.',
    ),
    ['confirmPassword'],
  ),
)
```
Which I then use in a form:
```ts
const schema = v.object({
  user: v.intersect([
    PasswordSchema,
    v.object({
      email: v.pipe(v.string(), v.email()),
    }),
  ]),
})
```
This resulted in `required` always being `true`.

I've implemented a fix for this along with two test cases.
