### PR TITLE
fix(devtools): display nested fields with name 'id'

### DIFF
--- a/.changeset/stupid-friends-relate.md
+++ b/.changeset/stupid-friends-relate.md
@@ -1,0 +1,5 @@
+---
+'vee-validate': patch
+---
+
+Fix dev tools do not display nested fields with name 'id'

--- a/packages/vee-validate/src/devtools.ts
+++ b/packages/vee-validate/src/devtools.ts
@@ -236,7 +236,7 @@ function mapFormForDevtoolsInspector(form: PrivateFormContext): CustomInspectorN
 
   function buildFormTree(tree: any[] | Record<string, any>, path: string[] = []): CustomInspectorNode {
     const key = [...path].pop();
-    if ('id' in tree) {
+    if ('id' in tree && typeof tree.id === 'string') {
       return {
         ...tree,
         label: key || tree.label,


### PR DESCRIPTION
🔎 __Overview__

This PR fixes an issue in Dev tools where nested fields which use name `id` are not displayed correctly, but instead JSON output is printed. See mentioned issue for more details.


✔ __Issues affected__

Closes #5116

 
