### PR TITLE
Suggested fix: Revert input type number back to string

### DIFF
--- a/.changeset/revert-number-to-string.md
+++ b/.changeset/revert-number-to-string.md
@@ -1,0 +1,5 @@
+---
+'vee-validate': patch
+---
+
+fix: revert number input type back to string from number, closes #4699 and #4482

--- a/packages/vee-validate/src/utils/events.ts
+++ b/packages/vee-validate/src/utils/events.ts
@@ -2,10 +2,6 @@ import { hasCheckedAttr, isNativeMultiSelect, isNativeSelect, isEvent } from './
 import { getBoundValue, hasValueBinding } from './vnode';
 
 function parseInputValue(el: HTMLInputElement) {
-  if (el.type === 'number') {
-    return Number.isNaN(el.valueAsNumber) ? el.value : el.valueAsNumber;
-  }
-
   if (el.type === 'range') {
     return Number.isNaN(el.valueAsNumber) ? el.value : el.valueAsNumber;
   }

--- a/packages/vee-validate/tests/useField.spec.ts
+++ b/packages/vee-validate/tests/useField.spec.ts
@@ -934,9 +934,9 @@ describe('useField()', () => {
 
     await flushPromises();
     const input = document.querySelector('input') as HTMLInputElement;
-    setValue(input, '123');
+    setValue(input, '0.00');
     await flushPromises();
-    expect(field.value.value).toBe(123);
+    expect(field.value.value).toBe('0.00');
 
     setValue(input, '');
     await flushPromises();


### PR DESCRIPTION
🔎 __Overview__

The bugs noted in the below issues were introduced between versions 9.6.0 and 10.0.0, specifically I believe, in the fix of issue #4313. This PR removes the line added for converting the type from string to number. (Input is converted to number unless isNaN - in which case stays as string).

The problem with this is:
- you can never have an output of 0.00, #4699 - since JS will not accept 0.00 as a number type (dealt with as 0).
- on backspace from 0.001, or some variant, 0.00 is converted to 0, #4482 - for the same reason as above.
- the fix for #{4313} is incomplete. An empty input of "" will stay as "" and return the error message noted in the issue.

I would suggest keeping the input type as a string and dealing with #{4313} as is suggested for Date inputs for the above reasons, plus, it feels like good practice to keep the input type consistent with the HTML input element.

Just a suggestion, does have potential impact on those currently using the library, just thought I'd at least note where the bugs stem from (if it hasn't been considered already).

✔ __Issues affected__

closes #4699
closes #4482
 
