### PR TITLE
chore(docs): fix missing comma typo

### DIFF
--- a/docs/src/pages/guide/composition-api/typed-schema.mdx
+++ b/docs/src/pages/guide/composition-api/typed-schema.mdx
@@ -306,7 +306,7 @@ const { values, handleSubmit } = useForm({
   validationSchema: toTypedSchema(
     v.object({
       name: v.pipe(v.string()),
-      email: v.pipe(v.string() v.nonEmpty('required')),
+      email: v.pipe(v.string(), v.nonEmpty('required')),
       password: v.pipe(v.string(), v.minLength(6, 'Must be at least 6 characters')),
     }),
   ),


### PR DESCRIPTION
🔎 __Overview__

This PR fixes a missing comma in the "valibot" usage documentation code snippet that was causing invalid syntax. This ensures the example code is correct and can be properly executed.