### PR TITLE
fix: fieldArray mutations now mark form as touched

### DIFF
--- a/.changeset/fix-5113-fieldarray-touched.md
+++ b/.changeset/fix-5113-fieldarray-touched.md
@@ -1,0 +1,5 @@
+---
+"vee-validate": patch
+---
+
+FieldArray mutation operations (push, remove, etc.) now set the form as touched (#5113)

--- a/packages/vee-validate/src/useFieldArray.ts
+++ b/packages/vee-validate/src/useFieldArray.ts
@@ -110,8 +110,25 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRefOrGetter<stri
 
   function afterMutation() {
     updateEntryFlags();
+    // Marking the field array path states as touched since any mutation is a user interaction #5113
+    markTouched();
     // Should trigger a silent validation since a field may not do that #4096
     form?.validate({ mode: 'silent' });
+  }
+
+  function markTouched() {
+    const pathName = toValue(arrayPath);
+    const pathState = form.getPathState(pathName as any);
+    if (pathState) {
+      pathState.touched = true;
+    }
+
+    const allStates = form.getAllPathStates();
+    allStates
+      .filter(s => toValue(s.path).startsWith(pathName + '['))
+      .forEach(s => {
+        s.touched = true;
+      });
   }
 
   function remove(idx: number) {
@@ -168,7 +185,7 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRefOrGetter<stri
     newFields[indexB] = tempEntry;
     setInPath(form.values, pathName, newValue);
     fields.value = newFields;
-    updateEntryFlags();
+    afterMutation();
   }
 
   function insert(idx: number, initialValue: TValue) {
@@ -205,6 +222,8 @@ export function useFieldArray<TValue = unknown>(arrayPath: MaybeRefOrGetter<stri
     }
 
     setInPath(form.values, `${pathName}[${idx}]`, value);
+    // Marking the field array path states as touched since any mutation is a user interaction #5113
+    markTouched();
     form?.validate({ mode: 'validated-only' });
   }
 

--- a/packages/vee-validate/tests/useFieldArray.spec.ts
+++ b/packages/vee-validate/tests/useFieldArray.spec.ts
@@ -577,3 +577,323 @@ test('errors are available to the newly inserted items', async () => {
   await flushPromises();
   expect(spanAt(1).textContent).toBeTruthy();
 });
+
+// #5113
+test('push should set the form as touched', async () => {
+  let form!: FormContext;
+  let arr!: FieldArrayContext;
+  const InputText = defineComponent({
+    props: { name: { type: String, required: true } },
+    setup(props) {
+      const { value } = useField(() => props.name);
+      return { value };
+    },
+    template: '<input v-model="value" />',
+  });
+
+  mountWithHoc({
+    components: { InputText },
+    setup() {
+      form = useForm<any>({
+        initialValues: {
+          users: ['one'],
+        },
+      });
+
+      arr = useFieldArray('users');
+
+      return { fields: arr.fields };
+    },
+    template: `
+      <div>
+        <InputText v-for="(field, idx) in fields" :key="field.key" :name="'users[' + idx + ']'" />
+      </div>
+    `,
+  });
+
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(false);
+  arr.push('two');
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(true);
+});
+
+// #5113
+test('remove should set the form as touched', async () => {
+  let form!: FormContext;
+  let arr!: FieldArrayContext;
+  const InputText = defineComponent({
+    props: { name: { type: String, required: true } },
+    setup(props) {
+      const { value } = useField(() => props.name);
+      return { value };
+    },
+    template: '<input v-model="value" />',
+  });
+
+  mountWithHoc({
+    components: { InputText },
+    setup() {
+      form = useForm<any>({
+        initialValues: {
+          users: ['one', 'two'],
+        },
+      });
+
+      arr = useFieldArray('users');
+
+      return { fields: arr.fields };
+    },
+    template: `
+      <div>
+        <InputText v-for="(field, idx) in fields" :key="field.key" :name="'users[' + idx + ']'" />
+      </div>
+    `,
+  });
+
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(false);
+  arr.remove(0);
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(true);
+});
+
+// #5113
+test('insert should set the form as touched', async () => {
+  let form!: FormContext;
+  let arr!: FieldArrayContext;
+  const InputText = defineComponent({
+    props: { name: { type: String, required: true } },
+    setup(props) {
+      const { value } = useField(() => props.name);
+      return { value };
+    },
+    template: '<input v-model="value" />',
+  });
+
+  mountWithHoc({
+    components: { InputText },
+    setup() {
+      form = useForm<any>({
+        initialValues: {
+          users: ['one', 'two'],
+        },
+      });
+
+      arr = useFieldArray('users');
+
+      return { fields: arr.fields };
+    },
+    template: `
+      <div>
+        <InputText v-for="(field, idx) in fields" :key="field.key" :name="'users[' + idx + ']'" />
+      </div>
+    `,
+  });
+
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(false);
+  arr.insert(1, 'inserted');
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(true);
+});
+
+// #5113
+test('prepend should set the form as touched', async () => {
+  let form!: FormContext;
+  let arr!: FieldArrayContext;
+  const InputText = defineComponent({
+    props: { name: { type: String, required: true } },
+    setup(props) {
+      const { value } = useField(() => props.name);
+      return { value };
+    },
+    template: '<input v-model="value" />',
+  });
+
+  mountWithHoc({
+    components: { InputText },
+    setup() {
+      form = useForm<any>({
+        initialValues: {
+          users: ['one'],
+        },
+      });
+
+      arr = useFieldArray('users');
+
+      return { fields: arr.fields };
+    },
+    template: `
+      <div>
+        <InputText v-for="(field, idx) in fields" :key="field.key" :name="'users[' + idx + ']'" />
+      </div>
+    `,
+  });
+
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(false);
+  arr.prepend('zero');
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(true);
+});
+
+// #5113
+test('swap should set the form as touched', async () => {
+  let form!: FormContext;
+  let arr!: FieldArrayContext;
+  const InputText = defineComponent({
+    props: { name: { type: String, required: true } },
+    setup(props) {
+      const { value } = useField(() => props.name);
+      return { value };
+    },
+    template: '<input v-model="value" />',
+  });
+
+  mountWithHoc({
+    components: { InputText },
+    setup() {
+      form = useForm<any>({
+        initialValues: {
+          users: ['one', 'two'],
+        },
+      });
+
+      arr = useFieldArray('users');
+
+      return { fields: arr.fields };
+    },
+    template: `
+      <div>
+        <InputText v-for="(field, idx) in fields" :key="field.key" :name="'users[' + idx + ']'" />
+      </div>
+    `,
+  });
+
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(false);
+  arr.swap(0, 1);
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(true);
+});
+
+// #5113
+test('move should set the form as touched', async () => {
+  let form!: FormContext;
+  let arr!: FieldArrayContext;
+  const InputText = defineComponent({
+    props: { name: { type: String, required: true } },
+    setup(props) {
+      const { value } = useField(() => props.name);
+      return { value };
+    },
+    template: '<input v-model="value" />',
+  });
+
+  mountWithHoc({
+    components: { InputText },
+    setup() {
+      form = useForm<any>({
+        initialValues: {
+          users: ['one', 'two', 'three'],
+        },
+      });
+
+      arr = useFieldArray('users');
+
+      return { fields: arr.fields };
+    },
+    template: `
+      <div>
+        <InputText v-for="(field, idx) in fields" :key="field.key" :name="'users[' + idx + ']'" />
+      </div>
+    `,
+  });
+
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(false);
+  arr.move(0, 2);
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(true);
+});
+
+// #5113
+test('replace should set the form as touched', async () => {
+  let form!: FormContext;
+  let arr!: FieldArrayContext;
+  const InputText = defineComponent({
+    props: { name: { type: String, required: true } },
+    setup(props) {
+      const { value } = useField(() => props.name);
+      return { value };
+    },
+    template: '<input v-model="value" />',
+  });
+
+  mountWithHoc({
+    components: { InputText },
+    setup() {
+      form = useForm<any>({
+        initialValues: {
+          users: ['one'],
+        },
+      });
+
+      arr = useFieldArray('users');
+
+      return { fields: arr.fields };
+    },
+    template: `
+      <div>
+        <InputText v-for="(field, idx) in fields" :key="field.key" :name="'users[' + idx + ']'" />
+      </div>
+    `,
+  });
+
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(false);
+  arr.replace(['a', 'b']);
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(true);
+});
+
+// #5113
+test('update should set the form as touched', async () => {
+  let form!: FormContext;
+  let arr!: FieldArrayContext;
+  const InputText = defineComponent({
+    props: { name: { type: String, required: true } },
+    setup(props) {
+      const { value } = useField(() => props.name);
+      return { value };
+    },
+    template: '<input v-model="value" />',
+  });
+
+  mountWithHoc({
+    components: { InputText },
+    setup() {
+      form = useForm<any>({
+        initialValues: {
+          users: ['one'],
+        },
+      });
+
+      arr = useFieldArray('users');
+
+      return { fields: arr.fields };
+    },
+    template: `
+      <div>
+        <InputText v-for="(field, idx) in fields" :key="field.key" :name="'users[' + idx + ']'" />
+      </div>
+    `,
+  });
+
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(false);
+  arr.update(0, 'updated');
+  await flushPromises();
+  expect(form.meta.value.touched).toBe(true);
+});


### PR DESCRIPTION
## Summary

Fixes #5113

- FieldArray mutation operations (`push`, `remove`, `insert`, `prepend`, `swap`, `move`, `replace`, `update`) now set the form's `meta.touched` to `true`
- These operations represent user interaction with the form, so the touched state should reflect that
- Also fixed `swap` to call `afterMutation()` (instead of just `updateEntryFlags()`) for consistency with other mutation methods

## How it works

Added a `markTouched()` helper inside `useFieldArray` that:
1. If a path state exists for the array path itself, marks it as touched
2. Marks all child path states (paths starting with `arrayPath[`) as touched

This is called from `afterMutation()` (used by `push`, `remove`, `insert`, `prepend`, `swap`, `move`, `replace`) and directly in `update()`.

## Test plan

- [x] Added tests for all 8 mutation operations verifying `form.meta.value.touched` becomes `true`
- [x] All existing tests continue to pass (27/27 in `useFieldArray.spec.ts`)
- [x] Full test suite passes with no regressions (363 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)