### PR TITLE
fix: resetField({ value: undefined }) form validity

### DIFF
--- a/.changeset/fix-4996-resetfield-undefined.md
+++ b/.changeset/fix-4996-resetfield-undefined.md
@@ -1,0 +1,5 @@
+---
+"vee-validate": patch
+---
+
+Fix resetField({ value: undefined }) preventing form from becoming valid (#4996)

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -779,6 +779,7 @@ export function useForm<
     const pathState = findPathState(field);
     if (pathState) {
       pathState.__flags.pendingReset = true;
+      pathState.validated = false;
     }
 
     setFieldInitialValue(field, deepCopy(newValue), true);
@@ -790,6 +791,8 @@ export function useForm<
       if (pathState) {
         pathState.__flags.pendingReset = false;
       }
+
+      validateField(field, { mode: 'silent' });
     });
   }
 

--- a/packages/vee-validate/tests/useForm.spec.ts
+++ b/packages/vee-validate/tests/useForm.spec.ts
@@ -1489,4 +1489,54 @@ describe('useForm()', () => {
     form.setValues({ file: f2 });
     expect(form.values.file).toEqual(f2);
   });
+
+  // #4996
+  test('resetField with undefined value should not prevent form from becoming valid', async () => {
+    let form!: FormContext<{ name: string }>;
+
+    mountWithHoc({
+      setup() {
+        form = useForm({
+          validationSchema: z.object({
+            name: z.string().min(1),
+          }),
+        });
+
+        form.defineField('name');
+
+        return {};
+      },
+      template: `
+        <div></div>
+      `,
+    });
+
+    await flushPromises();
+
+    // Fill in a valid value and validate
+    form.setFieldValue('name', 'John');
+    await flushPromises();
+
+    const pending1 = form.validate();
+    await flushPromises();
+    const result1 = await pending1;
+    expect(result1.valid).toBe(true);
+    expect(form.meta.value.valid).toBe(true);
+
+    // Reset field with undefined value using form-level resetField
+    form.resetField('name', { value: undefined });
+    await flushPromises();
+
+    // After reset, validated should be false so that subsequent validation works correctly
+    const pathState = form.getPathState('name');
+    expect(pathState?.validated).toBe(false);
+
+    // Now fill in a valid value again
+    form.setFieldValue('name', 'Jane');
+    await flushPromises();
+
+    // The form should be valid again
+    expect(form.meta.value.valid).toBe(true);
+    expect(form.errors.value.name).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes #4996: `resetField({ value: undefined })` no longer prevents the form from becoming valid again after entering a new valid value
- Aligns `useForm.resetField()` behavior with `resetForm()` by resetting the `validated` flag and running a silent validation after reset

## Root Cause

The `resetField` function in `useForm.ts` was missing two things that `resetForm` (and `useField`'s `resetField`) already did:

1. **Reset `pathState.validated = false`** -- Without this, the field's `validated` flag stayed `true` from prior validation/submission, leaving the field in an inconsistent state after reset.
2. **Run a silent validation in `nextTick`** -- Without this, the `pathState.valid` flag was not recalculated against the schema after the field value was reset, which could leave the form's `meta.valid` in an incorrect state.

## Test plan

- [x] Added test: `resetField with undefined value should not prevent form from becoming valid`
- [x] Verified the test fails without the fix (pathState.validated remains `true` after reset)
- [x] Verified the test passes with the fix
- [x] All existing 356 tests pass (3 pre-existing infrastructure failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)