### PR TITLE
fix(ci): upgrade to Node 24 for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Node 22 ships with npm v10, which doesn't support the OIDC handshake for trusted publishing
- This causes npm to silently fall back to anonymous auth, resulting in a misleading `E404` on publish
- Upgrading to Node 24 (npm v11) fixes the OIDC handshake

## Test plan
- [ ] Merge and trigger the Release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)