### PR TITLE
fix: normalize standard schema error paths to bracket notation

### DIFF
--- a/.changeset/fix-5108-standard-schema-paths.md
+++ b/.changeset/fix-5108-standard-schema-paths.md
@@ -1,0 +1,5 @@
+---
+"vee-validate": patch
+---
+
+Normalize standard schema error paths from dot notation to bracket notation (#5108)

--- a/packages/vee-validate/src/validate.ts
+++ b/packages/vee-validate/src/validate.ts
@@ -11,7 +11,7 @@ import {
   GenericObject,
   Path,
 } from './types';
-import { isCallable, FieldValidationMetaInfo } from '../../shared';
+import { isCallable, FieldValidationMetaInfo, normalizeFormPath } from '../../shared';
 import { StandardSchemaV1 } from '@standard-schema/spec';
 
 /**
@@ -273,7 +273,7 @@ export async function validateStandardSchema<TValues extends GenericObject, TOut
 
   for (const error of combinedIssues) {
     const messages = error.messages;
-    const path = error.path as Path<TValues>;
+    const path = normalizeFormPath(error.path) as Path<TValues>;
 
     results[path] = { valid: !messages.length, errors: messages };
     if (messages.length) {

--- a/packages/vee-validate/tests/validateStandardSchema.spec.ts
+++ b/packages/vee-validate/tests/validateStandardSchema.spec.ts
@@ -1,0 +1,66 @@
+import { validateStandardSchema } from '../src/validate';
+import { z } from 'zod';
+
+// #5108
+test('validateStandardSchema normalizes dot notation array paths to bracket notation', async () => {
+  const schema = z.object({
+    items: z.array(
+      z.object({
+        name: z.string().min(1, 'Name is required'),
+        id: z.string().min(1, 'ID is required'),
+      }),
+    ),
+  });
+
+  const result = await validateStandardSchema(schema, {
+    items: [{ name: '', id: '' }],
+  });
+
+  expect(result.valid).toBe(false);
+
+  // Error paths should use bracket notation (items[0].name) not dot notation (items.0.name)
+  expect(result.errors['items[0].name' as keyof typeof result.errors]).toBe('Name is required');
+  expect(result.errors['items[0].id' as keyof typeof result.errors]).toBe('ID is required');
+
+  // Dot notation should NOT be present
+  expect(result.errors['items.0.name' as keyof typeof result.errors]).toBeUndefined();
+  expect(result.errors['items.0.id' as keyof typeof result.errors]).toBeUndefined();
+});
+
+test('validateStandardSchema handles nested array paths with multiple indices', async () => {
+  const schema = z.object({
+    groups: z.array(
+      z.object({
+        members: z.array(
+          z.object({
+            email: z.string().email('Invalid email'),
+          }),
+        ),
+      }),
+    ),
+  });
+
+  const result = await validateStandardSchema(schema, {
+    groups: [{ members: [{ email: 'bad' }] }],
+  });
+
+  expect(result.valid).toBe(false);
+  expect(result.errors['groups[0].members[0].email' as keyof typeof result.errors]).toBe('Invalid email');
+  expect(result.errors['groups.0.members.0.email' as keyof typeof result.errors]).toBeUndefined();
+});
+
+test('validateStandardSchema preserves non-array dot paths', async () => {
+  const schema = z.object({
+    user: z.object({
+      name: z.string().min(1, 'Name is required'),
+    }),
+  });
+
+  const result = await validateStandardSchema(schema, {
+    user: { name: '' },
+  });
+
+  expect(result.valid).toBe(false);
+  // Non-array paths should remain as dot notation
+  expect(result.errors['user.name' as keyof typeof result.errors]).toBe('Name is required');
+});


### PR DESCRIPTION
## Summary

Fixes #5108

- When standard schema validation (e.g., Zod) returns errors for array fields, the error paths use dot notation (e.g., `items.0.name`). However, vee-validate internally uses bracket notation (e.g., `items[0].name`) when registering fields via `useField`/`useFieldArray`.
- This mismatch causes validation errors to not be mapped to the correct fields, particularly when multiple fields trigger validation concurrently and the `withLatest` deduplication skips the `onDone` path normalization for earlier callers.
- The fix applies `normalizeFormPath()` to error paths inside `validateStandardSchema()`, ensuring paths are consistently in bracket notation regardless of the `withLatest` execution path.

## Changes

- `packages/vee-validate/src/validate.ts`: Import `normalizeFormPath` from shared utilities and apply it to `error.path` in `validateStandardSchema()` before using it as a key in results/errors maps.
- `packages/vee-validate/tests/validateStandardSchema.spec.ts`: New test file with 3 tests verifying bracket notation normalization for single-level arrays, nested arrays, and non-array dot paths.
- `.changeset/fix-5108-standard-schema-paths.md`: Patch changeset for vee-validate.

## Test plan

- [x] New test: single-level array paths are normalized from `items.0.name` to `items[0].name`
- [x] New test: nested array paths are normalized from `groups.0.members.0.email` to `groups[0].members[0].email`
- [x] New test: non-array dot paths (e.g., `user.name`) remain unchanged
- [x] All existing tests pass (33/34 test files; the 1 failure in `validate.spec.ts` is a pre-existing environment issue unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)