### PR TITLE
fix: resetField properly resets arrays managed by useFieldArray

### DIFF
--- a/.changeset/fix-5053-resetfield-arrays.md
+++ b/.changeset/fix-5053-resetfield-arrays.md
@@ -1,0 +1,5 @@
+---
+"vee-validate": patch
+---
+
+Fix resetField to properly reset arrays managed by useFieldArray (#5053)

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -775,7 +775,7 @@ export function useForm<
   }
 
   function resetField(field: Path<TValues>, state?: Partial<FieldState>) {
-    const newValue = state && 'value' in state ? state.value : getFromPath(initialValues.value, field);
+    const newValue = state && 'value' in state ? state.value : getFromPath(originalInitialValues.value, field);
     const pathState = findPathState(field);
     if (pathState) {
       pathState.__flags.pendingReset = true;
@@ -785,6 +785,17 @@ export function useForm<
     setFieldValue(field, newValue as PathValue<TValues, typeof field>, false);
     setFieldTouched(field, state?.touched ?? false);
     setFieldError(field, state?.errors || []);
+
+    // Clear errors on child path states (e.g. users[0], users[1] when resetting 'users')
+    pathStates.value.forEach(s => {
+      if (toValue(s.path).startsWith(field + '[')) {
+        s.errors = [];
+        s.valid = true;
+      }
+    });
+
+    // Trigger field array re-sync so useFieldArray picks up the new value
+    fieldArrays.filter(f => toValue(f.path) === field).forEach(f => f.reset());
 
     nextTick(() => {
       if (pathState) {

--- a/packages/vee-validate/tests/useFieldArray.spec.ts
+++ b/packages/vee-validate/tests/useFieldArray.spec.ts
@@ -577,3 +577,35 @@ test('errors are available to the newly inserted items', async () => {
   await flushPromises();
   expect(spanAt(1).textContent).toBeTruthy();
 });
+
+// #5053
+test('resetField should properly reset array fields managed by useFieldArray', async () => {
+  let form!: Record<string, any>;
+  let arr!: Record<string, any>;
+  mountWithHoc({
+    setup() {
+      form = useForm<any>({
+        initialValues: {
+          users: ['one'],
+        },
+      });
+
+      arr = useFieldArray('users');
+      useField('users[0]');
+
+      return {};
+    },
+    template: '<div></div>',
+  });
+
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(1);
+  arr.push('two');
+  arr.push('three');
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(3);
+  form.resetField('users');
+  await flushPromises();
+  expect(arr.fields.value).toHaveLength(1);
+  expect(arr.fields.value[0].value).toBe('one');
+});


### PR DESCRIPTION
## Summary
- Fixes #5053: `resetField` now properly resets array fields managed by `useFieldArray`
- Uses `originalInitialValues` instead of `initialValues` (which gets polluted by field array operations like `push`/`insert` calling `stageInitialValue`)
- Clears errors on child path states (e.g. `users[0]`, `users[1]`) when resetting the parent array field
- Triggers field array re-sync so `useFieldArray` picks up the reset value

## Test plan
- [x] Added test: `resetField should properly reset array fields managed by useFieldArray`
- [x] Existing useFieldArray tests pass (20/20)
- [x] Full test suite passes (356 tests, 3 pre-existing unrelated failures from package resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)