### PR TITLE
fix: resetField respects current reactive initial value

### DIFF
--- a/.changeset/fix-4827-reactive-resetfield.md
+++ b/.changeset/fix-4827-reactive-resetfield.md
@@ -1,0 +1,5 @@
+---
+"vee-validate": patch
+---
+
+Fix resetField to use current reactive initial value instead of stale value (#4827)

--- a/packages/vee-validate/src/useFieldState.ts
+++ b/packages/vee-validate/src/useFieldState.ts
@@ -126,6 +126,11 @@ export function _useFieldValue<TValue = unknown>(
 
   function resolveInitialValue() {
     if (!form) {
+      // If the original modelValue is a ref, read from it directly to maintain reactivity
+      if (isRef(modelValue)) {
+        return modelValue.value as TValue;
+      }
+
       return unref(modelRef) as TValue;
     }
 
@@ -160,6 +165,15 @@ export function _useFieldValue<TValue = unknown>(
   // #3429
   const currentValue = resolveModelValue(modelValue, form, initialValue, path);
   form.stageInitialValue(unref(path), currentValue, true);
+
+  // If the modelValue is a ref, watch it and update the form's initial value when it changes
+  // This ensures resetField uses the current reactive initial value (#4827)
+  if (isRef(modelValue)) {
+    watch(modelValue, newVal => {
+      form.setFieldInitialValue(unref(path), newVal as any, true);
+    });
+  }
+
   // otherwise use a computed setter that triggers the `setFieldValue`
   const value = computed<TValue>({
     get() {

--- a/packages/vee-validate/tests/useField.spec.ts
+++ b/packages/vee-validate/tests/useField.spec.ts
@@ -1059,4 +1059,69 @@ describe('useField()', () => {
 
     expect(form.values.field).toEqual('test');
   });
+
+  // #4827
+  test('resetField should use current reactive initial value (without form)', async () => {
+    let field!: FieldContext;
+    const initialValue = ref('before change');
+
+    mountWithHoc({
+      setup() {
+        field = useField('field', undefined, { initialValue });
+
+        return {};
+      },
+      template: '<div></div>',
+    });
+
+    await flushPromises();
+    expect(field.value.value).toBe('before change');
+
+    // Change the reactive initial value
+    initialValue.value = 'after change';
+    await flushPromises();
+
+    // Change the field's current value to something else
+    field.value.value = 'some random value';
+    await flushPromises();
+
+    // Reset field should use the new reactive initial value
+    field.resetField();
+    await flushPromises();
+
+    expect(field.value.value).toBe('after change');
+  });
+
+  // #4827
+  test('resetField should use current reactive initial value (with form)', async () => {
+    let field!: FieldContext;
+    const initialValue = ref('before change');
+
+    mountWithHoc({
+      setup() {
+        useForm();
+        field = useField('field', undefined, { initialValue });
+
+        return {};
+      },
+      template: '<div></div>',
+    });
+
+    await flushPromises();
+    expect(field.value.value).toBe('before change');
+
+    // Change the reactive initial value
+    initialValue.value = 'after change';
+    await flushPromises();
+
+    // Change the field's current value to something else
+    field.value.value = 'some random value';
+    await flushPromises();
+
+    // Reset field should use the new reactive initial value
+    field.resetField();
+    await flushPromises();
+
+    expect(field.value.value).toBe('after change');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #4827

- When `useField` is given a reactive `ref` as `initialValue`, calling `resetField()` now resets to the **current** value of that ref, not the value captured at field creation time
- This works for both standalone `useField` (no form) and `useField` within a `useForm` context
- Added two new tests covering both cases

## Root Cause

In `useFieldState.ts`, `_useFieldValue` unwraps the reactive `modelValue` once via `ref(unref(modelValue))`, losing the reactive connection. The `resolveInitialValue` function then always reads from this stale copy.

## Fix

- **No-form path**: `resolveInitialValue` now checks if the original `modelValue` is a ref and reads from it directly, preserving reactivity for the computed `initialValue`
- **With-form path**: Added a watcher on the reactive `modelValue` that updates the form's field initial value via `setFieldInitialValue` when the ref changes

## Test plan

- [x] Verified `resetField` uses current reactive initial value when `useField` is used standalone (without form)
- [x] Verified `resetField` uses current reactive initial value when `useField` is used within `useForm`
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)