### PR TITLE
Fix shadcn-vue image in documentation

### DIFF
--- a/docs/src/components/UiLibraries.vue
+++ b/docs/src/components/UiLibraries.vue
@@ -14,8 +14,8 @@ const libraries = [
   {
     name: 'Shadcn Vue',
     link: 'https://www.shadcn-vue.com/docs/components/form',
-    logoLight: '/img/shadcn.svg',
-    logoDark: '/img/shadcn.svg',
+    logoLight: '/v4/img/shadcn.svg',
+    logoDark: '/v4/img/shadcn.svg',
   },
   {
     name: 'Vuetify',


### PR DESCRIPTION
https://vee-validate.logaretm.com/v4/

| Before | After |
| ---- | --- |
| `<img src="/img/shadcn.svg" loading="lazy" class="dark:hidden w-24 h-24" alt="Shadcn Vue">` |  `<img src="/v4/img/shadcn.svg" loading="lazy" class="dark:hidden w-24 h-24" alt="Shadcn Vue">` |
| ![image](https://github.com/user-attachments/assets/4c829dde-75f2-4fed-8805-c6eecd59ff6f) | ![image](https://github.com/user-attachments/assets/16d12c33-b0e1-4743-82f1-a4d2f6f37a0f) |
