### PR TITLE
fix: standard schema validation works with arktype (#5110)

### DIFF
--- a/.changeset/fix-5110-arktype-compat.md
+++ b/.changeset/fix-5110-arktype-compat.md
@@ -1,0 +1,5 @@
+---
+"vee-validate": patch
+---
+
+Fix standard schema validation compatibility with arktype (#5110)

--- a/packages/vee-validate/src/utils/assertions.ts
+++ b/packages/vee-validate/src/utils/assertions.ts
@@ -10,7 +10,11 @@ export function isLocator(value: unknown): value is Locator {
 }
 
 export function isStandardSchema(value: unknown): value is StandardSchemaV1 {
-  return isObject(value) && '~standard' in (value as unknown as StandardSchemaV1);
+  return (
+    !!value &&
+    (typeof value === 'object' || typeof value === 'function') &&
+    '~standard' in (value as Record<PropertyKey, unknown>)
+  );
 }
 
 export function hasCheckedAttr(type: unknown) {

--- a/packages/vee-validate/tests/utils/assertions.spec.ts
+++ b/packages/vee-validate/tests/utils/assertions.spec.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'packages/vee-validate/src/utils';
+import { isEqual, isStandardSchema } from 'packages/vee-validate/src/utils';
 
 describe('assertions', () => {
   test('equal objects are equal', () => {
@@ -227,5 +227,62 @@ describe('assertions', () => {
 
     expect(isEqual(a6, b1)).toBe(false);
     expect(isEqual(a6, b2)).toBe(false);
+  });
+});
+
+// #5110 - arktype compatibility
+describe('isStandardSchema', () => {
+  test('detects a plain object with ~standard property as a standard schema', () => {
+    const schema = {
+      '~standard': {
+        version: 1,
+        vendor: 'test',
+        validate: (value: unknown) => ({ value }),
+      },
+    };
+
+    expect(isStandardSchema(schema)).toBe(true);
+  });
+
+  test('detects a callable object with ~standard property as a standard schema (like arktype)', () => {
+    // Arktype schemas are functions that also have the ~standard property
+    const callableSchema = Object.assign(
+      function (value: unknown) {
+        return value;
+      },
+      {
+        '~standard': {
+          version: 1,
+          vendor: 'arktype',
+          validate: (value: unknown) => ({ value }),
+        },
+      },
+    );
+
+    expect(isStandardSchema(callableSchema)).toBe(true);
+  });
+
+  test('returns false for a plain function without ~standard', () => {
+    const fn = (value: unknown) => value;
+    expect(isStandardSchema(fn)).toBe(false);
+  });
+
+  test('returns false for primitive values', () => {
+    expect(isStandardSchema(null)).toBe(false);
+    expect(isStandardSchema(undefined)).toBe(false);
+    expect(isStandardSchema('')).toBe(false);
+    expect(isStandardSchema('required')).toBe(false);
+    expect(isStandardSchema(0)).toBe(false);
+    expect(isStandardSchema(true)).toBe(false);
+  });
+
+  test('returns false for arrays', () => {
+    expect(isStandardSchema([])).toBe(false);
+    expect(isStandardSchema([() => true])).toBe(false);
+  });
+
+  test('returns false for plain objects without ~standard', () => {
+    expect(isStandardSchema({})).toBe(false);
+    expect(isStandardSchema({ required: true })).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #5110: arktype schemas are callable (`typeof === 'function'`), so `isStandardSchema()` was rejecting them because `isObject()` only accepts `typeof === 'object'`
- Updated `isStandardSchema` to accept both objects and functions with the `~standard` property, matching the standard schema spec
- Added comprehensive tests for `isStandardSchema` covering callable schemas, primitives, arrays, and plain objects

## Details

The root cause was in `packages/vee-validate/src/utils/assertions.ts`:

```ts
// Before (broken for arktype)
export function isStandardSchema(value: unknown): value is StandardSchemaV1 {
  return isObject(value) && '~standard' in (value as unknown as StandardSchemaV1);
}

// After (works with arktype and any callable standard schema)
export function isStandardSchema(value: unknown): value is StandardSchemaV1 {
  return !!value && (typeof value === 'object' || typeof value === 'function') && '~standard' in (value as Record<PropertyKey, unknown>);
}
```

Arktype schemas are both functions and standard schemas — they are callable but also have the `~standard` property. The `isObject()` utility uses `typeof obj === 'object'` which returns `false` for functions, causing `isStandardSchema()` to return `false` for arktype schemas. This made vee-validate fall through to the `isCallable(rules)` branch, which tried to call the arktype schema as a plain validation function, leading to `TypeError: rule is not a function`.

## Test plan
- [x] Added 6 new tests for `isStandardSchema` in `assertions.spec.ts`
- [x] Tests cover: plain object standard schemas, callable standard schemas (arktype-like), plain functions, primitive values, arrays, and plain objects without `~standard`
- [x] All 361 existing tests continue to pass (3 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)