### PR TITLE
fix(devtools): prevent SSR memory leak in DevTools integration

### DIFF
--- a/.changeset/gentle-geckos-share.md
+++ b/.changeset/gentle-geckos-share.md
@@ -1,0 +1,5 @@
+---
+'vee-validate': patch
+---
+
+fix(devtools): prevent SSR memory leak in DevTools integration

--- a/packages/vee-validate/src/devtools.ts
+++ b/packages/vee-validate/src/devtools.ts
@@ -176,6 +176,10 @@ export const refreshInspector = throttle(() => {
 }, 100);
 
 export function registerFormWithDevTools(form: PrivateFormContext) {
+  if (!__DEV__ || !isClient) {
+    return;
+  }
+
   const vm = getCurrentInstance();
   if (!API) {
     const app = vm?.appContext.app;
@@ -197,6 +201,10 @@ export function registerFormWithDevTools(form: PrivateFormContext) {
 }
 
 export function registerSingleFieldWithDevtools(field: PrivateFieldContext) {
+  if (!__DEV__ || !isClient) {
+    return;
+  }
+
   const vm = getCurrentInstance();
   if (!API) {
     const app = vm?.appContext.app;


### PR DESCRIPTION
Add SSR guards to DevTools registration functions to prevent memory leaks in server-side environments by checking both `__DEV__` and `isClient`.

Fixes #4978

🔎 __Overview__

This PR fixes a memory leak in SSR environments like Nuxt, where the DevTools registration functions were running on the server-side, causing component references to accumulate in memory across requests. I've tested this fix locally and can confirm it successfully eliminates the need for the NODE_ENV=production workaround as described in #4978.

🤓 __Code snippets/examples__

```js
export function registerFormWithDevTools(form: PrivateFormContext) {
    if (!__DEV__ || !isClient) {
      return; // Exit immediately on server or in production
    }
    // ... rest of function
  }
```

✔ __Issues affected__
closes #4978

PS: I'll create another PR #5102 for the v4 Branch. :)