### PR TITLE
fix: valibot variants

### DIFF
--- a/.changeset/famous-wombats-tan.md
+++ b/.changeset/famous-wombats-tan.md
@@ -1,0 +1,5 @@
+---
+"@vee-validate/valibot": patch
+---
+
+fix: valibot intersections


### PR DESCRIPTION
🔎 __Overview__

Similar to https://github.com/logaretm/vee-validate/pull/5014

I use the required field on useField#meta to automatically show an "Optional" text on an input. I found that having `v.variant` breaks this.

