### PR TITLE
fix(zod): correct loop bounds in getSchemaForPath

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -160,7 +160,7 @@ function getSchemaForPath(path: string, schema: ZodSchema): ZodSchema | null {
   const paths = (path || '').split(/\.|\[(\d+)\]/).filter(Boolean);
 
   let currentSchema: ZodSchema = schema;
-  for (let i = 0; i <= paths.length; i++) {
+  for (let i = 0; i < paths.length; i++) {
     const p = paths[i];
     if (!p || !currentSchema) {
       return currentSchema;


### PR DESCRIPTION
🔎 **Overview**
This PR fixes a bug in the `getSchemaForPath` function where the for loop uses `<=` instead of `<`, causing array bounds overflow and console warnings when describing nested array paths.

🤓 **Code snippets/examples (if applicable)**
```js
// Before (line ~95 in getSchemaForPath function)
for (let i = 0; i <= paths.length; i++) {

// After
for (let i = 0; i < paths.length; i++) {
```

✔ **Issues affected**
Fixes console warnings: "Failed to describe path {arrayPath} on the schema, returning a default description" that occur when using nested array field names like `buttons[0].name` in Zod schemas.