### PR TITLE
fix(ci): add registry-url for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: pnpm install
       - name: Tag and Release


### PR DESCRIPTION
## Summary
- The Release workflow has been failing since June 2025 with `ENEEDAUTH` when publishing to npm
- `actions/setup-node` requires `registry-url` to generate the `.npmrc` that configures OIDC-based authentication for trusted publishers
- Added `registry-url: 'https://registry.npmjs.org'` to the setup-node step

## Test plan
- [ ] Trigger the Release workflow and verify packages publish successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)