### PR TITLE
fix: handle read-only properties in form values (#4889)

### DIFF
--- a/.changeset/fix-4889-readonly-typename.md
+++ b/.changeset/fix-4889-readonly-typename.md
@@ -1,0 +1,5 @@
+---
+'vee-validate': patch
+---
+
+Fix TypeError when form values contain read-only properties like __typename (#4889)

--- a/packages/vee-validate/src/Form.ts
+++ b/packages/vee-validate/src/Form.ts
@@ -1,4 +1,4 @@
-import { klona as deepCopy } from 'klona/full';
+import { klona as deepCopy } from 'klona';
 import { defineComponent, h, PropType, resolveDynamicComponent, toRef, UnwrapRef, VNode } from 'vue';
 import { FormContext, FormErrors, FormMeta, GenericObject, InvalidSubmissionHandler, SubmissionHandler } from './types';
 import { useForm } from './useForm';

--- a/packages/vee-validate/src/useField.ts
+++ b/packages/vee-validate/src/useField.ts
@@ -13,7 +13,7 @@ import {
   MaybeRefOrGetter,
   unref,
 } from 'vue';
-import { klona as deepCopy } from 'klona/full';
+import { klona as deepCopy } from 'klona';
 import { validate as validateValue } from './validate';
 import {
   GenericValidateFunction,

--- a/packages/vee-validate/src/useFieldArray.ts
+++ b/packages/vee-validate/src/useFieldArray.ts
@@ -1,5 +1,5 @@
 import { Ref, unref, ref, onBeforeUnmount, watch, MaybeRefOrGetter, toValue } from 'vue';
-import { klona as deepCopy } from 'klona/full';
+import { klona as deepCopy } from 'klona';
 import { isNullOrUndefined } from '../../shared';
 import { FormContextKey } from './symbols';
 import { FieldArrayContext, FieldEntry, PrivateFieldArrayContext, PrivateFormContext } from './types';

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -19,7 +19,7 @@ import {
   inject,
 } from 'vue';
 import { PartialDeep } from 'type-fest';
-import { klona as deepCopy } from 'klona/full';
+import { klona as deepCopy } from 'klona';
 import {
   FieldMeta,
   SubmissionHandler,

--- a/packages/vee-validate/src/utils/common.ts
+++ b/packages/vee-validate/src/utils/common.ts
@@ -11,7 +11,7 @@ import {
   MaybeRefOrGetter,
   toValue,
 } from 'vue';
-import { klona as deepCopy } from 'klona/full';
+import { klona as deepCopy } from 'klona';
 import { isIndex, isNullOrUndefined, isObject, toNumber } from '../../../shared';
 import { isContainerValue, isEmptyContainer, isEqual, isNotNestedPath } from './assertions';
 import { GenericObject, IssueCollection, MaybePromise } from '../types';

--- a/packages/vee-validate/src/validate.ts
+++ b/packages/vee-validate/src/validate.ts
@@ -1,5 +1,5 @@
 import { resolveRule } from './defineRule';
-import { klona as deepCopy } from 'klona/full';
+import { klona as deepCopy } from 'klona';
 import { isLocator, normalizeRules, keysOf, getFromPath, isStandardSchema, combineStandardIssues } from './utils';
 import { getConfig } from './config';
 import {

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -1489,4 +1489,96 @@ describe('useForm()', () => {
     form.setValues({ file: f2 });
     expect(form.values.file).toEqual(f2);
   });
+
+  // #4889
+  test('handles initial values with read-only properties like __typename', async () => {
+    // Simulate a GraphQL-like result with read-only nested properties
+    const graphqlResult: Record<string, unknown> = {
+      name: 'test',
+      nested: Object.defineProperties(
+        {},
+        {
+          __typename: { value: 'NestedType', writable: false, configurable: false, enumerable: true },
+          field: { value: 'value', writable: false, configurable: false, enumerable: true },
+        },
+      ),
+    };
+    Object.defineProperty(graphqlResult, '__typename', {
+      value: 'RootType',
+      writable: false,
+      configurable: false,
+      enumerable: true,
+    });
+
+    let form!: FormContext;
+    mountWithHoc({
+      setup() {
+        form = useForm({
+          initialValues: graphqlResult,
+        });
+
+        form.defineField('name');
+        form.defineField('nested.field');
+
+        return {};
+      },
+      template: `<div></div>`,
+    });
+
+    await flushPromises();
+    // Should not throw when reading values
+    expect(form.values.name).toBe('test');
+
+    // Should not throw when setting a field value
+    expect(() => form.setFieldValue('name', 'updated')).not.toThrow();
+    await flushPromises();
+    expect(form.values.name).toBe('updated');
+
+    // Should not throw when resetting the form
+    expect(() => form.resetForm()).not.toThrow();
+    await flushPromises();
+    expect(form.values.name).toBe('test');
+  });
+
+  // #4889
+  test('handles resetForm with read-only properties in new values', async () => {
+    const readOnlyValues: Record<string, unknown> = {};
+    Object.defineProperty(readOnlyValues, '__typename', {
+      value: 'SomeType',
+      writable: false,
+      configurable: false,
+      enumerable: true,
+    });
+    readOnlyValues.name = 'initial';
+
+    let form!: FormContext;
+    mountWithHoc({
+      setup() {
+        form = useForm({
+          initialValues: { name: 'initial' },
+        });
+
+        form.defineField('name');
+
+        return {};
+      },
+      template: `<div></div>`,
+    });
+
+    await flushPromises();
+
+    // Reset with values that contain read-only properties
+    const newValues: Record<string, unknown> = {};
+    Object.defineProperty(newValues, '__typename', {
+      value: 'AnotherType',
+      writable: false,
+      configurable: false,
+      enumerable: true,
+    });
+    newValues.name = 'reset-value';
+
+    expect(() => form.resetForm({ values: newValues })).not.toThrow();
+    await flushPromises();
+    expect(form.values.name).toBe('reset-value');
+  });
 });

--- a/scripts/config.mjs
+++ b/scripts/config.mjs
@@ -62,7 +62,7 @@ async function createConfig(pkg, format) {
         }),
         tsPlugin,
         resolve({
-          dedupe: ['klona', 'klona/full'],
+          dedupe: ['klona'],
         }),
         commonjs(),
       ],


### PR DESCRIPTION
## Summary

- Switch from `klona/full` to `klona` (default) for deep cloning form values
- `klona/full` preserves property descriptors including `writable: false` and `configurable: false`, which causes `TypeError: Cannot assign to read only property '__typename'` when vee-validate later mutates cloned values (e.g., in `setInPath`, `merge`, `resetForm`)
- The default `klona` variant handles all needed types (Object, Array, Set, Map, Date, RegExp, DataView, ArrayBuffer, TypedArrays) without preserving restrictive property descriptors, ensuring cloned values are always writable

Fixes #4889

## Test plan

- [x] Added test: `useForm` with initial values containing read-only `__typename` properties (nested objects with `writable: false, configurable: false`)
- [x] Added test: `resetForm` with new values containing read-only properties
- [x] All 48 `useForm.spec.ts` tests pass
- [x] All 317 vee-validate tests pass
- [x] Lint-staged (eslint, prettier, vitest) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)