### PR TITLE
Update use-form.mdx

### DIFF
--- a/docs/src/pages/api/use-form.mdx
+++ b/docs/src/pages/api/use-form.mdx
@@ -574,7 +574,7 @@ const { values, resetForm } = useForm({
   initialValues: { fname: '123', lname: '456' },
 });
 
-// values: { fname: '123', lname: '456' }
+// values: { fname: 'test', lname: '456' }
 resetForm({ values: { fname: 'test' } });
 
 // values: { fname: 'test' }


### PR DESCRIPTION
Fix resetForm force example.

🔎 __Overview__

This PR fixes the example for the `force` option of the `resetForm` method. Now the behavior of the function will be correctly understood.