### PR TITLE
docs(api): correct type for `useForm`'s initial values

### DIFF
--- a/docs/src/pages/api/use-form.mdx
+++ b/docs/src/pages/api/use-form.mdx
@@ -92,11 +92,11 @@ Enables form-level validation, uses the specified schema to validate the fields.
 
 <CodeTitle level="4">
 
-`initialValues?: MaybeRef<Record<string, any>>`
+`initialValues?: Record<string, any>`
 
 </CodeTitle>
 
-The initial values for the form, can be a reactive object or reference.
+The initial values for the form.
 
 ```js
 const { ... } = useForm({


### PR DESCRIPTION
🔎 __Overview__

Since https://github.com/logaretm/vee-validate/commit/bbecc973dee972a3d09ddf8b22c8b34b949f4431 reactive initial values are removed.
