### PR TITLE
fix: Vee-Validate 4 - add Zod 4 support for union errors

### DIFF
--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -97,7 +97,8 @@ function processIssues(issues: ZodIssue[], errors: Record<string, TypedSchemaErr
     const path = normalizeFormPath(issue.path.join('.'));
     if (issue.code === 'invalid_union') {
       processIssues(
-        issue.unionErrors.flatMap(ue => ue.issues),
+        // Use `unionErrors` (Zod v3) or fallback to `errors` (Zod v4)
+        issue.unionErrors?.flatMap(ue => ue.issues) || issue.errors?.flatMap(ue => ue),
         errors,
       );
 


### PR DESCRIPTION
🔎 __Overview__

<!-- Explain the why behind adding this PR, here is a couple of examples -->
<!--
  This PR {adds/fixes/improves} the {feature/bug/something}.
  This PR changes the {locale} messages style because {reason}
-->
Adds support for Zod 4 with Vee-Validate 4 for union errors.

🤓 __Code snippets/examples (if applicable)__

Handles errors for schema, for instance:
```js
z.union([z.string(), z.number()]);
```

✔ __Issues affected__

closes #5153

Please be sure to ask if furher details are required, I didn't bother too much with a full repro for instance because it's such a small fix but happy to help if needed!
 
