### PR TITLE
fix: prevent falsy values from being pruned on submit

### DIFF
--- a/.changeset/fix-5094-boolean-pruning.md
+++ b/.changeset/fix-5094-boolean-pruning.md
@@ -1,0 +1,5 @@
+---
+"vee-validate": patch
+---
+
+Prevent boolean false values from being pruned in form submissions (#5094)

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -869,7 +869,7 @@ export function useForm<
         errors: validation.errors,
       };
 
-      if (validation.value) {
+      if (validation.value !== undefined) {
         setInPath(values, validation.key, validation.value);
       }
 

--- a/packages/vee-validate/tests/useFieldArray.spec.ts
+++ b/packages/vee-validate/tests/useFieldArray.spec.ts
@@ -521,6 +521,45 @@ test('array move initializes the array if undefined', async () => {
   expect(arr.fields.value).toHaveLength(0);
 });
 
+// #5094
+test('boolean false values in field arrays are not pruned from submitted values', async () => {
+  const spy = vi.fn();
+  mountWithHoc({
+    setup() {
+      const { handleSubmit } = useForm({
+        initialValues: {
+          roles: [
+            { text: 'Admin', isDefault: true },
+            { text: 'User', isDefault: false },
+          ],
+        },
+      });
+
+      useFieldArray('roles');
+
+      useField('roles[0].text');
+      useField('roles[0].isDefault');
+      useField('roles[1].text');
+      useField('roles[1].isDefault');
+
+      const onSubmit = handleSubmit(values => {
+        spy(values);
+      });
+
+      onMounted(onSubmit);
+
+      return {};
+    },
+    template: `<div></div>`,
+  });
+
+  await flushPromises();
+  expect(spy).toHaveBeenCalledTimes(1);
+  const submitted = spy.mock.calls[0][0];
+  expect(submitted.roles[0].isDefault).toBe(true);
+  expect(submitted.roles[1].isDefault).toBe(false);
+});
+
 // #4557
 test('errors are available to the newly inserted items', async () => {
   let arr!: FieldArrayContext;


### PR DESCRIPTION
## Summary
- Fixes #5094: boolean `false` values (and other falsy values like `0` and `""`) in field arrays were being pruned from submitted values
- The `validate()` function in `useForm.ts` used a truthiness check (`if (validation.value)`) to decide whether to include a field's value in the results, which excluded any falsy value
- Changed the check to `if (validation.value !== undefined)` so only truly undefined values are excluded
- Added a regression test that verifies boolean `false` values in field arrays are preserved through form submission

## Test plan
- [x] New test: `boolean false values in field arrays are not pruned from submitted values`
- [x] All existing tests pass (356 passed, 3 skipped, 3 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)