### PR TITLE
fix(i18n): add missing URL validation message to Persian locale (#5118)

### DIFF
--- a/.changeset/fix-5118-fa-locale-url.md
+++ b/.changeset/fix-5118-fa-locale-url.md
@@ -1,0 +1,5 @@
+---
+"@vee-validate/i18n": patch
+---
+
+Add missing URL validation message to Persian (fa) locale (#5118)

--- a/packages/i18n/src/locale/fa.json
+++ b/packages/i18n/src/locale/fa.json
@@ -25,6 +25,7 @@
     "regex": "قالب {field} قابل قبول نیست",
     "required_if": "{field} الزامی است",
     "required": "{field} الزامی است",
-    "size": "حجم {field} کمتر از 0:{size}KB باشد"
+    "size": "حجم {field} کمتر از 0:{size}KB باشد",
+    "url": "{field} یک URL معتبر نیست"
   }
 }


### PR DESCRIPTION
## Summary
- Adds the missing `url` validation message key to the Persian (`fa`) locale file
- The message `"{field} یک URL معتبر نیست"` follows the same pattern as the English locale's `"The {field} field is not a valid URL"`
- Fixes #5118

## Test plan
- [x] Verified `fa.json` is valid JSON after the change
- [x] Confirmed the `url` key is placed in the correct alphabetical position (after `size`)
- [x] Compared structure with `en.json` to ensure consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)