### PR TITLE
test: regression tests for dirty with undefined (#5034)

### DIFF
--- a/.changeset/test-5034-dirty-undefined.md
+++ b/.changeset/test-5034-dirty-undefined.md
@@ -1,0 +1,5 @@
+---
+"vee-validate": patch
+---
+
+Add regression tests for meta.dirty with undefined initial values (#5034)

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -1489,4 +1489,56 @@ describe('useForm()', () => {
     form.setValues({ file: f2 });
     expect(form.values.file).toEqual(f2);
   });
+
+  // #5034
+  test('meta.dirty becomes true when a field initialized with undefined is changed', async () => {
+    let form!: Record<string, any>;
+    mountWithHoc({
+      setup() {
+        form = useForm({
+          initialValues: {
+            test: undefined,
+          },
+        });
+
+        useField('test');
+
+        return {};
+      },
+      template: '<div></div>',
+    });
+
+    await flushPromises();
+    expect(form.meta.value.dirty).toBe(false);
+    form.setFieldValue('test', 'hello');
+    await flushPromises();
+    expect(form.meta.value.dirty).toBe(true);
+  });
+
+  // #5034
+  test('meta.dirty becomes false again when field initialized with undefined is reset', async () => {
+    let form!: Record<string, any>;
+    mountWithHoc({
+      setup() {
+        form = useForm({
+          initialValues: {
+            test: undefined,
+          },
+        });
+
+        useField('test');
+
+        return {};
+      },
+      template: '<div></div>',
+    });
+
+    await flushPromises();
+    form.setFieldValue('test', 'hello');
+    await flushPromises();
+    expect(form.meta.value.dirty).toBe(true);
+    form.resetForm();
+    await flushPromises();
+    expect(form.meta.value.dirty).toBe(false);
+  });
 });

--- a/packages/vee-validate/tests/utils/assertions.spec.ts
+++ b/packages/vee-validate/tests/utils/assertions.spec.ts
@@ -228,4 +228,10 @@ describe('assertions', () => {
     expect(isEqual(a6, b1)).toBe(false);
     expect(isEqual(a6, b2)).toBe(false);
   });
+
+  // #5034
+  test('object with undefined value changed to string is not equal', () => {
+    expect(isEqual({ test: undefined }, { test: 'hello' })).toBe(false);
+    expect(isEqual({ a: 1, b: undefined }, { a: 1, b: 'hello' })).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds regression tests for issue #5034 where `meta.dirty` never becomes `true` when a field is initialized with `undefined`
- The underlying bug was already fixed via the `normalizeObject` function in `isEqual` which strips `undefined` values before comparison
- Tests cover: dirty becoming true on value change, dirty resetting on form reset, and `isEqual` correctly detecting inequality between `undefined` and string values

## Test plan
- [x] `useForm.spec.ts`: verify `meta.dirty` becomes `true` when a field initialized with `undefined` is changed to `'hello'`
- [x] `useForm.spec.ts`: verify `meta.dirty` returns to `false` after `resetForm()` on a field initialized with `undefined`
- [x] `assertions.spec.ts`: verify `isEqual({ test: undefined }, { test: 'hello' })` returns `false`
- [x] All 55 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)