### PR TITLE
fix(devtools): not showing all field states

### DIFF
--- a/.changeset/pretty-onions-add.md
+++ b/.changeset/pretty-onions-add.md
@@ -1,0 +1,5 @@
+---
+'vee-validate': patch
+---
+
+Fix dev tools not showing all field states

--- a/packages/vee-validate/src/devtools.ts
+++ b/packages/vee-validate/src/devtools.ts
@@ -350,7 +350,8 @@ function getFieldNodeTags(
 function encodeNodeId(form?: PrivateFormContext, stateOrField?: PathState | PrivateFieldContext): string {
   const type = stateOrField ? ('path' in stateOrField ? 'pathState' : 'field') : 'form';
   const fieldPath = stateOrField ? ('path' in stateOrField ? stateOrField?.path : toValue(stateOrField?.name)) : '';
-  const idObject = { f: form?.formId, ff: stateOrField?.id || fieldPath, type };
+  const ff = type === 'field' ? stateOrField?.id : fieldPath;
+  const idObject = { f: form?.formId, ff, type };
 
   return btoa(encodeURIComponent(JSON.stringify(idObject)));
 }


### PR DESCRIPTION
🔎 __Overview__

  This PR fixes Devtools not showing all fields states, but only showing the first one. This bug was introduced in `vee-validate@4.14.7`, specifically in this commit: https://github.com/fabian-hiller/vee-validate/commit/be994b4c59e0ead536573dc26b6947131b4b6eda

✔ __Issues affected__

Closes #5007 
 
