### PR TITLE
fix: show validation error when field array is empty (#4981)

### DIFF
--- a/.changeset/fix-4981-empty-array-error.md
+++ b/.changeset/fix-4981-empty-array-error.md
@@ -1,0 +1,5 @@
+---
+"vee-validate": patch
+---
+
+Fix error message not showing when field array is empty (#4981)

--- a/packages/vee-validate/src/useForm.ts
+++ b/packages/vee-validate/src/useForm.ts
@@ -366,7 +366,9 @@ export function useForm<
       const results = paths.reduce(
         (validation, _path) => {
           const expectedPath = _path as Path<TValues>;
-          const pathState = findPathState(expectedPath) || findHoistedPath(expectedPath);
+          const isFieldArrayPath = fieldArrays.some(a => toValue(a.path) === expectedPath);
+          const pathState =
+            findPathState(expectedPath) || (isFieldArrayPath ? undefined : findHoistedPath(expectedPath));
           const messages = formResult.results[expectedPath]?.errors || [];
           // This is the real path of the field, because it might've been a hoisted field
           const path = (toValue(pathState?.path) || expectedPath) as Path<TValues>;

--- a/packages/vee-validate/tests/useFieldArray.spec.ts
+++ b/packages/vee-validate/tests/useFieldArray.spec.ts
@@ -521,6 +521,72 @@ test('array move initializes the array if undefined', async () => {
   expect(arr.fields.value).toHaveLength(0);
 });
 
+// #4981
+test('shows validation error when field array is empty after removing all items', async () => {
+  let form!: FormContext;
+  let arr!: FieldArrayContext;
+  mountWithHoc({
+    setup() {
+      form = useForm<any>({
+        initialValues: {
+          users: ['one'],
+        },
+        validationSchema: z.object({
+          users: z.array(z.string()).min(1, 'At least one item is required'),
+        }),
+      });
+
+      arr = useFieldArray('users');
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+  expect(form.meta.value.valid).toBe(true);
+  arr.remove(0);
+  await flushPromises();
+  expect(form.meta.value.valid).toBe(false);
+  expect(form.errors.value['users']).toBe('At least one item is required');
+});
+
+// #4981
+test('shows validation error at correct path when nested field array is empty', async () => {
+  let form!: FormContext;
+  let arr!: FieldArrayContext;
+  mountWithHoc({
+    setup() {
+      form = useForm<any>({
+        initialValues: {
+          settings: {
+            items: ['one'],
+          },
+        },
+        validationSchema: z.object({
+          settings: z.object({
+            items: z.array(z.string()).min(1, 'At least one item is required'),
+          }),
+        }),
+      });
+
+      arr = useFieldArray('settings.items');
+    },
+    template: `
+      <div></div>
+    `,
+  });
+
+  await flushPromises();
+  expect(form.meta.value.valid).toBe(true);
+  arr.remove(0);
+  await flushPromises();
+  expect(form.meta.value.valid).toBe(false);
+  // The error should be at 'settings.items', NOT at 'settings'
+  expect(form.errors.value['settings.items']).toBe('At least one item is required');
+  expect(form.errors.value['settings']).toBeUndefined();
+});
+
 // #4557
 test('errors are available to the newly inserted items', async () => {
   let arr!: FieldArrayContext;


### PR DESCRIPTION
## Summary

- Fixes #4981: When all items are removed from a field array, validation errors for the array itself (e.g., `z.array().min(1)`) were not being shown at the correct error path.
- The root cause was `findHoistedPath` in `validateSchema` incorrectly hoisting array-level errors to a parent path state (e.g., error at `mySettings.myArray` was hoisted to `mySettings`).
- The fix skips hoisting when the error path matches a known field array path, ensuring the error is placed at the correct path in `extraErrorsBag`.

## Test plan

- [x] Added test: removing all items from a top-level field array shows the correct validation error at the array path
- [x] Added test: removing all items from a nested field array shows the error at the correct nested path (not hoisted to parent)
- [x] All existing tests pass (357 tests, 3 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)